### PR TITLE
fix: Remove broken label_from_instance admin override

### DIFF
--- a/src/firetower/incidents/admin.py
+++ b/src/firetower/incidents/admin.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-from typing import Any
-
 from django.contrib import admin
-from django.db.models import ForeignKey, ManyToManyField, QuerySet
-from django.forms import ModelChoiceField, ModelMultipleChoiceField
+from django.db.models import QuerySet
 from django.http import HttpRequest
 
 from .models import ExternalLink, Incident, Tag
@@ -50,20 +47,6 @@ class IncidentAdmin(admin.ModelAdmin):
             {"fields": ("created_at", "updated_at"), "classes": ("collapse",)},
         ),
     )
-
-    def formfield_for_foreignkey(
-        self, db_field: ForeignKey[Any, Any], request: HttpRequest, **kwargs: Any
-    ) -> ModelChoiceField | None:
-        if db_field.name in ["captain", "reporter"]:
-            kwargs["label_from_instance"] = lambda obj: obj.email or obj.username
-        return super().formfield_for_foreignkey(db_field, request, **kwargs)
-
-    def formfield_for_manytomany(
-        self, db_field: ManyToManyField[Any, Any], request: HttpRequest, **kwargs: Any
-    ) -> ModelMultipleChoiceField | None:
-        if db_field.name == "participants":
-            kwargs["label_from_instance"] = lambda obj: obj.email or obj.username
-        return super().formfield_for_manytomany(db_field, request, **kwargs)
 
     def incident_number_display(self, obj: Incident) -> str:
         return obj.incident_number


### PR DESCRIPTION
Removes dead code that was overriding label_from_instance for user dropdowns in the incident admin. This code was broken (passing label_from_instance as a kwarg instead of setting it on the formfield) and unnecessary since usernames are already emails.