### PR TITLE
ref: Remove tabIndex from captain/participants dropdown

### DIFF
--- a/frontend/src/routes/$incidentId/components/ParticipantsList.tsx
+++ b/frontend/src/routes/$incidentId/components/ParticipantsList.tsx
@@ -203,7 +203,6 @@ function ParticipantDropdown({
             <div
               key={participant.email}
               role="option"
-              tabIndex={-1}
               aria-selected={participant.email === value}
               className={cn(
                 dropdownItemStyles({


### PR DESCRIPTION
Removes the unnecessary tabIndex={-1} from dropdown options in the captain/reporter participant selector. Arrow key navigation from the search input already handles selection, so the tabIndex wasn't needed. Made the tab flow weird.