### PR TITLE
feat: Add navigation tabs to header

### DIFF
--- a/frontend/src/routes/components/Header.test.tsx
+++ b/frontend/src/routes/components/Header.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {createMemoryHistory, createRouter, RouterProvider} from '@tanstack/react-router';
 import {render, screen} from '@testing-library/react';
@@ -7,6 +6,7 @@ import {beforeEach, describe, expect, it, vi} from 'bun:test';
 
 import {routeTree} from '../../routeTree.gen';
 import type {IncidentDetail} from '../$incidentId/queries/incidentDetailQueryOptions';
+import type {AvailabilityData} from '../availability/queries/availabilityQueryOptions';
 import type {CurrentUser} from '../queries/currentUserQueryOptions';
 import type {PaginatedIncidents} from '../queries/incidentsQueryOptions';
 
@@ -32,6 +32,7 @@ const mockIncidents: PaginatedIncidents = {
       service_tier: null,
       created_at: '2024-08-27T18:14:00Z',
       is_private: false,
+      captain: null,
     },
     {
       id: 'INC-1246',
@@ -43,6 +44,7 @@ const mockIncidents: PaginatedIncidents = {
       service_tier: null,
       created_at: '2024-08-27T15:32:00Z',
       is_private: true,
+      captain: null,
     },
   ],
 };
@@ -68,6 +70,7 @@ const mockIncidentDetail: IncidentDetail = {
       name: 'John Doe',
       avatar_url: 'https://example.com/avatar.jpg',
       role: 'Captain',
+      email: 'john@example.com',
     },
   ],
   external_links: {
@@ -78,11 +81,25 @@ const mockIncidentDetail: IncidentDetail = {
   time_analyzed: null,
   time_mitigated: null,
   time_recovered: null,
+  total_downtime: null,
 };
 
 const mockCurrentUser: CurrentUser = {
   name: 'Test User',
   avatar_url: null,
+};
+
+const mockAvailability: AvailabilityData = {
+  months: [
+    {
+      label: 'Apr 2026',
+      start: '2026-04-01',
+      end: '2026-04-30',
+      regions: [],
+    },
+  ],
+  quarters: [],
+  years: [],
 };
 
 const STORAGE_KEY = 'firetower_list_search';
@@ -131,12 +148,15 @@ describe('Header - Root Route (Incident List)', () => {
     });
   });
 
-  it('shows centered logo without back button', async () => {
+  it('shows nav tabs and centered logo without back button', async () => {
     renderRoute('/');
 
     expect(await screen.findByText('INC-1247')).toBeInTheDocument();
 
     expect(screen.getByAltText('Firetower')).toBeInTheDocument();
+
+    expect(screen.getByText('Incidents')).toBeInTheDocument();
+    expect(screen.getByText('Availability')).toBeInTheDocument();
 
     expect(screen.queryByText('All Incidents')).not.toBeInTheDocument();
     expect(screen.queryByText('←')).not.toBeInTheDocument();
@@ -168,6 +188,34 @@ describe('Header - Root Route (Incident List)', () => {
 
     const parsed = JSON.parse(stored!);
     expect(parsed).toEqual({});
+  });
+});
+
+describe('Header - Availability Route', () => {
+  beforeEach(() => {
+    queryClient.clear();
+    sessionStorage.clear();
+    mockApiGet.mockImplementation((args: {path: string}) => {
+      if (args.path === '/ui/availability/') {
+        return Promise.resolve(mockAvailability);
+      }
+      if (args.path === '/ui/users/me/') {
+        return Promise.resolve(mockCurrentUser);
+      }
+      return Promise.reject(new Error('Not found'));
+    });
+  });
+
+  it('shows nav tabs with Availability active', async () => {
+    renderRoute('/availability');
+
+    expect(await screen.findByText('Availability by Region')).toBeInTheDocument();
+
+    expect(screen.getByText('Incidents')).toBeInTheDocument();
+    expect(screen.getByText('Availability')).toBeInTheDocument();
+
+    expect(screen.queryByText('All Incidents')).not.toBeInTheDocument();
+    expect(screen.queryByText('←')).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/routes/components/Header.tsx
+++ b/frontend/src/routes/components/Header.tsx
@@ -1,17 +1,26 @@
 import {useQuery} from '@tanstack/react-query';
 import {Link, useRouterState} from '@tanstack/react-router';
 import {Avatar} from 'components/Avatar';
+import {cn} from 'utils/cn';
 
 import {currentUserQueryOptions} from '../queries/currentUserQueryOptions';
 import type {StatusFilterValue} from '../types';
 
 const STORAGE_KEY = 'firetower_list_search';
 
+const NAV_PAGES = [
+  {label: 'Incidents', to: '/' as const},
+  {label: 'Availability', to: '/availability' as const},
+];
+
 export const Header = () => {
   const routerState = useRouterState();
   const {data: currentUser} = useQuery(currentUserQueryOptions());
+  const pathname = routerState.location.pathname;
 
-  const isRootRoute = routerState.location.pathname === '/';
+  const isTopLevelRoute = NAV_PAGES.some(
+    page => pathname === page.to || pathname === `${page.to}/`
+  );
 
   const getPreservedSearch = (): {status?: StatusFilterValue[]} | undefined => {
     const stored = sessionStorage.getItem(STORAGE_KEY);
@@ -28,11 +37,30 @@ export const Header = () => {
   const preservedSearch = getPreservedSearch();
 
   return (
-    <nav className="bg-background-primary border-secondary border-b">
+    <header className="bg-background-primary border-secondary border-b">
       <div className="px-space-md py-space-md md:px-space-xl mx-auto max-w-6xl">
-        {isRootRoute ? (
+        {isTopLevelRoute ? (
           <div className="flex items-center justify-between">
-            <div className="w-7"></div>
+            <nav className="gap-space-2xs flex">
+              {NAV_PAGES.map(page => (
+                <Link
+                  key={page.to}
+                  to={page.to}
+                  preload="intent"
+                  className={cn(
+                    'rounded-radius-sm px-space-lg py-space-sm text-size-sm font-medium transition-colors',
+                    {
+                      'bg-background-secondary text-content-headings':
+                        pathname === page.to || pathname === `${page.to}/`,
+                      'text-content-secondary hover:text-content-headings':
+                        pathname !== page.to && pathname !== `${page.to}/`,
+                    }
+                  )}
+                >
+                  {page.label}
+                </Link>
+              ))}
+            </nav>
             <Link to="/" className="gap-space-sm flex items-center no-underline">
               <img src="/firetower.svg" alt="Firetower" className="h-6 w-6" />
               <span className="text-content-headings text-xl font-semibold">
@@ -72,6 +100,6 @@ export const Header = () => {
           </div>
         )}
       </div>
-    </nav>
+    </header>
   );
 };

--- a/frontend/src/routes/components/Header.tsx
+++ b/frontend/src/routes/components/Header.tsx
@@ -18,9 +18,10 @@ export const Header = () => {
   const {data: currentUser} = useQuery(currentUserQueryOptions());
   const pathname = routerState.location.pathname;
 
-  const isTopLevelRoute = NAV_PAGES.some(
-    page => pathname === page.to || pathname === `${page.to}/`
-  );
+  const isActivePage = (to: string) =>
+    pathname === to || (to !== '/' && pathname === `${to}/`);
+
+  const isTopLevelRoute = NAV_PAGES.some(page => isActivePage(page.to));
 
   const getPreservedSearch = (): {status?: StatusFilterValue[]} | undefined => {
     const stored = sessionStorage.getItem(STORAGE_KEY);
@@ -49,12 +50,9 @@ export const Header = () => {
                   preload="intent"
                   className={cn(
                     'rounded-radius-sm px-space-lg py-space-sm text-size-sm font-medium transition-colors',
-                    {
-                      'bg-background-secondary text-content-headings':
-                        pathname === page.to || pathname === `${page.to}/`,
-                      'text-content-secondary hover:text-content-headings':
-                        pathname !== page.to && pathname !== `${page.to}/`,
-                    }
+                    isActivePage(page.to)
+                      ? 'bg-background-secondary text-content-headings'
+                      : 'text-content-secondary hover:text-content-headings'
                   )}
                 >
                   {page.label}

--- a/frontend/src/routes/components/Header.tsx
+++ b/frontend/src/routes/components/Header.tsx
@@ -41,7 +41,7 @@ export const Header = () => {
     <header className="bg-background-primary border-secondary border-b">
       <div className="px-space-md py-space-md md:px-space-xl mx-auto max-w-6xl">
         {isTopLevelRoute ? (
-          <div className="flex items-center justify-between">
+          <div className="relative flex items-center justify-between">
             <nav className="gap-space-2xs flex">
               {NAV_PAGES.map(page => (
                 <Link
@@ -59,7 +59,10 @@ export const Header = () => {
                 </Link>
               ))}
             </nav>
-            <Link to="/" className="gap-space-sm flex items-center no-underline">
+            <Link
+              to="/"
+              className="gap-space-sm absolute left-1/2 flex -translate-x-1/2 items-center no-underline"
+            >
               <img src="/firetower.svg" alt="Firetower" className="h-6 w-6" />
               <span className="text-content-headings text-xl font-semibold">
                 Firetower


### PR DESCRIPTION
Adds horizontal navigation tabs (Incidents, Availability) to the header for top-level routes. The logo is centered using absolute positioning, and detail pages retain the existing back button pattern. Data-driven NAV_PAGES array makes it easy to add future top-level routes.

<img width="1177" height="290" alt="Screenshot 2026-04-20 at 10 17 00" src="https://github.com/user-attachments/assets/8074411e-d27b-4372-8222-72890becf754" />
