### PR TITLE
fix: Strip query params off of url before use as JWT audience for IAP auth

### DIFF
--- a/sdk/src/firetower_sdk/auth.py
+++ b/sdk/src/firetower_sdk/auth.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import logging
+from urllib.parse import urlsplit, urlunsplit
 
 import google.auth
 import requests
@@ -52,6 +53,8 @@ class JwtAuth(AuthBase):
         url = r.url
         if url is None:
             raise RuntimeError("JwtAuth error: Cannot sign request with no URL set.")
-        jwt = self.jwt_interface.get_signed_jwt(url)
+        parsed = urlsplit(url)
+        audience = urlunsplit((parsed.scheme, parsed.netloc, parsed.path, "", ""))
+        jwt = self.jwt_interface.get_signed_jwt(audience)
         r.headers["Authorization"] = f"Bearer {jwt}"
         return r


### PR DESCRIPTION
Title. Went down rabbit hole trying to figure out why helios wasn't working and I'm 99% sure this is it. We're expecting the audience to match the resource explicitly but we were using the url as the audience, including query params for helios!