### PR TITLE
ref: Make Active status filters the default for empty url

### DIFF
--- a/frontend/src/routes/components/Header.test.tsx
+++ b/frontend/src/routes/components/Header.test.tsx
@@ -154,7 +154,7 @@ describe('Header - Root Route (Incident List)', () => {
     expect(parsed).toEqual({status: ['Postmortem', 'Actions Pending']});
   });
 
-  it('stores default search params in sessionStorage on initial load', async () => {
+  it('stores empty search params in sessionStorage on initial load', async () => {
     renderRoute('/');
 
     await screen.findByText('INC-1247');
@@ -163,7 +163,7 @@ describe('Header - Root Route (Incident List)', () => {
     expect(stored).not.toBeNull();
 
     const parsed = JSON.parse(stored!);
-    expect(parsed).toEqual({status: ['Active', 'Mitigated']});
+    expect(parsed).toEqual({});
   });
 });
 
@@ -376,7 +376,7 @@ describe('Header - sessionStorage Handling', () => {
 
     let stored = sessionStorage.getItem(STORAGE_KEY);
     let parsed = JSON.parse(stored!);
-    expect(parsed).toEqual({status: ['Active', 'Mitigated']});
+    expect(parsed).toEqual({});
 
     const reviewButton = screen.getByTestId('filter-review');
     await user.click(reviewButton);

--- a/frontend/src/routes/components/StatusFilter.tsx
+++ b/frontend/src/routes/components/StatusFilter.tsx
@@ -6,7 +6,7 @@ import {type IncidentStatus} from '../queries/incidentsQueryOptions';
 import {STATUS_FILTER_GROUPS} from '../types';
 
 interface FilterLinkProps {
-  statuses: IncidentStatus[];
+  statuses?: IncidentStatus[];
   label: string;
   isActive: boolean;
   testId?: string;
@@ -39,21 +39,23 @@ export function StatusFilter() {
   return (
     <div className="gap-space-2xs flex">
       <FilterLink
-        statuses={STATUS_FILTER_GROUPS.active}
+        statuses={undefined}
         label="Active"
-        isActive={arraysEqual(status, STATUS_FILTER_GROUPS.active)}
+        isActive={
+          status === undefined || arraysEqual(status, STATUS_FILTER_GROUPS.active)
+        }
         testId="filter-active"
       />
       <FilterLink
         statuses={STATUS_FILTER_GROUPS.review}
         label="In Review"
-        isActive={arraysEqual(status, STATUS_FILTER_GROUPS.review)}
+        isActive={arraysEqual(status ?? [], STATUS_FILTER_GROUPS.review)}
         testId="filter-review"
       />
       <FilterLink
         statuses={STATUS_FILTER_GROUPS.closed}
         label="Closed"
-        isActive={arraysEqual(status, STATUS_FILTER_GROUPS.closed)}
+        isActive={arraysEqual(status ?? [], STATUS_FILTER_GROUPS.closed)}
         testId="filter-closed"
       />
     </div>

--- a/frontend/src/routes/index.test.tsx
+++ b/frontend/src/routes/index.test.tsx
@@ -149,7 +149,7 @@ describe('IncidentCard (via Index Route)', () => {
     expect(incidentLinks[1]).toHaveAttribute('href', '/INC-1246');
   });
 
-  it('calls the incidents API with correct parameters', async () => {
+  it('calls the incidents API without status params by default', async () => {
     renderRoute();
 
     await screen.findByText('INC-1247');
@@ -157,7 +157,7 @@ describe('IncidentCard (via Index Route)', () => {
     expect(mockApiGet).toHaveBeenCalledWith(
       expect.objectContaining({
         path: '/ui/incidents/',
-        query: {status: ['Active', 'Mitigated'], page: 1},
+        query: {status: undefined, page: 1},
       })
     );
   });

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -19,7 +19,7 @@ import {STATUS_FILTER_GROUPS} from './types';
 
 // Zod schema for search params
 const incidentListSearchSchema = z.object({
-  status: z.array(IncidentStatusSchema).optional().default(['Active', 'Mitigated']),
+  status: z.array(IncidentStatusSchema).optional(),
 });
 
 function IncidentsLayout({children}: {children: React.ReactNode}) {
@@ -68,8 +68,8 @@ export const Route = createFileRoute('/')({
 
 const STORAGE_KEY = 'firetower_list_search';
 
-function IncidentsEmptyState({status}: {status: IncidentStatus[]}) {
-  if (arraysEqual(status, STATUS_FILTER_GROUPS.active)) {
+function IncidentsEmptyState({status}: {status?: IncidentStatus[]}) {
+  if (!status || arraysEqual(status, STATUS_FILTER_GROUPS.active)) {
     return (
       <div className="text-content-secondary py-space-4xl text-center">
         <p>There are no active incidents! {String.fromCodePoint(0x1f389)}</p>

--- a/src/firetower/incidents/tests/test_views.py
+++ b/src/firetower/incidents/tests/test_views.py
@@ -87,6 +87,35 @@ class TestIncidentViews:
         assert "Private Incident" in titles
         assert "Someone Else's Private" not in titles
 
+    def test_list_incidents_defaults_to_active_and_mitigated(self):
+        """Test that no status filter defaults to Active and Mitigated"""
+        Incident.objects.create(
+            title="Active Incident",
+            status=IncidentStatus.ACTIVE,
+            severity=IncidentSeverity.P1,
+        )
+        Incident.objects.create(
+            title="Mitigated Incident",
+            status=IncidentStatus.MITIGATED,
+            severity=IncidentSeverity.P2,
+        )
+        Incident.objects.create(
+            title="Done Incident",
+            status=IncidentStatus.DONE,
+            severity=IncidentSeverity.P3,
+        )
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get("/api/ui/incidents/")
+
+        assert response.status_code == 200
+        assert response.data["count"] == 2
+        assert len(response.data["results"]) == 2
+        titles = [inc["title"] for inc in response.data["results"]]
+        assert "Active Incident" in titles
+        assert "Mitigated Incident" in titles
+        assert "Done Incident" not in titles
+
     def test_list_incidents_filter_by_status(self):
         """Test filtering incidents by status"""
         Incident.objects.create(

--- a/src/firetower/incidents/views.py
+++ b/src/firetower/incidents/views.py
@@ -16,6 +16,7 @@ class IncidentListUIView(generics.ListAPIView):
     Supports:
     - Pagination (configured in settings.REST_FRAMEWORK)
     - Status filtering via query params: ?status=Active&status=Mitigated
+      (defaults to Active and Mitigated if no status param provided)
     - Privacy: users only see public incidents + their own private incidents
 
     Authentication enforced via DEFAULT_PERMISSION_CLASSES in settings.
@@ -28,10 +29,11 @@ class IncidentListUIView(generics.ListAPIView):
         queryset = Incident.objects.all()
         queryset = filter_visible_to_user(queryset, self.request.user)
 
-        # Filter by status if requested
+        # Filter by status (defaults to Active and Mitigated if not specified)
         status_filters = self.request.GET.getlist("status")
-        if status_filters:
-            queryset = queryset.filter(status__in=status_filters)
+        if not status_filters:
+            status_filters = ["Active", "Mitigated"]
+        queryset = queryset.filter(status__in=status_filters)
 
         return queryset
 


### PR DESCRIPTION
I found showing the Active & Mitigated statuses in the default page's url was a bit unsightly. This change makes empty search params return the same as explicitly setting the Active status filters (Active and Mitigated incidents).

If you don't like this lmk. It's definitely an opinionated change.
