### PR TITLE
set CSRF_TRUSTED_ORIGINS

### DIFF
--- a/src/firetower/settings.py
+++ b/src/firetower/settings.py
@@ -69,6 +69,11 @@ CORS_ALLOWED_ORIGINS = [
     "http://localhost:5173",
 ]
 
+CSRF_TRUSTED_ORIGINS = [
+    "https://firetower.getsentry.net",
+    "https://*.firetower.getsentry.net",
+]
+
 CORS_ALLOW_CREDENTIALS = True
 
 # Application definition


### PR DESCRIPTION
This allows CSRF protection to work properly in prod

## Test Plan

Deployed to test, verified I could create a Tag from the admin panel (this was failing before the deploy)