### PR TITLE
feat: Show email instead of google IAP id for Users in django admin

### DIFF
--- a/src/firetower/auth/admin.py
+++ b/src/firetower/auth/admin.py
@@ -6,14 +6,6 @@ from .models import ExternalProfile, UserProfile
 from .services import sync_user_profile_from_slack
 
 
-# Customize User string representation
-def user_str(self):
-    return self.email or self.username
-
-
-User.__str__ = user_str
-
-
 class UserProfileInline(admin.StackedInline):
     model = UserProfile
     can_delete = False
@@ -65,9 +57,19 @@ class UserProfileAdmin(admin.ModelAdmin):
         "user__last_name",
     ]
 
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        if db_field.name == "user":
+            kwargs["label_from_instance"] = lambda obj: obj.email or obj.username
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)
+
 
 @admin.register(ExternalProfile)
 class ExternalProfileAdmin(admin.ModelAdmin):
     list_display = ["user", "type", "external_id", "created_at"]
     list_filter = ["type"]
     search_fields = ["user__username", "external_id"]
+
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        if db_field.name == "user":
+            kwargs["label_from_instance"] = lambda obj: obj.email or obj.username
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)

--- a/src/firetower/incidents/admin.py
+++ b/src/firetower/incidents/admin.py
@@ -41,6 +41,16 @@ class IncidentAdmin(admin.ModelAdmin):
         ),
     )
 
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        if db_field.name in ["captain", "reporter"]:
+            kwargs["label_from_instance"] = lambda obj: obj.email or obj.username
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)
+
+    def formfield_for_manytomany(self, db_field, request, **kwargs):
+        if db_field.name == "participants":
+            kwargs["label_from_instance"] = lambda obj: obj.email or obj.username
+        return super().formfield_for_manytomany(db_field, request, **kwargs)
+
     def incident_number_display(self, obj):
         return obj.incident_number
 


### PR DESCRIPTION
I noticed when poking around the django admin in prod/test that users would show up on related models as accounts.google.com:123445... which is not very useful. This PR overrides the __str__ method of User for just the django admin, making Users show up as their email address instead. W.
