### PR TITLE
feat: Sync incident topic to Slack on field changes

### DIFF
--- a/src/firetower/incidents/serializers.py
+++ b/src/firetower/incidents/serializers.py
@@ -18,6 +18,7 @@ from .models import (
     Tag,
     TagType,
 )
+from .services import sync_incident_to_slack
 
 
 @dataclass
@@ -558,6 +559,12 @@ class IncidentWriteSerializer(serializers.ModelSerializer):
                 type=TagType.IMPACT_TYPE,
             )
             instance.impact_type_tags.set(tags)
+
+        # Only sync to Slack if title, severity, or captain changed
+        topic_fields = {"title", "severity", "captain"}
+        sync_relevant_fields = topic_fields.intersection(validated_data.keys())
+        if sync_relevant_fields:
+            sync_incident_to_slack(instance)
 
         return instance
 

--- a/src/firetower/incidents/services.py
+++ b/src/firetower/incidents/services.py
@@ -146,7 +146,13 @@ def sync_incident_to_slack(incident: Incident) -> None:
     else:
         captain_display = "None"
 
-    topic = f"[{incident.severity}] {incident.incident_number} {incident.title} | IC: {captain_display}"
+    # Slack topic limit is 250 chars, truncate title to fit
+    prefix = f"[{incident.severity}] {incident.incident_number} "
+    suffix = f" | IC: {captain_display}"
+    max_title_len = 250 - len(prefix) - len(suffix)
+    title = incident.title[:max_title_len]
+
+    topic = f"{prefix}{title}{suffix}"
 
     if _slack_service.update_channel_topic(channel_id, topic):
         logger.info(f"Successfully updated topic for incident {incident.id}")

--- a/src/firetower/incidents/tests/test_services.py
+++ b/src/firetower/incidents/tests/test_services.py
@@ -394,13 +394,12 @@ class TestSyncIncidentToSlack:
             "firetower.incidents.services._slack_service.update_channel_topic"
         ) as mock_update:
             mock_update.return_value = True
-            stats = sync_incident_to_slack(incident)
+            sync_incident_to_slack(incident)
 
             mock_update.assert_called_once_with(
                 "C12345",
                 f"[P1] {incident.incident_number} Test Incident | IC: <@U99999>",
             )
-            assert stats.errors == []
 
     def test_syncs_topic_falls_back_to_full_name_without_slack_profile(self):
         incident = Incident.objects.create(
@@ -425,13 +424,12 @@ class TestSyncIncidentToSlack:
             "firetower.incidents.services._slack_service.update_channel_topic"
         ) as mock_update:
             mock_update.return_value = True
-            stats = sync_incident_to_slack(incident)
+            sync_incident_to_slack(incident)
 
             mock_update.assert_called_once_with(
                 "C12345",
                 f"[P1] {incident.incident_number} Test Incident | IC: Captain One",
             )
-            assert stats.errors == []
 
     def test_skips_if_no_slack_link(self):
         incident = Incident.objects.create(
@@ -447,9 +445,7 @@ class TestSyncIncidentToSlack:
         )
         incident.captain = captain
 
-        stats = sync_incident_to_slack(incident)
-
-        assert stats.errors == [f"No Slack link found for incident {incident.id}"]
+        sync_incident_to_slack(incident)
 
     def test_handles_invalid_channel_url(self):
         incident = Incident.objects.create(
@@ -470,11 +466,7 @@ class TestSyncIncidentToSlack:
             url="https://invalid-url.com",
         )
 
-        stats = sync_incident_to_slack(incident)
-
-        assert stats.errors == [
-            "Could not parse channel ID from URL: https://invalid-url.com"
-        ]
+        sync_incident_to_slack(incident)
 
     def test_handles_slack_api_failure(self):
         incident = Incident.objects.create(
@@ -500,8 +492,4 @@ class TestSyncIncidentToSlack:
         ) as mock_update:
             mock_update.return_value = False
 
-            stats = sync_incident_to_slack(incident)
-
-            assert stats.errors == [
-                f"Failed to update topic for incident {incident.id}"
-            ]
+            sync_incident_to_slack(incident)

--- a/src/firetower/incidents/tests/test_services.py
+++ b/src/firetower/incidents/tests/test_services.py
@@ -445,7 +445,11 @@ class TestSyncIncidentToSlack:
         )
         incident.captain = captain
 
-        sync_incident_to_slack(incident)
+        with patch(
+            "firetower.incidents.services._slack_service.update_channel_topic"
+        ) as mock_update:
+            sync_incident_to_slack(incident)
+            mock_update.assert_not_called()
 
     def test_handles_invalid_channel_url(self):
         incident = Incident.objects.create(
@@ -466,7 +470,11 @@ class TestSyncIncidentToSlack:
             url="https://invalid-url.com",
         )
 
-        sync_incident_to_slack(incident)
+        with patch(
+            "firetower.incidents.services._slack_service.update_channel_topic"
+        ) as mock_update:
+            sync_incident_to_slack(incident)
+            mock_update.assert_not_called()
 
     def test_handles_slack_api_failure(self):
         incident = Incident.objects.create(

--- a/src/firetower/integrations/services/slack.py
+++ b/src/firetower/integrations/services/slack.py
@@ -221,7 +221,7 @@ class SlackService:
 
         except SlackApiError as e:
             logger.error(
-                f"Error updating channel topic: {e}",
+                f"Error updating channel topic: {e.response['error']}",
                 extra={"channel_id": channel_id},
             )
             return False

--- a/src/firetower/integrations/services/slack.py
+++ b/src/firetower/integrations/services/slack.py
@@ -202,6 +202,9 @@ class SlackService:
         """
         Update Slack channel topic.
 
+        Joins the channel if needed, checks if the topic has actually changed,
+        and updates it if so.
+
         Args:
             channel_id: Slack channel ID (e.g., C12345678)
             topic: New topic string
@@ -214,7 +217,22 @@ class SlackService:
             return False
 
         try:
-            logger.info(f"Updating channel topic for: {channel_id}")
+            self.client.conversations_join(channel=channel_id)
+        except SlackApiError as e:
+            if e.response["error"] != "already_in_channel":
+                logger.error(
+                    f"Error joining channel: {e.response['error']}",
+                    extra={"channel_id": channel_id},
+                )
+                return False
+
+        try:
+            channel_info = self.client.conversations_info(channel=channel_id)
+            current_topic = channel_info["channel"]["topic"]["value"]
+            if current_topic == topic:
+                logger.info(f"Topic already up to date for channel {channel_id}")
+                return True
+
             self.client.conversations_setTopic(channel=channel_id, topic=topic)
             logger.info(f"Successfully updated topic for channel {channel_id}")
             return True

--- a/src/firetower/integrations/services/slack.py
+++ b/src/firetower/integrations/services/slack.py
@@ -197,3 +197,31 @@ class SlackService:
                 extra={"slack_user_id": slack_user_id},
             )
             return None
+
+    def update_channel_topic(self, channel_id: str, topic: str) -> bool:
+        """
+        Update Slack channel topic.
+
+        Args:
+            channel_id: Slack channel ID (e.g., C12345678)
+            topic: New topic string
+
+        Returns:
+            True if successful, False otherwise
+        """
+        if not self.client:
+            logger.warning("Cannot update channel topic - Slack client not initialized")
+            return False
+
+        try:
+            logger.info(f"Updating channel topic for: {channel_id}")
+            self.client.conversations_setTopic(channel=channel_id, topic=topic)
+            logger.info(f"Successfully updated topic for channel {channel_id}")
+            return True
+
+        except SlackApiError as e:
+            logger.error(
+                f"Error updating channel topic: {e}",
+                extra={"channel_id": channel_id},
+            )
+            return False

--- a/src/firetower/integrations/services/slack.py
+++ b/src/firetower/integrations/services/slack.py
@@ -202,8 +202,6 @@ class SlackService:
         """
         Update Slack channel topic.
 
-        Checks if the topic has actually changed, and updates it if so.
-
         Args:
             channel_id: Slack channel ID (e.g., C12345678)
             topic: New topic string
@@ -216,12 +214,6 @@ class SlackService:
             return False
 
         try:
-            channel_info = self.client.conversations_info(channel=channel_id)
-            current_topic = channel_info["channel"]["topic"]["value"]
-            if current_topic == topic:
-                logger.info(f"Topic already up to date for channel {channel_id}")
-                return True
-
             self.client.conversations_setTopic(channel=channel_id, topic=topic)
             logger.info(f"Successfully updated topic for channel {channel_id}")
             return True

--- a/src/firetower/integrations/services/slack.py
+++ b/src/firetower/integrations/services/slack.py
@@ -202,8 +202,7 @@ class SlackService:
         """
         Update Slack channel topic.
 
-        Joins the channel if needed, checks if the topic has actually changed,
-        and updates it if so.
+        Checks if the topic has actually changed, and updates it if so.
 
         Args:
             channel_id: Slack channel ID (e.g., C12345678)
@@ -215,16 +214,6 @@ class SlackService:
         if not self.client:
             logger.warning("Cannot update channel topic - Slack client not initialized")
             return False
-
-        try:
-            self.client.conversations_join(channel=channel_id)
-        except SlackApiError as e:
-            if e.response["error"] != "already_in_channel":
-                logger.error(
-                    f"Error joining channel: {e.response['error']}",
-                    extra={"channel_id": channel_id},
-                )
-                return False
 
         try:
             channel_info = self.client.conversations_info(channel=channel_id)


### PR DESCRIPTION
When title, severity, or captain are updated via the API, syncs the incident's Slack channel topic to match. Topic format follows the existing convention: `[P2] INC-2030 some title | IC: @captain`. Uses Slack user ID mentions when the captain has a linked Slack profile, falling back to their full name otherwise.