### PR TITLE
feat: Incident list filters

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -27,6 +27,7 @@
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/bun": "^1.2.22",
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",
@@ -386,6 +387,8 @@
     "@testing-library/jest-dom": ["@testing-library/jest-dom@6.8.0", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ=="],
 
     "@testing-library/react": ["@testing-library/react@16.3.0", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw=="],
+
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/bun": "^1.2.22",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -2,13 +2,17 @@ import {z} from 'zod';
 
 import {env} from '../env';
 
-type ParamsObj = Record<string, string | number | undefined>;
+type ParamsObj = Record<string, string | number | undefined | (string | number)[]>;
 
 export function paramsFromObject(params: ParamsObj): URLSearchParams {
   const urlParams = new URLSearchParams();
   Object.entries(params).forEach(([key, value]) => {
     if (value != null) {
-      urlParams.append(key, value.toString());
+      if (Array.isArray(value)) {
+        value.forEach(v => urlParams.append(key, v.toString()));
+      } else {
+        urlParams.append(key, value.toString());
+      }
     }
   });
   return urlParams;

--- a/frontend/src/components/Spinner.tsx
+++ b/frontend/src/components/Spinner.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import {cn} from '../utils/cn';
+
+interface SpinnerProps extends React.HTMLAttributes<HTMLDivElement> {
+  size?: 'sm' | 'md' | 'lg';
+}
+
+const sizeClasses = {
+  sm: 'h-4 w-4 border-2',
+  md: 'h-8 w-8 border-2',
+  lg: 'h-12 w-12 border-4',
+};
+
+export const Spinner = React.forwardRef<HTMLDivElement, SpinnerProps>(
+  ({size = 'md', className, ...props}, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'animate-spin rounded-full border-border-secondary border-t-transparent',
+          sizeClasses[size],
+          className
+        )}
+        role="status"
+        aria-label="Loading"
+        data-testid="spinner"
+        {...props}
+      >
+        <span className="sr-only">Loading...</span>
+      </div>
+    );
+  }
+);
+Spinner.displayName = 'Spinner';

--- a/frontend/src/routes/components/StatusFilter.tsx
+++ b/frontend/src/routes/components/StatusFilter.tsx
@@ -1,0 +1,42 @@
+import {Link, useSearch} from '@tanstack/react-router';
+
+import {cn} from '../../utils/cn';
+
+type FilterValue = 'active' | 'review' | 'closed';
+
+interface FilterLinkProps {
+  value: FilterValue;
+  label: string;
+  isActive: boolean;
+}
+
+function FilterLink({value, label, isActive}: FilterLinkProps) {
+  return (
+    <Link
+      to="/"
+      search={{status: value}}
+      preload="intent"
+      className={cn(
+        'rounded-radius-sm px-space-lg py-space-sm text-size-sm font-medium transition-colors',
+        {
+          'bg-background-primary text-content-headings shadow-sm': isActive,
+          'text-content-secondary hover:text-black': !isActive,
+        }
+      )}
+    >
+      {label}
+    </Link>
+  );
+}
+
+export function StatusFilter() {
+  const {status} = useSearch({from: '/'});
+
+  return (
+    <div className="gap-space-2xs flex">
+      <FilterLink value="active" label="Active" isActive={status === 'active'} />
+      <FilterLink value="review" label="In Review" isActive={status === 'review'} />
+      <FilterLink value="closed" label="Closed" isActive={status === 'closed'} />
+    </div>
+  );
+}

--- a/frontend/src/routes/components/StatusFilter.tsx
+++ b/frontend/src/routes/components/StatusFilter.tsx
@@ -8,6 +8,7 @@ interface FilterLinkProps {
   statuses: JiraStatus[];
   label: string;
   isActive: boolean;
+  testId?: string;
 }
 
 const FILTER_GROUPS = {
@@ -22,12 +23,14 @@ function arraysEqual(a: JiraStatus[], b: JiraStatus[]): boolean {
   return a.every(val => setB.has(val));
 }
 
-function FilterLink({statuses, label, isActive}: FilterLinkProps) {
+function FilterLink({statuses, label, isActive, testId}: FilterLinkProps) {
   return (
     <Link
       to="/"
       search={{status: statuses}}
       preload="intent"
+      data-testid={testId}
+      aria-selected={isActive}
       className={cn(
         'rounded-radius-sm px-space-lg py-space-sm text-size-sm font-medium transition-colors',
         {
@@ -50,16 +53,19 @@ export function StatusFilter() {
         statuses={FILTER_GROUPS.active}
         label="Active"
         isActive={arraysEqual(status, FILTER_GROUPS.active)}
+        testId="filter-active"
       />
       <FilterLink
         statuses={FILTER_GROUPS.review}
         label="In Review"
         isActive={arraysEqual(status, FILTER_GROUPS.review)}
+        testId="filter-review"
       />
       <FilterLink
         statuses={FILTER_GROUPS.closed}
         label="Closed"
         isActive={arraysEqual(status, FILTER_GROUPS.closed)}
+        testId="filter-closed"
       />
     </div>
   );

--- a/frontend/src/routes/components/StatusFilter.tsx
+++ b/frontend/src/routes/components/StatusFilter.tsx
@@ -2,19 +2,31 @@ import {Link, useSearch} from '@tanstack/react-router';
 
 import {cn} from '../../utils/cn';
 
-type FilterValue = 'active' | 'review' | 'closed';
+type JiraStatus = 'Active' | 'Mitigated' | 'Postmortem' | 'Actions Pending' | 'Done';
 
 interface FilterLinkProps {
-  value: FilterValue;
+  statuses: JiraStatus[];
   label: string;
   isActive: boolean;
 }
 
-function FilterLink({value, label, isActive}: FilterLinkProps) {
+const FILTER_GROUPS = {
+  active: ['Active', 'Mitigated'] as JiraStatus[],
+  review: ['Postmortem', 'Actions Pending'] as JiraStatus[],
+  closed: ['Done'] as JiraStatus[],
+};
+
+function arraysEqual(a: JiraStatus[], b: JiraStatus[]): boolean {
+  if (a.length !== b.length) return false;
+  const setB = new Set(b);
+  return a.every(val => setB.has(val));
+}
+
+function FilterLink({statuses, label, isActive}: FilterLinkProps) {
   return (
     <Link
       to="/"
-      search={{status: value}}
+      search={{status: statuses}}
       preload="intent"
       className={cn(
         'rounded-radius-sm px-space-lg py-space-sm text-size-sm font-medium transition-colors',
@@ -34,9 +46,21 @@ export function StatusFilter() {
 
   return (
     <div className="gap-space-2xs flex">
-      <FilterLink value="active" label="Active" isActive={status === 'active'} />
-      <FilterLink value="review" label="In Review" isActive={status === 'review'} />
-      <FilterLink value="closed" label="Closed" isActive={status === 'closed'} />
+      <FilterLink
+        statuses={FILTER_GROUPS.active}
+        label="Active"
+        isActive={arraysEqual(status, FILTER_GROUPS.active)}
+      />
+      <FilterLink
+        statuses={FILTER_GROUPS.review}
+        label="In Review"
+        isActive={arraysEqual(status, FILTER_GROUPS.review)}
+      />
+      <FilterLink
+        statuses={FILTER_GROUPS.closed}
+        label="Closed"
+        isActive={arraysEqual(status, FILTER_GROUPS.closed)}
+      />
     </div>
   );
 }

--- a/frontend/src/routes/index.test.tsx
+++ b/frontend/src/routes/index.test.tsx
@@ -84,9 +84,11 @@ describe('IncidentCard (via Index Route)', () => {
     renderRoute();
 
     expect(await screen.findByText('P1')).toBeInTheDocument();
-    expect(await screen.findByText('Active')).toBeInTheDocument();
     expect(await screen.findByText('P2')).toBeInTheDocument();
     expect(await screen.findByText('Mitigated')).toBeInTheDocument();
+
+    const activeElements = await screen.findAllByText('Active');
+    expect(activeElements.length).toBeGreaterThan(0);
   });
 
   it('renders formatted dates for incidents', async () => {
@@ -124,7 +126,7 @@ describe('IncidentCard (via Index Route)', () => {
 
     expect(mockApiGet).toHaveBeenCalledWith({
       path: '/ui/incidents/',
-      query: {status: undefined},
+      query: {status: ['Active', 'Mitigated']},
       signal: expect.any(AbortSignal),
       responseSchema: expect.any(Object),
     });

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -4,11 +4,12 @@ import {zodValidator} from '@tanstack/zod-adapter';
 import {z} from 'zod';
 
 import {IncidentCard} from './components/IncidentCard';
+import {StatusFilter} from './components/StatusFilter';
 import {incidentsQueryOptions} from './queries/incidentsQueryOptions';
 
 // Zod schema for search params
 const incidentListSearchSchema = z.object({
-  status: z.string().optional(),
+  status: z.enum(['active', 'review', 'closed']).default('active'),
 });
 
 export const Route = createFileRoute('/')({
@@ -30,10 +31,14 @@ function Index() {
   const {data: incidents} = useSuspenseQuery(incidentsQueryOptions(params));
 
   return (
-    <div className="gap-space-lg flex flex-col">
-      {incidents.map(incident => (
-        <IncidentCard key={incident.id} incident={incident} />
-      ))}
+    <div className="flex flex-col">
+      <StatusFilter />
+      <hr className="mb-space-xl mt-space-lg border-secondary" />
+      <div className="gap-space-lg flex flex-col">
+        {incidents.map(incident => (
+          <IncidentCard key={incident.id} incident={incident} />
+        ))}
+      </div>
     </div>
   );
 }

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -9,7 +9,10 @@ import {incidentsQueryOptions} from './queries/incidentsQueryOptions';
 
 // Zod schema for search params
 const incidentListSearchSchema = z.object({
-  status: z.enum(['active', 'review', 'closed']).default('active'),
+  status: z
+    .array(z.enum(['Active', 'Mitigated', 'Postmortem', 'Actions Pending', 'Done']))
+    .optional()
+    .default(['Active', 'Mitigated']),
 });
 
 export const Route = createFileRoute('/')({

--- a/frontend/src/routes/queries/incidentsQueryOptions.ts
+++ b/frontend/src/routes/queries/incidentsQueryOptions.ts
@@ -19,7 +19,7 @@ export type IncidentListItem = z.infer<typeof IncidentListItemSchema>;
 export type IncidentList = z.infer<typeof IncidentsListSchema>;
 
 interface IncidentsQueryArgs {
-  status?: string;
+  status?: string[];
 }
 
 export function incidentsQueryOptions({status}: IncidentsQueryArgs) {

--- a/src/firetower/incidents/views.py
+++ b/src/firetower/incidents/views.py
@@ -18,9 +18,9 @@ def incident_list_ui(request):
     """List all incidents from Jira"""
     try:
         jira_service = JiraService()
-        status_filter = request.GET.get("status")
+        status_filters = request.GET.getlist("status")
         jira_incidents = jira_service.get_incidents(
-            status=status_filter, max_results=50
+            statuses=status_filters, max_results=50
         )
         incidents = [
             transform_jira_incident_for_list(incident) for incident in jira_incidents

--- a/src/firetower/integrations/test_jira.py
+++ b/src/firetower/integrations/test_jira.py
@@ -117,11 +117,11 @@ class TestJiraService:
 
                 # Test with invalid characters in status
                 with pytest.raises(ValueError, match="Invalid status format"):
-                    service.get_incidents(status="Active; DROP TABLE incidents;")
+                    service.get_incidents(statuses=["Active; DROP TABLE incidents;"])
 
                 # Test with numbers in status
                 with pytest.raises(ValueError, match="Invalid status format"):
-                    service.get_incidents(status="Status123")
+                    service.get_incidents(statuses=["Status123"])
 
     def test_get_incidents_builds_correct_jql_query(self):
         """Test that get_incidents builds the correct JQL query."""
@@ -147,11 +147,18 @@ class TestJiraService:
                     expected_jql, maxResults=50, expand="changelog"
                 )
 
-                # Test with status filter
-                service.get_incidents(status="Active")
-                expected_jql_with_status = (
-                    'project = "TESTINC" AND status = "Active" ORDER BY created DESC'
+                # Test with single status filter
+                service.get_incidents(statuses=["Active"])
+                expected_jql_single = (
+                    'project = "TESTINC" AND status IN ("Active") ORDER BY created DESC'
                 )
                 mock_client_instance.search_issues.assert_called_with(
-                    expected_jql_with_status, maxResults=50, expand="changelog"
+                    expected_jql_single, maxResults=50, expand="changelog"
+                )
+
+                # Test with multiple status filters
+                service.get_incidents(statuses=["Active", "Mitigated"])
+                expected_jql_multiple = 'project = "TESTINC" AND status IN ("Active", "Mitigated") ORDER BY created DESC'
+                mock_client_instance.search_issues.assert_called_with(
+                    expected_jql_multiple, maxResults=50, expand="changelog"
                 )


### PR DESCRIPTION
Implements the status filters for the incidents list. Also adds a Spinner component that is used in the pending state and updates the Error and Not Found states to look better. The backend change is to accommodate an array of incident statuses passed in the search param.
