### PR TITLE
feat: Create reusable Pill component

### DIFF
--- a/frontend/src/components/Card.test.tsx
+++ b/frontend/src/components/Card.test.tsx
@@ -1,7 +1,7 @@
-import { describe, expect, it } from 'bun:test';
-import { render, screen } from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import {describe, expect, it} from 'bun:test';
 
-import { Card } from './Card';
+import {Card} from './Card';
 
 describe('Card', () => {
   it('renders arbitrary child', async () => {

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -1,14 +1,13 @@
-import { cva, VariantProps } from 'class-variance-authority';
 import React from 'react';
+import {cva, type VariantProps} from 'class-variance-authority';
 
-import { cn } from '../../utils/cn';
+import {cn} from '../utils/cn';
 
-// Card styles based on mockup .card class
 const card = cva([
   'bg-background-primary',
-  'rounded-radius-lg', 
+  'rounded-radius-lg',
   'p-space-2xl',
-  'shadow-sm'
+  'shadow-sm',
 ]);
 
 interface CardProps
@@ -16,19 +15,13 @@ interface CardProps
     VariantProps<typeof card> {}
 
 const CardRoot = React.forwardRef<HTMLDivElement, CardProps>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn(card({ className }))} {...props} />
+  ({className, ...props}, ref) => (
+    <div ref={ref} className={cn(card({className}))} {...props} />
   )
 );
 CardRoot.displayName = 'Card';
 
-// Card Title styles based on mockup .card-title class
-const title = cva([
-  'text-lg',
-  'font-semibold', 
-  'mb-space-xl',
-  'text-content-headings'
-], {
+const title = cva(['text-lg', 'font-semibold', 'mb-space-xl', 'text-content-headings'], {
   variants: {
     size: {
       sm: ['text-sm'],
@@ -47,8 +40,8 @@ interface TitleProps
     VariantProps<typeof title> {}
 
 const Title = React.forwardRef<HTMLHeadingElement, TitleProps>(
-  ({ className, size, children, ...props }, ref) => (
-    <h3 ref={ref} className={cn(title({ className, size }))} {...props}>
+  ({className, size, children, ...props}, ref) => (
+    <h3 ref={ref} className={cn(title({className, size}))} {...props}>
       {children}
     </h3>
   )

--- a/frontend/src/components/Pill.test.tsx
+++ b/frontend/src/components/Pill.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+
+import {Pill} from './Pill';
+
+describe('Pill', () => {
+  it('renders children', () => {
+    render(<Pill>Test Pill</Pill>);
+    expect(screen.getByText('Test Pill')).toBeInTheDocument();
+  });
+
+  it('applies default variant', () => {
+    render(<Pill data-testid="pill">Default</Pill>);
+    const pill = screen.getByTestId('pill');
+
+    expect(pill).toHaveClass('bg-background-secondary');
+    expect(pill).toHaveClass('text-content-secondary');
+    expect(pill).toHaveClass('px-space-lg');
+    expect(pill).toHaveClass('py-space-xs');
+  });
+
+  it('applies variant classes', () => {
+    render(
+      <Pill variant="active" data-testid="pill">
+        Active
+      </Pill>
+    );
+    const pill = screen.getByTestId('pill');
+
+    expect(pill).toHaveClass('bg-background-transparent-danger-muted');
+    expect(pill).toHaveClass('text-content-danger');
+  });
+
+  it('accepts custom className', () => {
+    render(
+      <Pill className="custom-class" data-testid="pill">
+        Custom
+      </Pill>
+    );
+    const pill = screen.getByTestId('pill');
+
+    expect(pill).toHaveClass('custom-class');
+  });
+
+  it('forwards ref', () => {
+    const ref = React.createRef<HTMLSpanElement>();
+    render(<Pill ref={ref}>Ref Test</Pill>);
+
+    expect(ref.current).toBeInstanceOf(HTMLSpanElement);
+  });
+
+  it('spreads additional props', () => {
+    render(
+      <Pill data-custom="test" data-testid="pill">
+        Props Test
+      </Pill>
+    );
+    const pill = screen.getByTestId('pill');
+
+    expect(pill).toHaveAttribute('data-custom', 'test');
+  });
+});

--- a/frontend/src/components/Pill.tsx
+++ b/frontend/src/components/Pill.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import {cva, type VariantProps} from 'class-variance-authority';
+
+import {cn} from '../utils/cn';
+
+const pill = cva(
+  [
+    'inline-flex',
+    'items-center',
+    'justify-center',
+    'px-space-lg',
+    'py-space-xs',
+    'rounded-radius-full',
+    'text-size-sm',
+    'font-medium',
+    'uppercase',
+    'line-height-compressed',
+  ],
+  {
+    variants: {
+      // might want to tweak how the variants work later once we try using them
+      variant: {
+        // Status variants
+        active: ['bg-background-transparent-danger-muted', 'text-content-danger'],
+        mitigated: ['bg-background-transparent-accent-muted', 'text-content-accent'],
+        'actions-pending': [
+          'bg-background-transparent-warning-muted',
+          'text-content-warning',
+        ],
+        postmortem: ['bg-background-transparent-promotion-muted', 'text-content-danger'],
+        done: ['bg-background-transparent-success-muted', 'text-content-success'],
+        // Severity variants
+        p0: ['bg-background-transparent-danger-muted', 'text-content-danger'],
+        p1: ['bg-background-transparent-danger-muted', 'text-content-danger'],
+        p2: ['bg-background-transparent-warning-muted', 'text-content-warning'],
+        p3: ['bg-background-transparent-accent-muted', 'text-content-accent'],
+        p4: ['bg-background-transparent-accent-muted', 'text-content-accent'],
+        // Other variants
+        private: ['bg-background-transparent-promotion-muted', 'text-content-danger'],
+        default: ['bg-background-secondary', 'text-content-secondary'],
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+interface PillProps
+  extends React.HTMLAttributes<HTMLSpanElement>,
+    VariantProps<typeof pill> {}
+
+const Pill = React.forwardRef<HTMLSpanElement, PillProps>(
+  ({className, variant, ...props}, ref) => (
+    <span ref={ref} className={cn(pill({variant, className}))} {...props} />
+  )
+);
+Pill.displayName = 'Pill';
+
+export {Pill, type PillProps};

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -19,6 +19,27 @@
   .bg-background-danger-vibrant {
     background-color: var(--tokens-color-background-danger-vibrant);
   }
+  .bg-background-success-vibrant {
+    background-color: var(--tokens-color-background-success-vibrant);
+  }
+  .bg-background-warning-vibrant {
+    background-color: var(--tokens-color-background-warning-vibrant);
+  }
+  .bg-background-transparent-accent-muted {
+    background-color: var(--tokens-color-background-transparent-accent-muted);
+  }
+  .bg-background-transparent-danger-muted {
+    background-color: var(--tokens-color-background-transparent-danger-muted);
+  }
+  .bg-background-transparent-success-muted {
+    background-color: var(--tokens-color-background-transparent-success-muted);
+  }
+  .bg-background-transparent-warning-muted {
+    background-color: var(--tokens-color-background-transparent-warning-muted);
+  }
+  .bg-background-transparent-promotion-muted {
+    background-color: var(--tokens-color-background-transparent-promotion-muted);
+  }
 
   /* Text colors */
   .text-content-headings {

--- a/frontend/src/utils/cn.ts
+++ b/frontend/src/utils/cn.ts
@@ -66,7 +66,7 @@ const twMerge = extendTailwindMerge({
         'border-warning-vibrant',
       ],
       // Border radius
-      'border-radius': [
+      'rounded': [
         'rounded-radius-0',
         'rounded-radius-2xs',
         'rounded-radius-xs',

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -23,5 +23,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.tsx", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
Creates a Pill to be used across the app. In the shadcn style again. May want to tweak how the variants work later, but this is a starting point.
