### PR TITLE
feat: Increase time input width for 12-hour format

### DIFF
--- a/frontend/src/components/DateTimePicker.tsx
+++ b/frontend/src/components/DateTimePicker.tsx
@@ -53,7 +53,7 @@ export function DateTimePicker({
         onChange={e => {
           onTimeChange(e.target.value || undefined);
         }}
-        className="bg-background text-size-md w-16 px-2 appearance-none disabled:opacity-30 [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-calendar-picker-indicator]:appearance-none"
+        className="bg-background text-size-md w-[85px] px-2 appearance-none disabled:opacity-30 [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-calendar-picker-indicator]:appearance-none"
       />
       <Button
         variant="icon"


### PR DESCRIPTION
Increases the time input width from 64px to 85px to accommodate both 12-hour (with AM/PM) and 24-hour time formats.