### PR TITLE
fix: Set default value for slack team id

### DIFF
--- a/src/firetower/settings.py
+++ b/src/firetower/settings.py
@@ -158,5 +158,5 @@ JIRA = {
 # Slack Integration Configuration
 SLACK = {
     "BOT_TOKEN": os.environ.get("SLACK_BOT_TOKEN"),
-    "TEAM_ID": os.environ.get("SLACK_TEAM_ID"),
+    "TEAM_ID": os.environ.get("SLACK_TEAM_ID", "sentry"),
 }


### PR DESCRIPTION
If no team id is set, will fall back to `sentry`
