### PR TITLE
chore: Fix placeholder styling and add Description label

### DIFF
--- a/frontend/src/components/EditableTextField.tsx
+++ b/frontend/src/components/EditableTextField.tsx
@@ -18,7 +18,7 @@ const displayStyles = cva(['transition-opacity'], {
 });
 
 // Label layout styles
-const labelContainerStyles = cva(['flex', 'items-center', 'gap-space-xs', 'mb-space-xs']);
+const labelContainerStyles = cva(['flex', 'items-center', 'gap-space-xs', 'mb-space-md']);
 
 const labelStyles = cva(['font-medium', 'text-content-secondary', 'text-sm']);
 
@@ -249,8 +249,8 @@ export function EditableTextField({
             <Component
               className={cn(
                 multiline && 'whitespace-pre-wrap',
-                !value && placeholder && 'text-content-tertiary italic',
-                className
+                className,
+                !value && placeholder && 'text-content-disabled italic'
               )}
             >
               {value || placeholder}
@@ -266,8 +266,8 @@ export function EditableTextField({
             className={cn(
               fullWidth ? 'flex-1 min-w-0' : 'inline',
               multiline && 'whitespace-pre-wrap',
-              !value && placeholder && 'text-content-tertiary italic',
-              className
+              className,
+              !value && placeholder && 'text-content-disabled italic'
             )}
           >
             {value || placeholder}

--- a/frontend/src/routes/$incidentId/components/IncidentSummary.tsx
+++ b/frontend/src/routes/$incidentId/components/IncidentSummary.tsx
@@ -124,7 +124,9 @@ export function IncidentSummary({incident}: IncidentSummaryProps) {
         as="p"
         multiline
         placeholder="No description provided"
-        className="text-content-secondary leading-comfortable"
+        className="text-content-secondary"
+        label="Description"
+        labelClassName="text-size-md font-semibold"
       />
 
       <div className="mt-space-xl gap-space-xl grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4">
@@ -137,7 +139,7 @@ export function IncidentSummary({incident}: IncidentSummaryProps) {
             as="p"
             multiline
             placeholder="No impact specified"
-            className="text-size-sm leading-comfortable text-content-secondary"
+            className="text-size-sm text-content-secondary"
           />
         </div>
 


### PR DESCRIPTION
Fixes inconsistent placeholder styling between EditableTextField and EditableTags components (both now use text-content-disabled). Also adds a Description label to the incident summary page.