### PR TITLE
add "backend" to ALLOWED_HOSTS

### DIFF
--- a/src/firetower/settings.py
+++ b/src/firetower/settings.py
@@ -64,6 +64,7 @@ ALLOWED_HOSTS = [
     "firetower.getsentry.net",
     "test.firetower.getsentry.net",
     "firetower",
+    "backend",  # name from the nginx proxy_pass
 ]
 
 CORS_ALLOWED_ORIGINS = [


### PR DESCRIPTION
This appears to have broken in the test environment at some point? `backend` is the name used by the nginx proxy.

https://sentry.sentry.io/issues/6998345519/?project=4510076289548288