### PR TITLE
fix: environment selector should override branch name detection

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
           image: ${{ env.IMAGE_REF }}
           wait: true
       - name: deploy-prod-db-migration
-        if: ${{ github.ref ==  'refs/heads/main' || inputs.environment == 'prod' }}
+        if: ${{ (github.ref ==  'refs/heads/main' && !inputs.environment ) || inputs.environment == 'prod' }}
         uses: "google-github-actions/deploy-cloudrun@v3"
         with:
           job: firetower-prod-db-migration
@@ -69,7 +69,7 @@ jobs:
           region: us-west1
           image: ${{ env.IMAGE_REF }}
       - name: deploy-prod
-        if: ${{ github.ref ==  'refs/heads/main' || inputs.environment == 'prod' }}
+        if: ${{ (github.ref ==  'refs/heads/main' && !inputs.environment ) || inputs.environment == 'prod' }}
         uses: "google-github-actions/deploy-cloudrun@v3"
         with:
           service: firetower


### PR DESCRIPTION
I discovered when deploying branch `main` to environment `test` manually, that prod also pushed: https://github.com/getsentry/firetower/actions/runs/18856936238

This makes it explicit: regardless of the branch name, if the environment is specified, it should be the sole determinator of which environment gets updated.