### PR TITLE
django: allow test environment url

### DIFF
--- a/src/firetower/settings.py
+++ b/src/firetower/settings.py
@@ -37,6 +37,7 @@ ALLOWED_HOSTS = [
     "127.0.0.1",
     "::1",
     "firetower.getsentry.net",
+    "test.firetower.getsentry.net",
     "firetower",
 ]
 


### PR DESCRIPTION
Fixes 403 on the test environment deployment