### PR TITLE
feat: Statuspage integration for /ft statuspage command

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -37,3 +37,8 @@ integration_key = ""
 [datadog]
 api_key = ""
 app_key = ""
+
+# [statuspage]
+# api_key = ""
+# page_id = ""
+# url = "https://your-page.statuspage.io/"

--- a/config.example.toml
+++ b/config.example.toml
@@ -38,7 +38,7 @@ integration_key = ""
 api_key = ""
 app_key = ""
 
-# [statuspage]
-# api_key = ""
-# page_id = ""
-# url = "https://your-page.statuspage.io/"
+[statuspage]
+api_key = ""
+page_id = ""
+url = "https://your-page.statuspage.io/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "google-auth>=2.37.0",
     "psycopg[binary]>=3.2.11",
     "pyserde[toml]>=0.28.0",
+    "requests>=2.32.0",
     "slack-bolt>=1.27.0",
     "slack-sdk>=3.31.0",
 ]

--- a/src/firetower/config.py
+++ b/src/firetower/config.py
@@ -50,6 +50,13 @@ class SlackConfig:
 
 
 @deserialize
+class StatuspageConfig:
+    api_key: str
+    page_id: str
+    url: str
+
+
+@deserialize
 class AuthConfig:
     iap_enabled: bool
     iap_audience: str | None
@@ -66,6 +73,7 @@ class ConfigFile:
     slack: SlackConfig
     auth: AuthConfig
     pagerduty: PagerDutyConfig | None
+    statuspage: StatuspageConfig | None
 
     project_key: str
     django_secret_key: str
@@ -132,6 +140,7 @@ class DummyConfigFile(ConfigFile):
         )
         self.datadog = None
         self.pagerduty = None
+        self.statuspage = None
         self.project_key = ""
         self.django_secret_key = ""
         self.sentry_dsn = ""

--- a/src/firetower/integrations/services/__init__.py
+++ b/src/firetower/integrations/services/__init__.py
@@ -2,5 +2,6 @@
 
 from .pagerduty import PagerDutyService
 from .slack import SlackService
+from .statuspage import StatuspageService
 
-__all__ = ["PagerDutyService", "SlackService"]
+__all__ = ["PagerDutyService", "SlackService", "StatuspageService"]

--- a/src/firetower/integrations/services/statuspage.py
+++ b/src/firetower/integrations/services/statuspage.py
@@ -60,11 +60,12 @@ class StatuspageService:
 
         self.api_key = statuspage_config["API_KEY"]
         self.page_id = statuspage_config["PAGE_ID"]
-        self.base_url = statuspage_config["URL"].rstrip("/") + "/"
-        self.configured = bool(self.api_key and self.page_id)
+        raw_url = statuspage_config["URL"].strip()
+        self.base_url = (raw_url.rstrip("/") + "/") if raw_url else ""
+        self.configured = bool(self.api_key and self.page_id and self.base_url)
 
         if not self.configured:
-            logger.warning("StatuspageService missing API key or page ID")
+            logger.warning("StatuspageService missing API key, page ID, or URL")
 
     def _headers(self) -> dict[str, str]:
         return {

--- a/src/firetower/integrations/services/statuspage.py
+++ b/src/firetower/integrations/services/statuspage.py
@@ -101,7 +101,7 @@ class StatuspageService:
             headers=self._headers(),
             timeout=REQUEST_TIMEOUT_SECONDS,
         )
-        if response.status_code == 200:
+        if response.ok:
             return response.json()
         if response.status_code == 404:
             logger.info("Statuspage incident %s not found", incident_id)

--- a/src/firetower/integrations/services/statuspage.py
+++ b/src/firetower/integrations/services/statuspage.py
@@ -112,6 +112,7 @@ class StatuspageService:
             response.status_code,
         )
         response.raise_for_status()
+        return None
 
     def create_incident(
         self,

--- a/src/firetower/integrations/services/statuspage.py
+++ b/src/firetower/integrations/services/statuspage.py
@@ -139,6 +139,12 @@ class StatuspageService:
             headers=self._headers(),
             timeout=REQUEST_TIMEOUT_SECONDS,
         )
+        if not response.ok:
+            logger.error(
+                "Statuspage create_incident failed: %s %s",
+                response.status_code,
+                response.text,
+            )
         response.raise_for_status()
         return response.json()
 
@@ -165,6 +171,12 @@ class StatuspageService:
             headers=self._headers(),
             timeout=REQUEST_TIMEOUT_SECONDS,
         )
+        if not response.ok:
+            logger.error(
+                "Statuspage update_incident failed: %s %s",
+                response.status_code,
+                response.text,
+            )
         response.raise_for_status()
         return response.json()
 

--- a/src/firetower/integrations/services/statuspage.py
+++ b/src/firetower/integrations/services/statuspage.py
@@ -60,7 +60,7 @@ class StatuspageService:
 
         self.api_key = statuspage_config["API_KEY"]
         self.page_id = statuspage_config["PAGE_ID"]
-        self.base_url = statuspage_config["URL"]
+        self.base_url = statuspage_config["URL"].rstrip("/") + "/"
         self.configured = bool(self.api_key and self.page_id)
 
         if not self.configured:
@@ -112,7 +112,6 @@ class StatuspageService:
             response.status_code,
         )
         response.raise_for_status()
-        return None
 
     def create_incident(
         self,

--- a/src/firetower/integrations/services/statuspage.py
+++ b/src/firetower/integrations/services/statuspage.py
@@ -8,6 +8,7 @@ from django.conf import settings
 logger = logging.getLogger(__name__)
 
 STATUSPAGE_API_BASE = "https://api.statuspage.io/v1"
+REQUEST_TIMEOUT_SECONDS = 15
 
 STATUS_OPTIONS = [
     ("investigating", "Investigating"),
@@ -80,6 +81,7 @@ class StatuspageService:
         response = requests.get(
             self._api_url("components"),
             headers=self._headers(),
+            timeout=REQUEST_TIMEOUT_SECONDS,
         )
         response.raise_for_status()
         components = response.json()
@@ -97,15 +99,19 @@ class StatuspageService:
         response = requests.get(
             self._api_url(f"incidents/{incident_id}"),
             headers=self._headers(),
+            timeout=REQUEST_TIMEOUT_SECONDS,
         )
         if response.status_code == 200:
             return response.json()
+        if response.status_code == 404:
+            logger.info("Statuspage incident %s not found", incident_id)
+            return None
         logger.error(
             "Failed to fetch statuspage incident %s: %s",
             incident_id,
             response.status_code,
         )
-        return None
+        response.raise_for_status()
 
     def create_incident(
         self,
@@ -131,6 +137,7 @@ class StatuspageService:
             self._api_url("incidents"),
             json=payload,
             headers=self._headers(),
+            timeout=REQUEST_TIMEOUT_SECONDS,
         )
         response.raise_for_status()
         return response.json()
@@ -156,6 +163,7 @@ class StatuspageService:
             self._api_url(f"incidents/{incident_id}"),
             json=payload,
             headers=self._headers(),
+            timeout=REQUEST_TIMEOUT_SECONDS,
         )
         response.raise_for_status()
         return response.json()
@@ -166,5 +174,10 @@ class StatuspageService:
     def extract_incident_id_from_url(self, url: str) -> str | None:
         if not url:
             return None
-        parts = url.rstrip("/").split("/")
-        return parts[-1] if parts else None
+        path = url.split("?", 1)[0].split("#", 1)[0].rstrip("/")
+        marker = "/incidents/"
+        idx = path.find(marker)
+        if idx == -1:
+            return None
+        incident_id = path[idx + len(marker) :].split("/", 1)[0]
+        return incident_id or None

--- a/src/firetower/integrations/services/statuspage.py
+++ b/src/firetower/integrations/services/statuspage.py
@@ -1,0 +1,170 @@
+import logging
+from collections import defaultdict
+from typing import Any
+
+import requests
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+STATUSPAGE_API_BASE = "https://api.statuspage.io/v1"
+
+STATUS_OPTIONS = [
+    ("investigating", "Investigating"),
+    ("identified", "Identified"),
+    ("monitoring", "Monitoring"),
+    ("resolved", "Resolved"),
+]
+
+IMPACT_OPTIONS = [
+    ("critical", "Critical"),
+    ("major", "Major"),
+    ("minor", "Minor"),
+    ("none", "None"),
+]
+
+COMPONENT_STATUS_OPTIONS = [
+    ("operational", "Operational"),
+    ("degraded_performance", "Degraded Performance"),
+    ("partial_outage", "Partial Outage"),
+    ("major_outage", "Major Outage"),
+]
+
+DEFAULT_MESSAGES = {
+    "investigating": "We are currently investigating this issue.",
+    "identified": "The issue has been identified and a fix is being implemented.",
+    "monitoring": "A fix has been implemented and we are monitoring the results.",
+    "resolved": "This incident has been resolved.",
+}
+
+SEVERITY_TO_IMPACT = {
+    "P0": "critical",
+    "P1": "major",
+    "P2": "minor",
+    "P3": "minor",
+    "P4": "none",
+}
+
+
+class StatuspageService:
+    def __init__(self) -> None:
+        statuspage_config = settings.STATUSPAGE
+        if not statuspage_config:
+            self.api_key = ""
+            self.page_id = ""
+            self.base_url = ""
+            self.configured = False
+            logger.warning("StatuspageService initialized without configuration")
+            return
+
+        self.api_key = statuspage_config["API_KEY"]
+        self.page_id = statuspage_config["PAGE_ID"]
+        self.base_url = statuspage_config["URL"]
+        self.configured = bool(self.api_key and self.page_id)
+
+        if not self.configured:
+            logger.warning("StatuspageService missing API key or page ID")
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"OAuth {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _api_url(self, path: str) -> str:
+        return f"{STATUSPAGE_API_BASE}/pages/{self.page_id}/{path}"
+
+    def get_components(
+        self,
+    ) -> tuple[list[dict[str, Any]], dict[str, list[dict[str, Any]]]]:
+        response = requests.get(
+            self._api_url("components"),
+            headers=self._headers(),
+        )
+        response.raise_for_status()
+        components = response.json()
+
+        children_map: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for component in components:
+            group_id = component.get("group_id")
+            if group_id:
+                children_map[group_id].append(component)
+
+        top_level = [c for c in components if not c.get("group_id")]
+        return top_level, children_map
+
+    def get_incident(self, incident_id: str) -> dict[str, Any] | None:
+        response = requests.get(
+            self._api_url(f"incidents/{incident_id}"),
+            headers=self._headers(),
+        )
+        if response.status_code == 200:
+            return response.json()
+        logger.error(
+            "Failed to fetch statuspage incident %s: %s",
+            incident_id,
+            response.status_code,
+        )
+        return None
+
+    def create_incident(
+        self,
+        title: str,
+        status: str,
+        message: str,
+        impact: str = "major",
+        components: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "incident": {
+                "name": title,
+                "status": status,
+                "body": message,
+                "impact": impact,
+                "deliver_notifications": True,
+            }
+        }
+        if components:
+            payload["incident"]["components"] = components
+
+        response = requests.post(
+            self._api_url("incidents"),
+            json=payload,
+            headers=self._headers(),
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def update_incident(
+        self,
+        incident_id: str,
+        status: str | None = None,
+        message: str | None = None,
+        components: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        incident_data: dict[str, Any] = {"deliver_notifications": True}
+        if status:
+            incident_data["status"] = status
+        if message:
+            incident_data["body"] = message
+        if components:
+            incident_data["components"] = components
+
+        payload = {"incident": incident_data}
+
+        response = requests.patch(
+            self._api_url(f"incidents/{incident_id}"),
+            json=payload,
+            headers=self._headers(),
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def get_incident_url(self, incident_id: str) -> str:
+        return f"{self.base_url}incidents/{incident_id}"
+
+    def extract_incident_id_from_url(self, url: str) -> str | None:
+        if not url:
+            return None
+        parts = url.rstrip("/").split("/")
+        return parts[-1] if parts else None

--- a/src/firetower/integrations/test_statuspage.py
+++ b/src/firetower/integrations/test_statuspage.py
@@ -86,6 +86,7 @@ class TestStatuspageServiceGetIncident:
     def test_get_incident_success(self):
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.ok = True
         mock_response.json.return_value = {
             "id": "abc123",
             "name": "Test Incident",
@@ -113,6 +114,7 @@ class TestStatuspageServiceGetIncident:
     def test_get_incident_not_found(self):
         mock_response = MagicMock()
         mock_response.status_code = 404
+        mock_response.ok = False
 
         with patch.object(settings, "STATUSPAGE", MOCK_STATUSPAGE_CONFIG):
             service = StatuspageService()

--- a/src/firetower/integrations/test_statuspage.py
+++ b/src/firetower/integrations/test_statuspage.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
 from django.conf import settings
 
 from .services.statuspage import StatuspageService
@@ -106,6 +107,7 @@ class TestStatuspageServiceGetIncident:
             mock_get.assert_called_once_with(
                 "https://api.statuspage.io/v1/pages/test-page-id/incidents/abc123",
                 headers=service._headers(),
+                timeout=15,
             )
 
     def test_get_incident_not_found(self):
@@ -186,11 +188,8 @@ class TestStatuspageServiceCreateIncident:
             "firetower.integrations.services.statuspage.requests.post",
             return_value=mock_response,
         ):
-            try:
+            with pytest.raises(Exception, match="API error"):
                 service.create_incident("title", "investigating", "msg")
-                assert False, "Should have raised"
-            except Exception:
-                pass
 
 
 class TestStatuspageServiceUpdateIncident:
@@ -295,3 +294,21 @@ class TestStatuspageServiceUrlHelpers:
         with patch.object(settings, "STATUSPAGE", MOCK_STATUSPAGE_CONFIG):
             service = StatuspageService()
         assert service.extract_incident_id_from_url("") is None
+
+    def test_extract_incident_id_from_url_without_incidents_segment(self):
+        with patch.object(settings, "STATUSPAGE", MOCK_STATUSPAGE_CONFIG):
+            service = StatuspageService()
+        assert (
+            service.extract_incident_id_from_url("https://test.statuspage.io/foo/bar")
+            is None
+        )
+
+    def test_extract_incident_id_from_url_with_query_and_fragment(self):
+        with patch.object(settings, "STATUSPAGE", MOCK_STATUSPAGE_CONFIG):
+            service = StatuspageService()
+        assert (
+            service.extract_incident_id_from_url(
+                "https://test.statuspage.io/incidents/abc123?utm=foo#bar"
+            )
+            == "abc123"
+        )

--- a/src/firetower/integrations/test_statuspage.py
+++ b/src/firetower/integrations/test_statuspage.py
@@ -1,0 +1,297 @@
+from unittest.mock import MagicMock, patch
+
+from django.conf import settings
+
+from .services.statuspage import StatuspageService
+
+MOCK_STATUSPAGE_CONFIG = {
+    "API_KEY": "test-api-key",
+    "PAGE_ID": "test-page-id",
+    "URL": "https://test.statuspage.io/",
+}
+
+
+class TestStatuspageServiceInit:
+    def test_init_with_config(self):
+        with patch.object(settings, "STATUSPAGE", MOCK_STATUSPAGE_CONFIG):
+            service = StatuspageService()
+            assert service.configured is True
+            assert service.api_key == "test-api-key"
+            assert service.page_id == "test-page-id"
+            assert service.base_url == "https://test.statuspage.io/"
+
+    def test_init_without_config(self):
+        with patch.object(settings, "STATUSPAGE", None):
+            service = StatuspageService()
+            assert service.configured is False
+
+    def test_init_with_empty_api_key(self):
+        config = {**MOCK_STATUSPAGE_CONFIG, "API_KEY": ""}
+        with patch.object(settings, "STATUSPAGE", config):
+            service = StatuspageService()
+            assert service.configured is False
+
+
+class TestStatuspageServiceGetComponents:
+    def test_get_components_groups_hierarchy(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {"id": "parent1", "name": "API", "group_id": None, "position": 1},
+            {"id": "child1", "name": "REST API", "group_id": "parent1", "position": 1},
+            {
+                "id": "child2",
+                "name": "GraphQL API",
+                "group_id": "parent1",
+                "position": 2,
+            },
+            {"id": "standalone", "name": "Website", "group_id": None, "position": 0},
+        ]
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(settings, "STATUSPAGE", MOCK_STATUSPAGE_CONFIG):
+            service = StatuspageService()
+
+        with patch(
+            "firetower.integrations.services.statuspage.requests.get",
+            return_value=mock_response,
+        ) as mock_get:
+            top_level, children_map = service.get_components()
+
+            mock_get.assert_called_once()
+            assert len(top_level) == 2
+            assert top_level[0]["id"] in ("parent1", "standalone")
+            assert len(children_map["parent1"]) == 2
+            assert "standalone" not in children_map
+
+    def test_get_components_empty(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = []
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(settings, "STATUSPAGE", MOCK_STATUSPAGE_CONFIG):
+            service = StatuspageService()
+
+        with patch(
+            "firetower.integrations.services.statuspage.requests.get",
+            return_value=mock_response,
+        ):
+            top_level, children_map = service.get_components()
+            assert top_level == []
+            assert len(children_map) == 0
+
+
+class TestStatuspageServiceGetIncident:
+    def test_get_incident_success(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "id": "abc123",
+            "name": "Test Incident",
+            "status": "investigating",
+        }
+
+        with patch.object(settings, "STATUSPAGE", MOCK_STATUSPAGE_CONFIG):
+            service = StatuspageService()
+
+        with patch(
+            "firetower.integrations.services.statuspage.requests.get",
+            return_value=mock_response,
+        ) as mock_get:
+            result = service.get_incident("abc123")
+
+            assert result is not None
+            assert result["id"] == "abc123"
+            assert result["name"] == "Test Incident"
+            mock_get.assert_called_once_with(
+                "https://api.statuspage.io/v1/pages/test-page-id/incidents/abc123",
+                headers=service._headers(),
+            )
+
+    def test_get_incident_not_found(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+
+        with patch.object(settings, "STATUSPAGE", MOCK_STATUSPAGE_CONFIG):
+            service = StatuspageService()
+
+        with patch(
+            "firetower.integrations.services.statuspage.requests.get",
+            return_value=mock_response,
+        ):
+            result = service.get_incident("nonexistent")
+            assert result is None
+
+
+class TestStatuspageServiceCreateIncident:
+    def test_create_incident_basic(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": "new123", "name": "Outage"}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(settings, "STATUSPAGE", MOCK_STATUSPAGE_CONFIG):
+            service = StatuspageService()
+
+        with patch(
+            "firetower.integrations.services.statuspage.requests.post",
+            return_value=mock_response,
+        ) as mock_post:
+            result = service.create_incident(
+                title="Outage",
+                status="investigating",
+                message="Looking into it",
+            )
+
+            assert result["id"] == "new123"
+            call_kwargs = mock_post.call_args
+            payload = call_kwargs[1]["json"]
+            assert payload["incident"]["name"] == "Outage"
+            assert payload["incident"]["status"] == "investigating"
+            assert payload["incident"]["body"] == "Looking into it"
+            assert payload["incident"]["impact"] == "major"
+            assert payload["incident"]["deliver_notifications"] is True
+
+    def test_create_incident_with_components_and_impact(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": "new456"}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(settings, "STATUSPAGE", MOCK_STATUSPAGE_CONFIG):
+            service = StatuspageService()
+
+        with patch(
+            "firetower.integrations.services.statuspage.requests.post",
+            return_value=mock_response,
+        ) as mock_post:
+            service.create_incident(
+                title="Outage",
+                status="investigating",
+                message="Looking into it",
+                impact="critical",
+                components={"comp1": "major_outage"},
+            )
+
+            payload = mock_post.call_args[1]["json"]
+            assert payload["incident"]["impact"] == "critical"
+            assert payload["incident"]["components"] == {"comp1": "major_outage"}
+
+    def test_create_incident_raises_on_error(self):
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = Exception("API error")
+
+        with patch.object(settings, "STATUSPAGE", MOCK_STATUSPAGE_CONFIG):
+            service = StatuspageService()
+
+        with patch(
+            "firetower.integrations.services.statuspage.requests.post",
+            return_value=mock_response,
+        ):
+            try:
+                service.create_incident("title", "investigating", "msg")
+                assert False, "Should have raised"
+            except Exception:
+                pass
+
+
+class TestStatuspageServiceUpdateIncident:
+    def test_update_incident_status_and_message(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": "inc123", "status": "identified"}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(settings, "STATUSPAGE", MOCK_STATUSPAGE_CONFIG):
+            service = StatuspageService()
+
+        with patch(
+            "firetower.integrations.services.statuspage.requests.patch",
+            return_value=mock_response,
+        ) as mock_patch:
+            result = service.update_incident(
+                incident_id="inc123",
+                status="identified",
+                message="Found the issue",
+            )
+
+            assert result["status"] == "identified"
+            call_kwargs = mock_patch.call_args
+            assert "incidents/inc123" in call_kwargs[0][0]
+            payload = call_kwargs[1]["json"]
+            assert payload["incident"]["status"] == "identified"
+            assert payload["incident"]["body"] == "Found the issue"
+
+    def test_update_incident_with_components(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": "inc123"}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(settings, "STATUSPAGE", MOCK_STATUSPAGE_CONFIG):
+            service = StatuspageService()
+
+        with patch(
+            "firetower.integrations.services.statuspage.requests.patch",
+            return_value=mock_response,
+        ) as mock_patch:
+            service.update_incident(
+                incident_id="inc123",
+                components={"comp1": "degraded_performance"},
+            )
+
+            payload = mock_patch.call_args[1]["json"]
+            assert payload["incident"]["components"] == {
+                "comp1": "degraded_performance"
+            }
+
+    def test_update_incident_minimal(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": "inc123"}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(settings, "STATUSPAGE", MOCK_STATUSPAGE_CONFIG):
+            service = StatuspageService()
+
+        with patch(
+            "firetower.integrations.services.statuspage.requests.patch",
+            return_value=mock_response,
+        ) as mock_patch:
+            service.update_incident(incident_id="inc123")
+
+            payload = mock_patch.call_args[1]["json"]
+            assert "status" not in payload["incident"]
+            assert "body" not in payload["incident"]
+            assert "components" not in payload["incident"]
+            assert payload["incident"]["deliver_notifications"] is True
+
+
+class TestStatuspageServiceUrlHelpers:
+    def test_get_incident_url(self):
+        with patch.object(settings, "STATUSPAGE", MOCK_STATUSPAGE_CONFIG):
+            service = StatuspageService()
+        assert (
+            service.get_incident_url("abc123")
+            == "https://test.statuspage.io/incidents/abc123"
+        )
+
+    def test_extract_incident_id_from_url(self):
+        with patch.object(settings, "STATUSPAGE", MOCK_STATUSPAGE_CONFIG):
+            service = StatuspageService()
+        assert (
+            service.extract_incident_id_from_url(
+                "https://test.statuspage.io/incidents/abc123"
+            )
+            == "abc123"
+        )
+
+    def test_extract_incident_id_from_url_trailing_slash(self):
+        with patch.object(settings, "STATUSPAGE", MOCK_STATUSPAGE_CONFIG):
+            service = StatuspageService()
+        assert (
+            service.extract_incident_id_from_url(
+                "https://test.statuspage.io/incidents/abc123/"
+            )
+            == "abc123"
+        )
+
+    def test_extract_incident_id_from_empty_url(self):
+        with patch.object(settings, "STATUSPAGE", MOCK_STATUSPAGE_CONFIG):
+            service = StatuspageService()
+        assert service.extract_incident_id_from_url("") is None

--- a/src/firetower/integrations/tests/test_statuspage.py
+++ b/src/firetower/integrations/tests/test_statuspage.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 from django.conf import settings
 
 from firetower.integrations.services.statuspage import StatuspageService
@@ -125,6 +126,24 @@ class TestStatuspageServiceGetIncident:
         ):
             result = service.get_incident("nonexistent")
             assert result is None
+
+    def test_get_incident_server_error_raises(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.ok = False
+        mock_response.raise_for_status.side_effect = requests.HTTPError(
+            "500 Server Error"
+        )
+
+        with patch.object(settings, "STATUSPAGE", MOCK_STATUSPAGE_CONFIG):
+            service = StatuspageService()
+
+        with patch(
+            "firetower.integrations.services.statuspage.requests.get",
+            return_value=mock_response,
+        ):
+            with pytest.raises(requests.HTTPError):
+                service.get_incident("abc123")
 
 
 class TestStatuspageServiceCreateIncident:

--- a/src/firetower/integrations/tests/test_statuspage.py
+++ b/src/firetower/integrations/tests/test_statuspage.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from django.conf import settings
 
-from .services.statuspage import StatuspageService
+from firetower.integrations.services.statuspage import StatuspageService
 
 MOCK_STATUSPAGE_CONFIG = {
     "API_KEY": "test-api-key",

--- a/src/firetower/settings.py
+++ b/src/firetower/settings.py
@@ -236,6 +236,23 @@ SLACK: SlackSettings = {
 
 PARTICIPANT_SYNC_THROTTLE_SECONDS = int(config.slack.participant_sync_throttle_seconds)
 
+
+class StatuspageSettings(TypedDict):
+    API_KEY: str
+    PAGE_ID: str
+    URL: str
+
+
+STATUSPAGE: StatuspageSettings | None = (
+    {
+        "API_KEY": config.statuspage.api_key,
+        "PAGE_ID": config.statuspage.page_id,
+        "URL": config.statuspage.url,
+    }
+    if config.statuspage
+    else None
+)
+
 FIRETOWER_BASE_URL = config.firetower_base_url
 HOOKS_ENABLED = config.hooks_enabled
 

--- a/src/firetower/slack_app/bolt.py
+++ b/src/firetower/slack_app/bolt.py
@@ -31,6 +31,7 @@ from firetower.slack_app.handlers.statuspage import (
     handle_statuspage_command,
     handle_statuspage_confirm_resolve,
     handle_statuspage_reset_and_resolve,
+    handle_statuspage_resolve_anyway,
     handle_statuspage_submission,
 )
 from firetower.slack_app.handlers.subject import handle_subject_command
@@ -148,6 +149,7 @@ def _register_views(app: App) -> None:
     app.view("statuspage_confirm_resolve")(handle_statuspage_confirm_resolve)
     app.action("component_impact_select")(handle_component_impact_select)
     app.action("statuspage_reset_and_resolve")(handle_statuspage_reset_and_resolve)
+    app.action("statuspage_resolve_anyway")(handle_statuspage_resolve_anyway)
     for action_id in (
         "impact_type_tags",
         "affected_service_tags",

--- a/src/firetower/slack_app/bolt.py
+++ b/src/firetower/slack_app/bolt.py
@@ -27,6 +27,7 @@ from firetower.slack_app.handlers.resolved import (
 )
 from firetower.slack_app.handlers.severity import handle_severity_command
 from firetower.slack_app.handlers.statuspage import (
+    handle_component_impact_select,
     handle_statuspage_command,
     handle_statuspage_confirm_resolve,
     handle_statuspage_reset_and_resolve,
@@ -145,6 +146,7 @@ def _register_views(app: App) -> None:
     app.view("captain_incident_modal")(handle_captain_submission)
     app.view("statuspage_modal")(handle_statuspage_submission)
     app.view("statuspage_confirm_resolve")(handle_statuspage_confirm_resolve)
+    app.action("component_impact_select")(handle_component_impact_select)
     app.action("statuspage_reset_and_resolve")(handle_statuspage_reset_and_resolve)
     for action_id in (
         "impact_type_tags",

--- a/src/firetower/slack_app/bolt.py
+++ b/src/firetower/slack_app/bolt.py
@@ -26,7 +26,10 @@ from firetower.slack_app.handlers.resolved import (
     handle_resolved_submission,
 )
 from firetower.slack_app.handlers.severity import handle_severity_command
-from firetower.slack_app.handlers.statuspage import handle_statuspage_command
+from firetower.slack_app.handlers.statuspage import (
+    handle_statuspage_command,
+    handle_statuspage_submission,
+)
 from firetower.slack_app.handlers.subject import handle_subject_command
 from firetower.slack_app.handlers.update_incident import (
     handle_update_command,
@@ -115,7 +118,7 @@ def handle_command(ack: Any, body: dict, command: dict, respond: Any) -> None:
         elif subcommand in ("captain", "ic"):
             handle_captain_command(ack, body, command, respond)
         elif subcommand == "statuspage":
-            handle_statuspage_command(ack, command, respond)
+            handle_statuspage_command(ack, body, command, respond)
         elif subcommand == "dumpslack":
             handle_dumpslack_command(ack, command, respond)
         else:
@@ -138,6 +141,7 @@ def _register_views(app: App) -> None:
     app.view("mitigated_incident_modal")(handle_mitigated_submission)
     app.view("resolved_incident_modal")(handle_resolved_submission)
     app.view("captain_incident_modal")(handle_captain_submission)
+    app.view("statuspage_modal")(handle_statuspage_submission)
     for action_id in (
         "impact_type_tags",
         "affected_service_tags",

--- a/src/firetower/slack_app/bolt.py
+++ b/src/firetower/slack_app/bolt.py
@@ -28,6 +28,8 @@ from firetower.slack_app.handlers.resolved import (
 from firetower.slack_app.handlers.severity import handle_severity_command
 from firetower.slack_app.handlers.statuspage import (
     handle_statuspage_command,
+    handle_statuspage_confirm_resolve,
+    handle_statuspage_reset_and_resolve,
     handle_statuspage_submission,
 )
 from firetower.slack_app.handlers.subject import handle_subject_command
@@ -142,6 +144,8 @@ def _register_views(app: App) -> None:
     app.view("resolved_incident_modal")(handle_resolved_submission)
     app.view("captain_incident_modal")(handle_captain_submission)
     app.view("statuspage_modal")(handle_statuspage_submission)
+    app.view("statuspage_confirm_resolve")(handle_statuspage_confirm_resolve)
+    app.action("statuspage_reset_and_resolve")(handle_statuspage_reset_and_resolve)
     for action_id in (
         "impact_type_tags",
         "affected_service_tags",

--- a/src/firetower/slack_app/bolt.py
+++ b/src/firetower/slack_app/bolt.py
@@ -29,7 +29,6 @@ from firetower.slack_app.handlers.severity import handle_severity_command
 from firetower.slack_app.handlers.statuspage import (
     handle_component_impact_select,
     handle_statuspage_command,
-    handle_statuspage_confirm_resolve,
     handle_statuspage_reset_and_resolve,
     handle_statuspage_resolve_anyway,
     handle_statuspage_submission,
@@ -146,7 +145,6 @@ def _register_views(app: App) -> None:
     app.view("resolved_incident_modal")(handle_resolved_submission)
     app.view("captain_incident_modal")(handle_captain_submission)
     app.view("statuspage_modal")(handle_statuspage_submission)
-    app.view("statuspage_confirm_resolve")(handle_statuspage_confirm_resolve)
     app.action("component_impact_select")(handle_component_impact_select)
     app.action("statuspage_reset_and_resolve")(handle_statuspage_reset_and_resolve)
     app.action("statuspage_resolve_anyway")(handle_statuspage_resolve_anyway)

--- a/src/firetower/slack_app/handlers/help.py
+++ b/src/firetower/slack_app/handlers/help.py
@@ -16,7 +16,7 @@ def handle_help_command(ack: Any, command: dict, respond: Any) -> None:
         f"  `{cmd} update` - Interactively update incident metadata (alias: `{cmd} edit`)\n"
         f"  `{cmd} mitigated` - Mark incident as mitigated (alias: `{cmd} mit`)\n"
         f"  `{cmd} resolved` - Mark incident as resolved (alias: `{cmd} fixed`)\n"
-        f"  `{cmd} statuspage` - Create or update a statuspage post (not yet implemented)\n"
+        f"  `{cmd} statuspage` - Create or update a statuspage post\n"
         f"  `{cmd} dumpslack` - Dump slack channel history (not yet implemented)\n"
         f"  `{cmd} reopen` - Reopen an incident\n"
     )

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -50,7 +50,7 @@ def _build_statuspage_modal(
     if statuspage_incident:
         incident_updates = sorted(
             statuspage_incident.get("incident_updates", []),
-            key=lambda x: x["created_at"],
+            key=lambda x: x.get("created_at", ""),
             reverse=True,
         )
         if incident_updates:
@@ -338,12 +338,6 @@ def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) 
         .get("value", "investigating")
     )
     title = values.get("title_block", {}).get("title_input", {}).get("value", "")
-    impact = (
-        values.get("impact_block", {})
-        .get("impact_select", {})
-        .get("selected_option", {})
-        .get("value", "major")
-    )
 
     ack()
 
@@ -400,6 +394,12 @@ def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) 
         else:
             if not title:
                 title = incident.title
+            impact = (
+                values.get("impact_block", {})
+                .get("impact_select", {})
+                .get("selected_option", {})
+                .get("value", "major")
+            )
             try:
                 result = service.create_incident(
                     title=title,
@@ -412,14 +412,14 @@ def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) 
                 statuspage_link.url = statuspage_url
                 statuspage_link.save(update_fields=["url"])
             except Exception:
-                if created:
+                if created or not statuspage_link.url:
                     statuspage_link.delete()
                 raise
             client.chat_postMessage(
                 channel=channel_id,
                 text=f"Statuspage post created: {statuspage_url}",
             )
-    except (requests.RequestException, KeyError):
+    except Exception:
         logger.exception("Failed to create/update statuspage incident")
         client.chat_postMessage(
             channel=channel_id,

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -1,6 +1,8 @@
 import logging
 from typing import Any
 
+import requests
+
 from firetower.incidents.models import ExternalLink, ExternalLinkType
 from firetower.integrations.services.statuspage import (
     COMPONENT_STATUS_OPTIONS,
@@ -14,13 +16,15 @@ from firetower.slack_app.handlers.utils import get_incident_from_channel
 
 logger = logging.getLogger(__name__)
 
+COMPONENT_BLOCK_PREFIX = "component_"
+
 
 def _build_statuspage_modal(
     channel_id: str,
     incident_title: str,
     incident_severity: str,
-    statuspage_incident: dict | None = None,
-) -> dict:
+    statuspage_incident: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     status_options = [
         {"text": {"type": "plain_text", "text": label}, "value": value}
         for value, label in STATUS_OPTIONS
@@ -53,7 +57,7 @@ def _build_statuspage_modal(
             latest_status = incident_updates[0]["status"]
             for update in incident_updates:
                 for component in update.get("affected_components") or []:
-                    component_id = component["code"]
+                    component_id = component["id"]
                     if component_id not in affected_components:
                         affected_components[component_id] = component["new_status"]
         default_impact = statuspage_incident.get("impact", default_impact)
@@ -64,7 +68,10 @@ def _build_statuspage_modal(
     )
     initial_impact = next(
         (opt for opt in impact_options if opt["value"] == default_impact),
-        impact_options[1],
+        next(
+            (opt for opt in impact_options if opt["value"] == "major"),
+            impact_options[0],
+        ),
     )
 
     blocks: list[dict[str, Any]] = []
@@ -147,12 +154,29 @@ def _build_statuspage_modal(
     if service.configured:
         try:
             top_level, children_map = service.get_components()
+        except requests.RequestException:
+            logger.exception("Failed to fetch statuspage components")
+            blocks.append(
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": (
+                            ":warning: Could not load Statuspage components. "
+                            "You can still submit, but component statuses "
+                            "won't be updated."
+                        ),
+                    },
+                }
+            )
+        else:
             parent_ids = set(children_map.keys())
+            sorted_top = sorted(top_level, key=lambda x: x.get("position", 0))
 
-            non_parents = [c for c in top_level if c["id"] not in parent_ids]
+            non_parents = [c for c in sorted_top if c["id"] not in parent_ids]
             if non_parents:
                 blocks.append({"type": "divider"})
-            for component in sorted(non_parents, key=lambda x: x.get("position", 0)):
+            for component in non_parents:
                 current_impact = affected_components.get(component["id"], "operational")
                 initial_component_option = next(
                     (
@@ -165,7 +189,7 @@ def _build_statuspage_modal(
                 blocks.append(
                     {
                         "type": "section",
-                        "block_id": component["id"],
+                        "block_id": f"{COMPONENT_BLOCK_PREFIX}{component['id']}",
                         "text": {"type": "mrkdwn", "text": f"*{component['name']}*"},
                         "accessory": {
                             "type": "static_select",
@@ -176,7 +200,7 @@ def _build_statuspage_modal(
                     }
                 )
 
-            for parent in sorted(top_level, key=lambda x: x.get("position", 0)):
+            for parent in sorted_top:
                 if parent["id"] not in parent_ids:
                     continue
                 blocks.append(
@@ -205,7 +229,7 @@ def _build_statuspage_modal(
                     blocks.append(
                         {
                             "type": "section",
-                            "block_id": child["id"],
+                            "block_id": f"{COMPONENT_BLOCK_PREFIX}{child['id']}",
                             "text": {"type": "mrkdwn", "text": f"*{child['name']}*"},
                             "accessory": {
                                 "type": "static_select",
@@ -215,8 +239,6 @@ def _build_statuspage_modal(
                             },
                         }
                     )
-        except Exception:
-            logger.exception("Failed to fetch statuspage components")
 
     return {
         "type": "modal",
@@ -247,16 +269,30 @@ def handle_statuspage_command(
         respond("Could not open modal — missing trigger_id.")
         return
 
+    service = StatuspageService()
+    if not service.configured:
+        respond("Statuspage is not configured.")
+        return
+
     statuspage_incident = None
     statuspage_link = incident.external_links.filter(
         type=ExternalLinkType.STATUSPAGE
     ).first()
 
     if statuspage_link:
-        service = StatuspageService()
         sp_id = service.extract_incident_id_from_url(statuspage_link.url)
         if sp_id:
-            statuspage_incident = service.get_incident(sp_id)
+            try:
+                statuspage_incident = service.get_incident(sp_id)
+            except requests.RequestException:
+                logger.exception(
+                    "Failed to fetch existing statuspage incident %s", sp_id
+                )
+                respond(
+                    "Could not reach Statuspage to load the existing post. "
+                    "Please try again in a moment."
+                )
+                return
 
     from firetower.slack_app.bolt import get_bolt_app  # noqa: PLC0415
 
@@ -275,13 +311,33 @@ def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) 
     values = view.get("state", {}).get("values", {})
     channel_id = view.get("private_metadata", "")
 
+    message = values.get("message_block", {}).get("message_input", {}).get("value", "")
+    if not message:
+        ack(
+            response_action="errors",
+            errors={"message_block": "Message is required."},
+        )
+        return
+
+    service = StatuspageService()
+    if not service.configured:
+        ack()
+        channel_id_for_msg = view.get("private_metadata", "")
+        if channel_id_for_msg:
+            client.chat_postMessage(
+                channel=channel_id_for_msg,
+                text=(
+                    "Statuspage is not configured. Please contact your administrator."
+                ),
+            )
+        return
+
     status = (
         values.get("status_block", {})
         .get("status_select", {})
         .get("selected_option", {})
         .get("value", "investigating")
     )
-    message = values.get("message_block", {}).get("message_input", {}).get("value", "")
     title = values.get("title_block", {}).get("title_input", {}).get("value", "")
     impact = (
         values.get("impact_block", {})
@@ -290,45 +346,40 @@ def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) 
         .get("value", "major")
     )
 
-    if not message:
-        ack(
-            response_action="errors",
-            errors={"message_block": "Message is required."},
-        )
-        return
-
     ack()
 
     incident = get_incident_from_channel(channel_id)
     if not incident:
         logger.error("Statuspage submission: no incident for channel %s", channel_id)
+        if channel_id:
+            client.chat_postMessage(
+                channel=channel_id,
+                text=(
+                    "Could not find an incident associated with this channel — "
+                    "the Statuspage submission was not processed."
+                ),
+            )
         return
 
     components: dict[str, str] = {}
-    reserved_blocks = {"status_block", "title_block", "message_block", "impact_block"}
     for block_id, block_content in values.items():
-        if block_id in reserved_blocks:
+        if not block_id.startswith(COMPONENT_BLOCK_PREFIX):
             continue
         select_data = block_content.get("component_impact_select", {})
         if select_data:
             selected = select_data.get("selected_option", {})
             if selected:
-                components[block_id] = selected.get("value", "operational")
-
-    service = StatuspageService()
-    if not service.configured:
-        client.chat_postMessage(
-            channel=channel_id,
-            text="Statuspage is not configured. Please contact your administrator.",
-        )
-        return
-
-    statuspage_link = incident.external_links.filter(
-        type=ExternalLinkType.STATUSPAGE
-    ).first()
+                component_id = block_id[len(COMPONENT_BLOCK_PREFIX) :]
+                components[component_id] = selected.get("value", "operational")
 
     try:
-        if statuspage_link:
+        statuspage_link, created = ExternalLink.objects.get_or_create(
+            incident=incident,
+            type=ExternalLinkType.STATUSPAGE,
+            defaults={"url": ""},
+        )
+
+        if not created and statuspage_link.url:
             sp_id = service.extract_incident_id_from_url(statuspage_link.url)
             if not sp_id:
                 client.chat_postMessage(
@@ -350,24 +401,26 @@ def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) 
         else:
             if not title:
                 title = incident.title
-            result = service.create_incident(
-                title=title,
-                status=status,
-                message=message,
-                impact=impact,
-                components=components or None,
-            )
+            try:
+                result = service.create_incident(
+                    title=title,
+                    status=status,
+                    message=message,
+                    impact=impact,
+                    components=components or None,
+                )
+            except Exception:
+                if created:
+                    statuspage_link.delete()
+                raise
             statuspage_url = service.get_incident_url(result["id"])
-            ExternalLink.objects.create(
-                incident=incident,
-                type=ExternalLinkType.STATUSPAGE,
-                url=statuspage_url,
-            )
+            statuspage_link.url = statuspage_url
+            statuspage_link.save(update_fields=["url"])
             client.chat_postMessage(
                 channel=channel_id,
                 text=f"Statuspage post created: {statuspage_url}",
             )
-    except Exception:
+    except (requests.RequestException, KeyError):
         logger.exception("Failed to create/update statuspage incident")
         client.chat_postMessage(
             channel=channel_id,

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -21,17 +21,6 @@ logger = logging.getLogger(__name__)
 COMPONENT_BLOCK_PREFIX = "component_"
 
 
-def _parse_private_metadata(raw: str) -> dict[str, Any]:
-    """Parse a modal's private_metadata, tolerating pre-deploy raw channel_id strings."""
-    try:
-        parsed = json.loads(raw or "{}")
-    except json.JSONDecodeError:
-        return {"channel_id": raw}
-    if not isinstance(parsed, dict):
-        return {"channel_id": ""}
-    return parsed
-
-
 def _build_statuspage_modal(
     channel_id: str,
     incident_title: str,
@@ -254,11 +243,10 @@ def _build_statuspage_modal(
                         }
                     )
 
-    private_metadata = json.dumps({"channel_id": channel_id})
     return {
         "type": "modal",
         "callback_id": "statuspage_modal",
-        "private_metadata": private_metadata,
+        "private_metadata": channel_id,
         "title": {
             "type": "plain_text",
             "text": "Update Statuspage" if is_update else "New Statuspage Post",
@@ -332,8 +320,7 @@ def handle_statuspage_command(
 
 def _extract_submission_data(view: dict) -> dict[str, Any]:
     values = view.get("state", {}).get("values", {})
-    metadata = _parse_private_metadata(view.get("private_metadata", "{}"))
-    channel_id = metadata.get("channel_id", "")
+    channel_id = view.get("private_metadata", "")
 
     status = (
         values.get("status_block", {})
@@ -563,7 +550,7 @@ def handle_component_impact_select(ack: Any, body: dict) -> None:
 def handle_statuspage_reset_and_resolve(ack: Any, body: dict, client: Any) -> None:
     ack()
     view = body.get("view", {})
-    data = _parse_private_metadata(view.get("private_metadata", "{}"))
+    data = json.loads(view.get("private_metadata", "{}"))
     data["components"] = dict.fromkeys(data.get("components", {}), "operational")
     success = _process_statuspage_submission(data, client)
     from firetower.slack_app.bolt import get_bolt_app  # noqa: PLC0415
@@ -592,7 +579,7 @@ def handle_statuspage_reset_and_resolve(ack: Any, body: dict, client: Any) -> No
 def handle_statuspage_resolve_anyway(ack: Any, body: dict, client: Any) -> None:
     ack()
     view = body.get("view", {})
-    data = _parse_private_metadata(view.get("private_metadata", "{}"))
+    data = json.loads(view.get("private_metadata", "{}"))
     success = _process_statuspage_submission(data, client)
     from firetower.slack_app.bolt import get_bolt_app  # noqa: PLC0415
 

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -532,7 +532,7 @@ def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) 
 def handle_statuspage_confirm_resolve(
     ack: Any, body: dict, view: dict, client: Any
 ) -> None:
-    ack()
+    ack(response_action="clear")
     data = json.loads(view.get("private_metadata", "{}"))
     _process_statuspage_submission(data, client)
 

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -516,21 +516,18 @@ def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) 
         ]
         if non_operational:
             service = StatuspageService()
-            if service.configured:
-                try:
-                    top_level, children_map = service.get_components()
-                except requests.RequestException:
-                    top_level, children_map = [], {}
-                all_components = {c["id"]: c["name"] for c in top_level}
-                for children in children_map.values():
-                    for c in children:
-                        all_components[c["id"]] = c["name"]
-                labeled = [
-                    (all_components.get(cid, cid), status)
-                    for cid, status in non_operational
-                ]
-            else:
-                labeled = non_operational
+            try:
+                top_level, children_map = service.get_components()
+            except requests.RequestException:
+                top_level, children_map = [], {}
+            all_components = {c["id"]: c["name"] for c in top_level}
+            for children in children_map.values():
+                for c in children:
+                    all_components[c["id"]] = c["name"]
+            labeled = [
+                (all_components.get(cid, cid), status)
+                for cid, status in non_operational
+            ]
             ack(
                 response_action="push",
                 view=_build_component_warning_modal(data, labeled),

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -571,7 +571,7 @@ def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) 
     _process_statuspage_submission(data, client)
 
 
-# Retained for in-flight modals from before the action-button migration; safe to remove after one deploy cycle.
+# Retained for in-flight modals opened before the action-button migration; remove after 2026-05-04.
 def handle_statuspage_confirm_resolve(
     ack: Any, body: dict, view: dict, client: Any
 ) -> None:
@@ -621,7 +621,9 @@ def handle_statuspage_resolve_anyway(ack: Any, body: dict, client: Any) -> None:
     from firetower.slack_app.bolt import get_bolt_app  # noqa: PLC0415
 
     if success:
-        message = ":white_check_mark: Statuspage resolved."
+        message = (
+            ":white_check_mark: Statuspage resolved (component statuses left as-is)."
+        )
     else:
         message = ":x: Something went wrong — check the incident channel for details."
     get_bolt_app().client.views_update(

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -96,7 +96,7 @@ def _build_statuspage_modal(
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"*Title:* {statuspage_incident['name']}",
+                    "text": f"*Title:* {statuspage_incident.get('name', '')}",
                 },
             }
         )
@@ -408,13 +408,13 @@ def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) 
                     impact=impact,
                     components=components or None,
                 )
+                statuspage_url = service.get_incident_url(result["id"])
+                statuspage_link.url = statuspage_url
+                statuspage_link.save(update_fields=["url"])
             except Exception:
                 if created:
                     statuspage_link.delete()
                 raise
-            statuspage_url = service.get_incident_url(result["id"])
-            statuspage_link.url = statuspage_url
-            statuspage_link.save(update_fields=["url"])
             client.chat_postMessage(
                 channel=channel_id,
                 text=f"Statuspage post created: {statuspage_url}",

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -416,7 +416,6 @@ def _build_component_warning_modal(
     ]
     return {
         "type": "modal",
-        "callback_id": "statuspage_confirm_resolve",
         "private_metadata": json.dumps(data),
         "title": {"type": "plain_text", "text": "Confirm Resolution"},
         "close": {"type": "plain_text", "text": "Go Back"},
@@ -554,15 +553,6 @@ def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) 
             return
 
     ack()
-    _process_statuspage_submission(data, client)
-
-
-# Retained for in-flight modals opened before the action-button migration; remove after 2026-05-04.
-def handle_statuspage_confirm_resolve(
-    ack: Any, body: dict, view: dict, client: Any
-) -> None:
-    ack(response_action="clear")
-    data = _parse_private_metadata(view.get("private_metadata", "{}"))
     _process_statuspage_submission(data, client)
 
 

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import Any
 
@@ -307,29 +308,9 @@ def handle_statuspage_command(
     )
 
 
-def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) -> None:
+def _extract_submission_data(view: dict) -> dict[str, Any]:
     values = view.get("state", {}).get("values", {})
     channel_id = view.get("private_metadata", "")
-
-    message = values.get("message_block", {}).get("message_input", {}).get("value", "")
-    if not message:
-        ack(
-            response_action="errors",
-            errors={"message_block": "Message is required."},
-        )
-        return
-
-    service = StatuspageService()
-    if not service.configured:
-        ack()
-        if channel_id:
-            client.chat_postMessage(
-                channel=channel_id,
-                text=(
-                    "Statuspage is not configured. Please contact your administrator."
-                ),
-            )
-        return
 
     status = (
         values.get("status_block", {})
@@ -338,8 +319,96 @@ def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) 
         .get("value", "investigating")
     )
     title = values.get("title_block", {}).get("title_input", {}).get("value", "")
+    message = values.get("message_block", {}).get("message_input", {}).get("value", "")
+    impact = (
+        values.get("impact_block", {})
+        .get("impact_select", {})
+        .get("selected_option", {})
+        .get("value", "major")
+    )
 
-    ack()
+    components: dict[str, str] = {}
+    for block_id, block_content in values.items():
+        if not block_id.startswith(COMPONENT_BLOCK_PREFIX):
+            continue
+        select_data = block_content.get("component_impact_select", {})
+        if select_data:
+            selected = select_data.get("selected_option", {})
+            if selected:
+                component_id = block_id[len(COMPONENT_BLOCK_PREFIX) :]
+                components[component_id] = selected.get("value", "operational")
+
+    return {
+        "channel_id": channel_id,
+        "status": status,
+        "title": title,
+        "message": message,
+        "impact": impact,
+        "components": components,
+    }
+
+
+def _build_component_warning_modal(
+    data: dict[str, Any],
+    non_operational: list[tuple[str, str]],
+) -> dict[str, Any]:
+    component_lines = "\n".join(
+        f"• *{name}* — {status.replace('_', ' ')}" for name, status in non_operational
+    )
+    blocks: list[dict[str, Any]] = [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": (
+                    ":warning: You're resolving this Statuspage incident, "
+                    "but the following components are not set to *Operational*:\n\n"
+                    f"{component_lines}"
+                ),
+            },
+        },
+        {
+            "type": "actions",
+            "elements": [
+                {
+                    "type": "button",
+                    "action_id": "statuspage_reset_and_resolve",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "Set All Operational & Resolve",
+                    },
+                    "style": "primary",
+                },
+            ],
+        },
+    ]
+    return {
+        "type": "modal",
+        "callback_id": "statuspage_confirm_resolve",
+        "private_metadata": json.dumps(data),
+        "title": {"type": "plain_text", "text": "Confirm Resolution"},
+        "submit": {"type": "plain_text", "text": "Resolve Anyway"},
+        "close": {"type": "plain_text", "text": "Go Back"},
+        "blocks": blocks,
+    }
+
+
+def _process_statuspage_submission(data: dict[str, Any], client: Any) -> None:
+    channel_id = data["channel_id"]
+    status = data["status"]
+    title = data["title"]
+    message = data["message"]
+    impact = data["impact"]
+    components = data["components"]
+
+    service = StatuspageService()
+    if not service.configured:
+        if channel_id:
+            client.chat_postMessage(
+                channel=channel_id,
+                text="Statuspage is not configured. Please contact your administrator.",
+            )
+        return
 
     incident = get_incident_from_channel(channel_id)
     if not incident:
@@ -353,17 +422,6 @@ def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) 
                 ),
             )
         return
-
-    components: dict[str, str] = {}
-    for block_id, block_content in values.items():
-        if not block_id.startswith(COMPONENT_BLOCK_PREFIX):
-            continue
-        select_data = block_content.get("component_impact_select", {})
-        if select_data:
-            selected = select_data.get("selected_option", {})
-            if selected:
-                component_id = block_id[len(COMPONENT_BLOCK_PREFIX) :]
-                components[component_id] = selected.get("value", "operational")
 
     try:
         statuspage_link, created = ExternalLink.objects.get_or_create(
@@ -394,12 +452,6 @@ def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) 
         else:
             if not title:
                 title = incident.title
-            impact = (
-                values.get("impact_block", {})
-                .get("impact_select", {})
-                .get("selected_option", {})
-                .get("value", "major")
-            )
             try:
                 result = service.create_incident(
                     title=title,
@@ -425,3 +477,84 @@ def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) 
             channel=channel_id,
             text="Something went wrong updating Statuspage. Please try again.",
         )
+
+
+def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) -> None:
+    values = view.get("state", {}).get("values", {})
+    message = values.get("message_block", {}).get("message_input", {}).get("value", "")
+    if not message:
+        ack(
+            response_action="errors",
+            errors={"message_block": "Message is required."},
+        )
+        return
+
+    data = _extract_submission_data(view)
+
+    if data["status"] == "resolved":
+        non_operational = [
+            (cid, status)
+            for cid, status in data["components"].items()
+            if status != "operational"
+        ]
+        if non_operational:
+            service = StatuspageService()
+            if service.configured:
+                try:
+                    top_level, children_map = service.get_components()
+                except requests.RequestException:
+                    top_level, children_map = [], {}
+                all_components = {c["id"]: c["name"] for c in top_level}
+                for children in children_map.values():
+                    for c in children:
+                        all_components[c["id"]] = c["name"]
+                labeled = [
+                    (all_components.get(cid, cid), status)
+                    for cid, status in non_operational
+                ]
+            else:
+                labeled = non_operational
+            ack(
+                response_action="push",
+                view=_build_component_warning_modal(data, labeled),
+            )
+            return
+
+    ack()
+    _process_statuspage_submission(data, client)
+
+
+def handle_statuspage_confirm_resolve(
+    ack: Any, body: dict, view: dict, client: Any
+) -> None:
+    ack()
+    data = json.loads(view.get("private_metadata", "{}"))
+    _process_statuspage_submission(data, client)
+
+
+def handle_statuspage_reset_and_resolve(ack: Any, body: dict, client: Any) -> None:
+    ack()
+    view = body.get("view", {})
+    data = json.loads(view.get("private_metadata", "{}"))
+    for cid in data.get("components", {}):
+        data["components"][cid] = "operational"
+    _process_statuspage_submission(data, client)
+    from firetower.slack_app.bolt import get_bolt_app  # noqa: PLC0415
+
+    get_bolt_app().client.views_update(
+        view_id=view["id"],
+        view={
+            "type": "modal",
+            "title": {"type": "plain_text", "text": "Confirm Resolution"},
+            "close": {"type": "plain_text", "text": "Close"},
+            "blocks": [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": ":white_check_mark: All components set to operational and statuspage resolved.",
+                    },
+                },
+            ],
+        },
+    )

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -399,7 +399,7 @@ def _build_component_warning_modal(
                     "action_id": "statuspage_resolve_anyway",
                     "text": {
                         "type": "plain_text",
-                        "text": "Resolve Without Updating Components",
+                        "text": "Resolve & Keep Current Statuses",
                     },
                     "style": "danger",
                 },

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -57,9 +57,9 @@ def _build_statuspage_modal(
             latest_status = incident_updates[0]["status"]
             for update in incident_updates:
                 for component in update.get("affected_components") or []:
-                    component_id = component["id"]
+                    component_id = component["code"]
                     if component_id not in affected_components:
-                        affected_components[component_id] = component["new_status"]
+                        affected_components[component_id] = component["new_value"]
         default_impact = statuspage_incident.get("impact", default_impact)
 
     initial_status = next(
@@ -322,10 +322,9 @@ def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) 
     service = StatuspageService()
     if not service.configured:
         ack()
-        channel_id_for_msg = view.get("private_metadata", "")
-        if channel_id_for_msg:
+        if channel_id:
             client.chat_postMessage(
-                channel=channel_id_for_msg,
+                channel=channel_id,
                 text=(
                     "Statuspage is not configured. Please contact your administrator."
                 ),

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -296,6 +296,14 @@ def handle_statuspage_command(
                     "Please try again in a moment."
                 )
                 return
+            if statuspage_incident is None:
+                logger.info(
+                    "Removing stale Statuspage ExternalLink for incident %s "
+                    "(Statuspage incident %s missing)",
+                    incident.id,
+                    sp_id,
+                )
+                statuspage_link.delete()
 
     from firetower.slack_app.bolt import get_bolt_app  # noqa: PLC0415
 

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -153,6 +153,7 @@ def _build_statuspage_modal(
             }
         )
 
+    component_names: dict[str, str] = {}
     service = StatuspageService()
     if service.configured:
         try:
@@ -180,6 +181,7 @@ def _build_statuspage_modal(
             if non_parents:
                 blocks.append({"type": "divider"})
             for component in non_parents:
+                component_names[component["id"]] = component["name"]
                 current_impact = affected_components.get(component["id"], "operational")
                 initial_component_option = next(
                     (
@@ -220,6 +222,7 @@ def _build_statuspage_modal(
                     key=lambda x: x.get("position", 0),
                 )
                 for child in children:
+                    component_names[child["id"]] = child["name"]
                     current_impact = affected_components.get(child["id"], "operational")
                     initial_component_option = next(
                         (
@@ -243,10 +246,13 @@ def _build_statuspage_modal(
                         }
                     )
 
+    private_metadata = json.dumps(
+        {"channel_id": channel_id, "component_names": component_names}
+    )
     return {
         "type": "modal",
         "callback_id": "statuspage_modal",
-        "private_metadata": channel_id,
+        "private_metadata": private_metadata,
         "title": {
             "type": "plain_text",
             "text": "Update Statuspage" if is_update else "New Statuspage Post",
@@ -320,7 +326,9 @@ def handle_statuspage_command(
 
 def _extract_submission_data(view: dict) -> dict[str, Any]:
     values = view.get("state", {}).get("values", {})
-    channel_id = view.get("private_metadata", "")
+    metadata = json.loads(view.get("private_metadata", "{}"))
+    channel_id = metadata.get("channel_id", "")
+    component_names = metadata.get("component_names", {})
 
     status = (
         values.get("status_block", {})
@@ -355,6 +363,7 @@ def _extract_submission_data(view: dict) -> dict[str, Any]:
         "message": message,
         "impact": impact,
         "components": components,
+        "component_names": component_names,
     }
 
 
@@ -515,17 +524,9 @@ def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) 
             if status != "operational"
         ]
         if non_operational:
-            service = StatuspageService()
-            try:
-                top_level, children_map = service.get_components()
-            except requests.RequestException:
-                top_level, children_map = [], {}
-            all_components = {c["id"]: c["name"] for c in top_level}
-            for children in children_map.values():
-                for c in children:
-                    all_components[c["id"]] = c["name"]
+            component_names = data["component_names"]
             labeled = [
-                (all_components.get(cid, cid), status)
+                (component_names.get(cid, cid), status)
                 for cid, status in non_operational
             ]
             ack(

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -532,6 +532,10 @@ def handle_statuspage_confirm_resolve(
     _process_statuspage_submission(data, client)
 
 
+def handle_component_impact_select(ack: Any, body: dict) -> None:
+    ack()
+
+
 def handle_statuspage_reset_and_resolve(ack: Any, body: dict, client: Any) -> None:
     ack()
     view = body.get("view", {})
@@ -545,6 +549,7 @@ def handle_statuspage_reset_and_resolve(ack: Any, body: dict, client: Any) -> No
         view_id=view["id"],
         view={
             "type": "modal",
+            "clear_on_close": True,
             "title": {"type": "plain_text", "text": "Confirm Resolution"},
             "close": {"type": "plain_text", "text": "Close"},
             "blocks": [

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -389,6 +389,11 @@ def _build_component_warning_modal(
                     },
                     "style": "primary",
                 },
+            ],
+        },
+        {
+            "type": "actions",
+            "elements": [
                 {
                     "type": "button",
                     "action_id": "statuspage_resolve_anyway",

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -473,10 +473,7 @@ def _process_statuspage_submission(data: dict[str, Any], client: Any) -> bool:
                     components=components or None,
                 )
                 statuspage_url = service.get_incident_url(result["id"])
-                client.chat_postMessage(
-                    channel=channel_id,
-                    text=f"Statuspage has been updated: {statuspage_url}",
-                )
+                success_message = f"Statuspage has been updated: {statuspage_url}"
             else:
                 result = service.create_incident(
                     title=title,
@@ -488,10 +485,8 @@ def _process_statuspage_submission(data: dict[str, Any], client: Any) -> bool:
                 statuspage_url = service.get_incident_url(result["id"])
                 statuspage_link.url = statuspage_url
                 statuspage_link.save(update_fields=["url"])
-                client.chat_postMessage(
-                    channel=channel_id,
-                    text=f"Statuspage post created: {statuspage_url}",
-                )
+                success_message = f"Statuspage post created: {statuspage_url}"
+        client.chat_postMessage(channel=channel_id, text=success_message)
     except Exception:
         logger.exception("Failed to create/update statuspage incident")
         client.chat_postMessage(

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -1,7 +1,375 @@
+import logging
 from typing import Any
 
+from firetower.incidents.models import ExternalLink, ExternalLinkType
+from firetower.integrations.services.statuspage import (
+    COMPONENT_STATUS_OPTIONS,
+    DEFAULT_MESSAGES,
+    IMPACT_OPTIONS,
+    SEVERITY_TO_IMPACT,
+    STATUS_OPTIONS,
+    StatuspageService,
+)
+from firetower.slack_app.handlers.utils import get_incident_from_channel
 
-def handle_statuspage_command(ack: Any, command: dict, respond: Any) -> None:
+logger = logging.getLogger(__name__)
+
+
+def _build_statuspage_modal(
+    channel_id: str,
+    incident_title: str,
+    incident_severity: str,
+    statuspage_incident: dict | None = None,
+) -> dict:
+    status_options = [
+        {"text": {"type": "plain_text", "text": label}, "value": value}
+        for value, label in STATUS_OPTIONS
+    ]
+
+    impact_options = [
+        {"text": {"type": "plain_text", "text": label}, "value": value}
+        for value, label in IMPACT_OPTIONS
+    ]
+
+    component_status_options = [
+        {"text": {"type": "plain_text", "text": label}, "value": value}
+        for value, label in COMPONENT_STATUS_OPTIONS
+    ]
+
+    default_component_option = component_status_options[0]
+
+    is_update = statuspage_incident is not None
+    latest_status = "investigating"
+    default_impact = SEVERITY_TO_IMPACT.get(incident_severity, "major")
+    affected_components: dict[str, str] = {}
+
+    if statuspage_incident:
+        incident_updates = sorted(
+            statuspage_incident.get("incident_updates", []),
+            key=lambda x: x["created_at"],
+            reverse=True,
+        )
+        if incident_updates:
+            latest_status = incident_updates[0]["status"]
+            for update in incident_updates:
+                for component in update.get("affected_components") or []:
+                    component_id = component["code"]
+                    if component_id not in affected_components:
+                        affected_components[component_id] = component["new_status"]
+        default_impact = statuspage_incident.get("impact", default_impact)
+
+    initial_status = next(
+        (opt for opt in status_options if opt["value"] == latest_status),
+        status_options[0],
+    )
+    initial_impact = next(
+        (opt for opt in impact_options if opt["value"] == default_impact),
+        impact_options[1],
+    )
+
+    blocks: list[dict[str, Any]] = []
+
+    blocks.append(
+        {
+            "type": "input",
+            "block_id": "status_block",
+            "element": {
+                "type": "static_select",
+                "action_id": "status_select",
+                "options": status_options,
+                "initial_option": initial_status,
+            },
+            "label": {"type": "plain_text", "text": "Status"},
+        }
+    )
+
+    if statuspage_incident is not None:
+        blocks.append(
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"*Title:* {statuspage_incident['name']}",
+                },
+            }
+        )
+    else:
+        blocks.append(
+            {
+                "type": "input",
+                "block_id": "title_block",
+                "element": {
+                    "type": "plain_text_input",
+                    "action_id": "title_input",
+                    "initial_value": incident_title,
+                    "placeholder": {
+                        "type": "plain_text",
+                        "text": "Enter a descriptive title for the customer",
+                    },
+                },
+                "label": {"type": "plain_text", "text": "Title"},
+            }
+        )
+
+    blocks.append(
+        {
+            "type": "input",
+            "block_id": "message_block",
+            "element": {
+                "type": "plain_text_input",
+                "action_id": "message_input",
+                "multiline": True,
+                "placeholder": {
+                    "type": "plain_text",
+                    "text": DEFAULT_MESSAGES.get(latest_status, ""),
+                },
+            },
+            "label": {"type": "plain_text", "text": "Message"},
+        }
+    )
+
+    if not is_update:
+        blocks.append(
+            {
+                "type": "input",
+                "block_id": "impact_block",
+                "element": {
+                    "type": "static_select",
+                    "action_id": "impact_select",
+                    "options": impact_options,
+                    "initial_option": initial_impact,
+                },
+                "label": {"type": "plain_text", "text": "Impact"},
+            }
+        )
+
+    service = StatuspageService()
+    if service.configured:
+        try:
+            top_level, children_map = service.get_components()
+            parent_ids = set(children_map.keys())
+
+            non_parents = [c for c in top_level if c["id"] not in parent_ids]
+            if non_parents:
+                blocks.append({"type": "divider"})
+            for component in sorted(non_parents, key=lambda x: x.get("position", 0)):
+                current_impact = affected_components.get(component["id"], "operational")
+                initial_component_option = next(
+                    (
+                        opt
+                        for opt in component_status_options
+                        if opt["value"] == current_impact
+                    ),
+                    default_component_option,
+                )
+                blocks.append(
+                    {
+                        "type": "section",
+                        "block_id": component["id"],
+                        "text": {"type": "mrkdwn", "text": f"*{component['name']}*"},
+                        "accessory": {
+                            "type": "static_select",
+                            "action_id": "component_impact_select",
+                            "options": component_status_options,
+                            "initial_option": initial_component_option,
+                        },
+                    }
+                )
+
+            for parent in sorted(top_level, key=lambda x: x.get("position", 0)):
+                if parent["id"] not in parent_ids:
+                    continue
+                blocks.append(
+                    {
+                        "type": "header",
+                        "text": {
+                            "type": "plain_text",
+                            "text": parent["name"],
+                        },
+                    }
+                )
+                children = sorted(
+                    children_map.get(parent["id"], []),
+                    key=lambda x: x.get("position", 0),
+                )
+                for child in children:
+                    current_impact = affected_components.get(child["id"], "operational")
+                    initial_component_option = next(
+                        (
+                            opt
+                            for opt in component_status_options
+                            if opt["value"] == current_impact
+                        ),
+                        default_component_option,
+                    )
+                    blocks.append(
+                        {
+                            "type": "section",
+                            "block_id": child["id"],
+                            "text": {"type": "mrkdwn", "text": f"*{child['name']}*"},
+                            "accessory": {
+                                "type": "static_select",
+                                "action_id": "component_impact_select",
+                                "options": component_status_options,
+                                "initial_option": initial_component_option,
+                            },
+                        }
+                    )
+        except Exception:
+            logger.exception("Failed to fetch statuspage components")
+
+    return {
+        "type": "modal",
+        "callback_id": "statuspage_modal",
+        "private_metadata": channel_id,
+        "title": {
+            "type": "plain_text",
+            "text": "Update Statuspage" if is_update else "New Statuspage Post",
+        },
+        "submit": {"type": "plain_text", "text": "Submit"},
+        "close": {"type": "plain_text", "text": "Cancel"},
+        "blocks": blocks,
+    }
+
+
+def handle_statuspage_command(
+    ack: Any, body: dict, command: dict, respond: Any
+) -> None:
     ack()
-    cmd = command.get("command", "/ft")
-    respond(f"`{cmd} statuspage` is not yet implemented.")
+    channel_id = body.get("channel_id", "")
+    incident = get_incident_from_channel(channel_id)
+    if not incident:
+        respond("Could not find an incident associated with this channel.")
+        return
+
+    trigger_id = body.get("trigger_id")
+    if not trigger_id:
+        respond("Could not open modal — missing trigger_id.")
+        return
+
+    statuspage_incident = None
+    statuspage_link = incident.external_links.filter(
+        type=ExternalLinkType.STATUSPAGE
+    ).first()
+
+    if statuspage_link:
+        service = StatuspageService()
+        sp_id = service.extract_incident_id_from_url(statuspage_link.url)
+        if sp_id:
+            statuspage_incident = service.get_incident(sp_id)
+
+    from firetower.slack_app.bolt import get_bolt_app  # noqa: PLC0415
+
+    get_bolt_app().client.views_open(
+        trigger_id=trigger_id,
+        view=_build_statuspage_modal(
+            channel_id=channel_id,
+            incident_title=incident.title,
+            incident_severity=incident.severity,
+            statuspage_incident=statuspage_incident,
+        ),
+    )
+
+
+def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) -> None:
+    values = view.get("state", {}).get("values", {})
+    channel_id = view.get("private_metadata", "")
+
+    status = (
+        values.get("status_block", {})
+        .get("status_select", {})
+        .get("selected_option", {})
+        .get("value", "investigating")
+    )
+    message = values.get("message_block", {}).get("message_input", {}).get("value", "")
+    title = values.get("title_block", {}).get("title_input", {}).get("value", "")
+    impact = (
+        values.get("impact_block", {})
+        .get("impact_select", {})
+        .get("selected_option", {})
+        .get("value", "major")
+    )
+
+    if not message:
+        ack(
+            response_action="errors",
+            errors={"message_block": "Message is required."},
+        )
+        return
+
+    ack()
+
+    incident = get_incident_from_channel(channel_id)
+    if not incident:
+        logger.error("Statuspage submission: no incident for channel %s", channel_id)
+        return
+
+    components: dict[str, str] = {}
+    reserved_blocks = {"status_block", "title_block", "message_block", "impact_block"}
+    for block_id, block_content in values.items():
+        if block_id in reserved_blocks:
+            continue
+        select_data = block_content.get("component_impact_select", {})
+        if select_data:
+            selected = select_data.get("selected_option", {})
+            if selected:
+                components[block_id] = selected.get("value", "operational")
+
+    service = StatuspageService()
+    if not service.configured:
+        client.chat_postMessage(
+            channel=channel_id,
+            text="Statuspage is not configured. Please contact your administrator.",
+        )
+        return
+
+    statuspage_link = incident.external_links.filter(
+        type=ExternalLinkType.STATUSPAGE
+    ).first()
+
+    try:
+        if statuspage_link:
+            sp_id = service.extract_incident_id_from_url(statuspage_link.url)
+            if not sp_id:
+                client.chat_postMessage(
+                    channel=channel_id,
+                    text="Could not determine the existing statuspage incident ID.",
+                )
+                return
+            result = service.update_incident(
+                incident_id=sp_id,
+                status=status,
+                message=message,
+                components=components or None,
+            )
+            statuspage_url = service.get_incident_url(result["id"])
+            client.chat_postMessage(
+                channel=channel_id,
+                text=f"Statuspage has been updated: {statuspage_url}",
+            )
+        else:
+            if not title:
+                title = incident.title
+            result = service.create_incident(
+                title=title,
+                status=status,
+                message=message,
+                impact=impact,
+                components=components or None,
+            )
+            statuspage_url = service.get_incident_url(result["id"])
+            ExternalLink.objects.create(
+                incident=incident,
+                type=ExternalLinkType.STATUSPAGE,
+                url=statuspage_url,
+            )
+            client.chat_postMessage(
+                channel=channel_id,
+                text=f"Statuspage post created: {statuspage_url}",
+            )
+    except Exception:
+        logger.exception("Failed to create/update statuspage incident")
+        client.chat_postMessage(
+            channel=channel_id,
+            text="Something went wrong updating Statuspage. Please try again.",
+        )

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -55,12 +55,14 @@ def _build_statuspage_modal(
             reverse=True,
         )
         if incident_updates:
-            latest_status = incident_updates[0]["status"]
+            latest_status = incident_updates[0].get("status", "investigating")
             for update in incident_updates:
                 for component in update.get("affected_components") or []:
-                    component_id = component["code"]
-                    if component_id not in affected_components:
-                        affected_components[component_id] = component["new_status"]
+                    component_id = component.get("code", "")
+                    if component_id and component_id not in affected_components:
+                        affected_components[component_id] = component.get(
+                            "new_status", "operational"
+                        )
         default_impact = statuspage_incident.get("impact", default_impact)
 
     initial_status = next(
@@ -392,7 +394,7 @@ def _build_component_warning_modal(
     }
 
 
-def _process_statuspage_submission(data: dict[str, Any], client: Any) -> None:
+def _process_statuspage_submission(data: dict[str, Any], client: Any) -> bool:
     channel_id = data["channel_id"]
     status = data["status"]
     title = data["title"]
@@ -407,7 +409,7 @@ def _process_statuspage_submission(data: dict[str, Any], client: Any) -> None:
                 channel=channel_id,
                 text="Statuspage is not configured. Please contact your administrator.",
             )
-        return
+        return False
 
     incident = get_incident_from_channel(channel_id)
     if not incident:
@@ -420,7 +422,7 @@ def _process_statuspage_submission(data: dict[str, Any], client: Any) -> None:
                     "the Statuspage submission was not processed."
                 ),
             )
-        return
+        return False
 
     try:
         statuspage_link, created = ExternalLink.objects.get_or_create(
@@ -436,7 +438,7 @@ def _process_statuspage_submission(data: dict[str, Any], client: Any) -> None:
                     channel=channel_id,
                     text="Could not determine the existing statuspage incident ID.",
                 )
-                return
+                return False
             result = service.update_incident(
                 incident_id=sp_id,
                 status=status,
@@ -474,6 +476,8 @@ def _process_statuspage_submission(data: dict[str, Any], client: Any) -> None:
             channel=channel_id,
             text="Something went wrong updating Statuspage. Please try again.",
         )
+        return False
+    return True
 
 
 def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) -> None:
@@ -543,9 +547,13 @@ def handle_statuspage_reset_and_resolve(ack: Any, body: dict, client: Any) -> No
     data = json.loads(view.get("private_metadata", "{}"))
     for cid in data.get("components", {}):
         data["components"][cid] = "operational"
-    _process_statuspage_submission(data, client)
+    success = _process_statuspage_submission(data, client)
     from firetower.slack_app.bolt import get_bolt_app  # noqa: PLC0415
 
+    if success:
+        message = ":white_check_mark: All components set to operational and statuspage resolved."
+    else:
+        message = ":x: Something went wrong — check the incident channel for details."
     get_bolt_app().client.views_update(
         view_id=view["id"],
         view={
@@ -556,10 +564,7 @@ def handle_statuspage_reset_and_resolve(ack: Any, body: dict, client: Any) -> No
             "blocks": [
                 {
                     "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": ":white_check_mark: All components set to operational and statuspage resolved.",
-                    },
+                    "text": {"type": "mrkdwn", "text": message},
                 },
             ],
         },

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -3,6 +3,7 @@ import logging
 from typing import Any
 
 import requests
+from django.db import transaction
 
 from firetower.incidents.models import ExternalLink, ExternalLinkType
 from firetower.integrations.services.statuspage import (
@@ -425,51 +426,54 @@ def _process_statuspage_submission(data: dict[str, Any], client: Any) -> bool:
         return False
 
     try:
-        statuspage_link, created = ExternalLink.objects.get_or_create(
-            incident=incident,
-            type=ExternalLinkType.STATUSPAGE,
-            defaults={"url": ""},
-        )
-
-        if not created and statuspage_link.url:
-            sp_id = service.extract_incident_id_from_url(statuspage_link.url)
-            if not sp_id:
-                client.chat_postMessage(
-                    channel=channel_id,
-                    text="Could not determine the existing statuspage incident ID.",
+        with transaction.atomic():
+            statuspage_link, created = (
+                ExternalLink.objects.select_for_update().get_or_create(
+                    incident=incident,
+                    type=ExternalLinkType.STATUSPAGE,
+                    defaults={"url": ""},
                 )
-                return False
-            result = service.update_incident(
-                incident_id=sp_id,
-                status=status,
-                message=message,
-                components=components or None,
             )
-            statuspage_url = service.get_incident_url(result["id"])
-            client.chat_postMessage(
-                channel=channel_id,
-                text=f"Statuspage has been updated: {statuspage_url}",
-            )
-        else:
-            try:
-                result = service.create_incident(
-                    title=title,
+
+            if not created and statuspage_link.url:
+                sp_id = service.extract_incident_id_from_url(statuspage_link.url)
+                if not sp_id:
+                    client.chat_postMessage(
+                        channel=channel_id,
+                        text="Could not determine the existing statuspage incident ID.",
+                    )
+                    return False
+                result = service.update_incident(
+                    incident_id=sp_id,
                     status=status,
                     message=message,
-                    impact=impact,
                     components=components or None,
                 )
                 statuspage_url = service.get_incident_url(result["id"])
-                statuspage_link.url = statuspage_url
-                statuspage_link.save(update_fields=["url"])
-            except Exception:
-                if created or not statuspage_link.url:
-                    statuspage_link.delete()
-                raise
-            client.chat_postMessage(
-                channel=channel_id,
-                text=f"Statuspage post created: {statuspage_url}",
-            )
+                client.chat_postMessage(
+                    channel=channel_id,
+                    text=f"Statuspage has been updated: {statuspage_url}",
+                )
+            else:
+                try:
+                    result = service.create_incident(
+                        title=title,
+                        status=status,
+                        message=message,
+                        impact=impact,
+                        components=components or None,
+                    )
+                    statuspage_url = service.get_incident_url(result["id"])
+                    statuspage_link.url = statuspage_url
+                    statuspage_link.save(update_fields=["url"])
+                except Exception:
+                    if created or not statuspage_link.url:
+                        statuspage_link.delete()
+                    raise
+                client.chat_postMessage(
+                    channel=channel_id,
+                    text=f"Statuspage post created: {statuspage_url}",
+                )
     except Exception:
         logger.exception("Failed to create/update statuspage incident")
         client.chat_postMessage(

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -59,7 +59,7 @@ def _build_statuspage_modal(
                 for component in update.get("affected_components") or []:
                     component_id = component["code"]
                     if component_id not in affected_components:
-                        affected_components[component_id] = component["new_value"]
+                        affected_components[component_id] = component["new_status"]
         default_impact = statuspage_incident.get("impact", default_impact)
 
     initial_status = next(

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -19,7 +19,6 @@ from firetower.slack_app.handlers.utils import get_incident_from_channel
 logger = logging.getLogger(__name__)
 
 COMPONENT_BLOCK_PREFIX = "component_"
-SLACK_PRIVATE_METADATA_MAX_BYTES = 3000
 
 
 def _parse_private_metadata(raw: str) -> dict[str, Any]:
@@ -27,24 +26,10 @@ def _parse_private_metadata(raw: str) -> dict[str, Any]:
     try:
         parsed = json.loads(raw or "{}")
     except json.JSONDecodeError:
-        return {"channel_id": raw, "component_names": {}}
+        return {"channel_id": raw}
     if not isinstance(parsed, dict):
-        return {"channel_id": "", "component_names": {}}
+        return {"channel_id": ""}
     return parsed
-
-
-def _clamp_private_metadata(payload: dict[str, Any]) -> str:
-    """JSON-encode payload, dropping component_names if it would exceed Slack's limit."""
-    encoded = json.dumps(payload)
-    if len(encoded) > SLACK_PRIVATE_METADATA_MAX_BYTES:
-        logger.info(
-            "Statuspage modal private_metadata exceeded Slack's limit (%d bytes); "
-            "dropping component_names — warning modal will fall back to raw IDs.",
-            len(encoded),
-        )
-        trimmed = {k: v for k, v in payload.items() if k != "component_names"}
-        encoded = json.dumps(trimmed)
-    return encoded
 
 
 def _build_statuspage_modal(
@@ -179,7 +164,6 @@ def _build_statuspage_modal(
             }
         )
 
-    component_names: dict[str, str] = {}
     service = StatuspageService()
     if service.configured:
         try:
@@ -207,7 +191,6 @@ def _build_statuspage_modal(
             if non_parents:
                 blocks.append({"type": "divider"})
             for component in non_parents:
-                component_names[component["id"]] = component["name"]
                 current_impact = affected_components.get(component["id"], "operational")
                 initial_component_option = next(
                     (
@@ -248,7 +231,6 @@ def _build_statuspage_modal(
                     key=lambda x: x.get("position", 0),
                 )
                 for child in children:
-                    component_names[child["id"]] = child["name"]
                     current_impact = affected_components.get(child["id"], "operational")
                     initial_component_option = next(
                         (
@@ -272,9 +254,7 @@ def _build_statuspage_modal(
                         }
                     )
 
-    private_metadata = _clamp_private_metadata(
-        {"channel_id": channel_id, "component_names": component_names}
-    )
+    private_metadata = json.dumps({"channel_id": channel_id})
     return {
         "type": "modal",
         "callback_id": "statuspage_modal",
@@ -354,7 +334,6 @@ def _extract_submission_data(view: dict) -> dict[str, Any]:
     values = view.get("state", {}).get("values", {})
     metadata = _parse_private_metadata(view.get("private_metadata", "{}"))
     channel_id = metadata.get("channel_id", "")
-    component_names = metadata.get("component_names", {})
 
     status = (
         values.get("status_block", {})
@@ -389,7 +368,6 @@ def _extract_submission_data(view: dict) -> dict[str, Any]:
         "message": message,
         "impact": impact,
         "components": components,
-        "component_names": component_names,
     }
 
 
@@ -439,7 +417,7 @@ def _build_component_warning_modal(
     return {
         "type": "modal",
         "callback_id": "statuspage_confirm_resolve",
-        "private_metadata": _clamp_private_metadata(data),
+        "private_metadata": json.dumps(data),
         "title": {"type": "plain_text", "text": "Confirm Resolution"},
         "close": {"type": "plain_text", "text": "Go Back"},
         "blocks": blocks,
@@ -556,9 +534,17 @@ def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) 
             if status != "operational"
         ]
         if non_operational:
-            component_names = data["component_names"]
+            service = StatuspageService()
+            try:
+                top_level, children_map = service.get_components()
+            except requests.RequestException:
+                top_level, children_map = [], {}
+            all_components = {c["id"]: c["name"] for c in top_level}
+            for children in children_map.values():
+                for c in children:
+                    all_components[c["id"]] = c["name"]
             labeled = [
-                (component_names.get(cid, cid), status)
+                (all_components.get(cid, cid), status)
                 for cid, status in non_operational
             ]
             ack(

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -19,6 +19,32 @@ from firetower.slack_app.handlers.utils import get_incident_from_channel
 logger = logging.getLogger(__name__)
 
 COMPONENT_BLOCK_PREFIX = "component_"
+SLACK_PRIVATE_METADATA_MAX_BYTES = 3000
+
+
+def _parse_private_metadata(raw: str) -> dict[str, Any]:
+    """Parse a modal's private_metadata, tolerating pre-deploy raw channel_id strings."""
+    try:
+        parsed = json.loads(raw or "{}")
+    except json.JSONDecodeError:
+        return {"channel_id": raw, "component_names": {}}
+    if not isinstance(parsed, dict):
+        return {"channel_id": "", "component_names": {}}
+    return parsed
+
+
+def _clamp_private_metadata(payload: dict[str, Any]) -> str:
+    """JSON-encode payload, dropping component_names if it would exceed Slack's limit."""
+    encoded = json.dumps(payload)
+    if len(encoded) > SLACK_PRIVATE_METADATA_MAX_BYTES:
+        logger.info(
+            "Statuspage modal private_metadata exceeded Slack's limit (%d bytes); "
+            "dropping component_names — warning modal will fall back to raw IDs.",
+            len(encoded),
+        )
+        trimmed = {k: v for k, v in payload.items() if k != "component_names"}
+        encoded = json.dumps(trimmed)
+    return encoded
 
 
 def _build_statuspage_modal(
@@ -246,7 +272,7 @@ def _build_statuspage_modal(
                         }
                     )
 
-    private_metadata = json.dumps(
+    private_metadata = _clamp_private_metadata(
         {"channel_id": channel_id, "component_names": component_names}
     )
     return {
@@ -326,7 +352,7 @@ def handle_statuspage_command(
 
 def _extract_submission_data(view: dict) -> dict[str, Any]:
     values = view.get("state", {}).get("values", {})
-    metadata = json.loads(view.get("private_metadata", "{}"))
+    metadata = _parse_private_metadata(view.get("private_metadata", "{}"))
     channel_id = metadata.get("channel_id", "")
     component_names = metadata.get("component_names", {})
 
@@ -404,7 +430,7 @@ def _build_component_warning_modal(
     return {
         "type": "modal",
         "callback_id": "statuspage_confirm_resolve",
-        "private_metadata": json.dumps(data),
+        "private_metadata": _clamp_private_metadata(data),
         "title": {"type": "plain_text", "text": "Confirm Resolution"},
         "submit": {"type": "plain_text", "text": "Resolve Anyway"},
         "close": {"type": "plain_text", "text": "Go Back"},
@@ -444,6 +470,9 @@ def _process_statuspage_submission(data: dict[str, Any], client: Any) -> bool:
 
     try:
         with transaction.atomic():
+            # Hold the row lock across the Statuspage API call so concurrent submits
+            # serialize and only one external incident is created. Trade-off: a stuck
+            # Statuspage API blocks DB writers on this row until REQUEST_TIMEOUT_SECONDS.
             statuspage_link, created = (
                 ExternalLink.objects.select_for_update().get_or_create(
                     incident=incident,
@@ -472,21 +501,16 @@ def _process_statuspage_submission(data: dict[str, Any], client: Any) -> bool:
                     text=f"Statuspage has been updated: {statuspage_url}",
                 )
             else:
-                try:
-                    result = service.create_incident(
-                        title=title,
-                        status=status,
-                        message=message,
-                        impact=impact,
-                        components=components or None,
-                    )
-                    statuspage_url = service.get_incident_url(result["id"])
-                    statuspage_link.url = statuspage_url
-                    statuspage_link.save(update_fields=["url"])
-                except Exception:
-                    if created or not statuspage_link.url:
-                        statuspage_link.delete()
-                    raise
+                result = service.create_incident(
+                    title=title,
+                    status=status,
+                    message=message,
+                    impact=impact,
+                    components=components or None,
+                )
+                statuspage_url = service.get_incident_url(result["id"])
+                statuspage_link.url = statuspage_url
+                statuspage_link.save(update_fields=["url"])
                 client.chat_postMessage(
                     channel=channel_id,
                     text=f"Statuspage post created: {statuspage_url}",
@@ -543,7 +567,7 @@ def handle_statuspage_confirm_resolve(
     ack: Any, body: dict, view: dict, client: Any
 ) -> None:
     ack(response_action="clear")
-    data = json.loads(view.get("private_metadata", "{}"))
+    data = _parse_private_metadata(view.get("private_metadata", "{}"))
     _process_statuspage_submission(data, client)
 
 
@@ -554,9 +578,8 @@ def handle_component_impact_select(ack: Any, body: dict) -> None:
 def handle_statuspage_reset_and_resolve(ack: Any, body: dict, client: Any) -> None:
     ack()
     view = body.get("view", {})
-    data = json.loads(view.get("private_metadata", "{}"))
-    for cid in data.get("components", {}):
-        data["components"][cid] = "operational"
+    data = _parse_private_metadata(view.get("private_metadata", "{}"))
+    data["components"] = dict.fromkeys(data.get("components", {}), "operational")
     success = _process_statuspage_submission(data, client)
     from firetower.slack_app.bolt import get_bolt_app  # noqa: PLC0415
 

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -486,7 +486,6 @@ def _process_statuspage_submission(data: dict[str, Any], client: Any) -> bool:
                 statuspage_link.url = statuspage_url
                 statuspage_link.save(update_fields=["url"])
                 success_message = f"Statuspage post created: {statuspage_url}"
-        client.chat_postMessage(channel=channel_id, text=success_message)
     except Exception:
         logger.exception("Failed to create/update statuspage incident")
         client.chat_postMessage(
@@ -494,6 +493,16 @@ def _process_statuspage_submission(data: dict[str, Any], client: Any) -> bool:
             text="Something went wrong updating Statuspage. Please try again.",
         )
         return False
+
+    try:
+        client.chat_postMessage(channel=channel_id, text=success_message)
+    except Exception:
+        logger.exception(
+            "Failed to post statuspage success message for incident %s (%s)",
+            incident.id,
+            success_message,
+        )
+
     return True
 
 

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -424,6 +424,15 @@ def _build_component_warning_modal(
                     },
                     "style": "primary",
                 },
+                {
+                    "type": "button",
+                    "action_id": "statuspage_resolve_anyway",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "Resolve Anyway",
+                    },
+                    "style": "danger",
+                },
             ],
         },
     ]
@@ -432,7 +441,6 @@ def _build_component_warning_modal(
         "callback_id": "statuspage_confirm_resolve",
         "private_metadata": _clamp_private_metadata(data),
         "title": {"type": "plain_text", "text": "Confirm Resolution"},
-        "submit": {"type": "plain_text", "text": "Resolve Anyway"},
         "close": {"type": "plain_text", "text": "Go Back"},
         "blocks": blocks,
     }
@@ -563,6 +571,7 @@ def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) 
     _process_statuspage_submission(data, client)
 
 
+# Retained for in-flight modals from before the action-button migration; safe to remove after one deploy cycle.
 def handle_statuspage_confirm_resolve(
     ack: Any, body: dict, view: dict, client: Any
 ) -> None:
@@ -585,6 +594,34 @@ def handle_statuspage_reset_and_resolve(ack: Any, body: dict, client: Any) -> No
 
     if success:
         message = ":white_check_mark: All components set to operational and statuspage resolved."
+    else:
+        message = ":x: Something went wrong — check the incident channel for details."
+    get_bolt_app().client.views_update(
+        view_id=view["id"],
+        view={
+            "type": "modal",
+            "clear_on_close": True,
+            "title": {"type": "plain_text", "text": "Confirm Resolution"},
+            "close": {"type": "plain_text", "text": "Close"},
+            "blocks": [
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": message},
+                },
+            ],
+        },
+    )
+
+
+def handle_statuspage_resolve_anyway(ack: Any, body: dict, client: Any) -> None:
+    ack()
+    view = body.get("view", {})
+    data = _parse_private_metadata(view.get("private_metadata", "{}"))
+    success = _process_statuspage_submission(data, client)
+    from firetower.slack_app.bolt import get_bolt_app  # noqa: PLC0415
+
+    if success:
+        message = ":white_check_mark: Statuspage resolved."
     else:
         message = ":x: Something went wrong — check the incident channel for details."
     get_bolt_app().client.views_update(

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -399,7 +399,7 @@ def _build_component_warning_modal(
                     "action_id": "statuspage_resolve_anyway",
                     "text": {
                         "type": "plain_text",
-                        "text": "Resolve Anyway",
+                        "text": "Resolve Without Updating Components",
                     },
                     "style": "danger",
                 },

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -109,10 +109,9 @@ def _build_statuspage_modal(
                 "element": {
                     "type": "plain_text_input",
                     "action_id": "title_input",
-                    "initial_value": incident_title,
                     "placeholder": {
                         "type": "plain_text",
-                        "text": "Enter a descriptive title for the customer",
+                        "text": incident_title,
                     },
                 },
                 "label": {"type": "plain_text", "text": "Title"},
@@ -450,8 +449,6 @@ def _process_statuspage_submission(data: dict[str, Any], client: Any) -> None:
                 text=f"Statuspage has been updated: {statuspage_url}",
             )
         else:
-            if not title:
-                title = incident.title
             try:
                 result = service.create_incident(
                     title=title,
@@ -481,12 +478,16 @@ def _process_statuspage_submission(data: dict[str, Any], client: Any) -> None:
 
 def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) -> None:
     values = view.get("state", {}).get("values", {})
+    errors: dict[str, str] = {}
     message = values.get("message_block", {}).get("message_input", {}).get("value", "")
     if not message:
-        ack(
-            response_action="errors",
-            errors={"message_block": "Message is required."},
-        )
+        errors["message_block"] = "Message is required."
+    if "title_block" in values:
+        title = values["title_block"].get("title_input", {}).get("value", "")
+        if not title:
+            errors["title_block"] = "Title is required."
+    if errors:
+        ack(response_action="errors", errors=errors)
         return
 
     data = _extract_submission_data(view)

--- a/src/firetower/slack_app/tests/handlers/test_statuspage.py
+++ b/src/firetower/slack_app/tests/handlers/test_statuspage.py
@@ -33,7 +33,7 @@ class TestBuildStatuspageModal:
         assert "status_block" in block_ids
         assert "impact_block" in block_ids
 
-    def test_new_post_prefills_title(self):
+    def test_new_post_shows_title_as_placeholder(self):
         with patch(
             "firetower.slack_app.handlers.statuspage.StatuspageService"
         ) as MockService:
@@ -47,7 +47,8 @@ class TestBuildStatuspageModal:
         title_block = next(
             b for b in modal["blocks"] if b.get("block_id") == "title_block"
         )
-        assert title_block["element"]["initial_value"] == "Database Issues"
+        assert "initial_value" not in title_block["element"]
+        assert title_block["element"]["placeholder"]["text"] == "Database Issues"
 
     def test_new_post_derives_impact_from_severity(self):
         with patch(
@@ -486,23 +487,15 @@ class TestStatuspageSubmission:
             "Could not find an incident" in client.chat_postMessage.call_args[1]["text"]
         )
 
-    def test_uses_incident_title_when_no_title_in_form(self, incident):
+    def test_rejects_empty_title(self, incident):
         ack = MagicMock()
         body = {}
         view = self._make_view(title="")
         client = MagicMock()
 
-        with patch(
-            "firetower.slack_app.handlers.statuspage.StatuspageService"
-        ) as MockService:
-            instance = MockService.return_value
-            instance.configured = True
-            instance.create_incident.return_value = {"id": "sp_new"}
-            instance.get_incident_url.return_value = (
-                "https://test.statuspage.io/incidents/sp_new"
-            )
+        handle_statuspage_submission(ack, body, view, client)
 
-            handle_statuspage_submission(ack, body, view, client)
-
-        call_kwargs = instance.create_incident.call_args[1]
-        assert call_kwargs["title"] == "Test Incident"
+        ack.assert_called_once_with(
+            response_action="errors",
+            errors={"title_block": "Title is required."},
+        )

--- a/src/firetower/slack_app/tests/handlers/test_statuspage.py
+++ b/src/firetower/slack_app/tests/handlers/test_statuspage.py
@@ -534,7 +534,7 @@ class TestStatuspageSubmission:
         assert len(actions_blocks) == 2
 
         second_button = actions_blocks[1]["elements"][0]
-        assert second_button["text"]["text"] == "Resolve Without Updating Components"
+        assert second_button["text"]["text"] == "Resolve & Keep Current Statuses"
         assert second_button["style"] == "danger"
 
         client.chat_postMessage.assert_not_called()

--- a/src/firetower/slack_app/tests/handlers/test_statuspage.py
+++ b/src/firetower/slack_app/tests/handlers/test_statuspage.py
@@ -464,6 +464,9 @@ class TestStatuspageSubmission:
 
         ack.assert_called_once()
         assert "went wrong" in client.chat_postMessage.call_args[1]["text"]
+        assert not ExternalLink.objects.filter(
+            incident=incident, type=ExternalLinkType.STATUSPAGE
+        ).exists()
 
     def test_no_incident_for_channel(self, db):
         ack = MagicMock()

--- a/src/firetower/slack_app/tests/handlers/test_statuspage.py
+++ b/src/firetower/slack_app/tests/handlers/test_statuspage.py
@@ -8,6 +8,8 @@ from firetower.incidents.models import ExternalLink, ExternalLinkType
 from firetower.slack_app.handlers.statuspage import (
     _build_statuspage_modal,
     handle_statuspage_command,
+    handle_statuspage_confirm_resolve,
+    handle_statuspage_reset_and_resolve,
     handle_statuspage_submission,
 )
 
@@ -506,3 +508,102 @@ class TestStatuspageSubmission:
             response_action="errors",
             errors={"title_block": "Title is required."},
         )
+
+
+class TestStatuspageResetAndResolve:
+    def _make_body(self, data: dict) -> dict:
+        return {
+            "view": {
+                "id": "V_WARNING",
+                "private_metadata": json.dumps(data),
+            }
+        }
+
+    def test_sets_all_components_operational_and_processes(self):
+        data = {
+            "channel_id": CHANNEL_ID,
+            "status": "resolved",
+            "title": "Outage",
+            "message": "Resolved",
+            "impact": "major",
+            "components": {"c1": "major_outage", "c2": "degraded_performance"},
+            "component_names": {"c1": "API", "c2": "Web"},
+        }
+        ack = MagicMock()
+        body = self._make_body(data)
+        client = MagicMock()
+
+        with (
+            patch(
+                "firetower.slack_app.handlers.statuspage._process_statuspage_submission",
+                return_value=True,
+            ) as mock_process,
+            patch("firetower.slack_app.bolt.get_bolt_app") as mock_app,
+        ):
+            handle_statuspage_reset_and_resolve(ack, body, client)
+
+        ack.assert_called_once_with()
+        mock_process.assert_called_once()
+        passed_data = mock_process.call_args[0][0]
+        assert passed_data["components"] == {"c1": "operational", "c2": "operational"}
+        mock_app.return_value.client.views_update.assert_called_once()
+        update_kwargs = mock_app.return_value.client.views_update.call_args[1]
+        assert update_kwargs["view_id"] == "V_WARNING"
+        assert update_kwargs["view"]["clear_on_close"] is True
+        section_text = update_kwargs["view"]["blocks"][0]["text"]["text"]
+        assert "operational" in section_text
+        assert "resolved" in section_text
+
+    def test_failure_shows_failure_message(self):
+        data = {
+            "channel_id": CHANNEL_ID,
+            "status": "resolved",
+            "title": "Outage",
+            "message": "Resolved",
+            "impact": "major",
+            "components": {"c1": "major_outage"},
+            "component_names": {"c1": "API"},
+        }
+        ack = MagicMock()
+        body = self._make_body(data)
+        client = MagicMock()
+
+        with (
+            patch(
+                "firetower.slack_app.handlers.statuspage._process_statuspage_submission",
+                return_value=False,
+            ),
+            patch("firetower.slack_app.bolt.get_bolt_app") as mock_app,
+        ):
+            handle_statuspage_reset_and_resolve(ack, body, client)
+
+        update_kwargs = mock_app.return_value.client.views_update.call_args[1]
+        assert update_kwargs["view"]["clear_on_close"] is True
+        section_text = update_kwargs["view"]["blocks"][0]["text"]["text"]
+        assert "went wrong" in section_text
+
+
+class TestStatuspageConfirmResolve:
+    def test_clears_modal_stack_and_processes_submission(self):
+        data = {
+            "channel_id": CHANNEL_ID,
+            "status": "resolved",
+            "title": "Outage",
+            "message": "Resolved anyway",
+            "impact": "major",
+            "components": {"c1": "major_outage"},
+            "component_names": {"c1": "API"},
+        }
+        ack = MagicMock()
+        body = {}
+        view = {"private_metadata": json.dumps(data)}
+        client = MagicMock()
+
+        with patch(
+            "firetower.slack_app.handlers.statuspage._process_statuspage_submission",
+            return_value=True,
+        ) as mock_process:
+            handle_statuspage_confirm_resolve(ack, body, view, client)
+
+        ack.assert_called_once_with(response_action="clear")
+        mock_process.assert_called_once_with(data, client)

--- a/src/firetower/slack_app/tests/handlers/test_statuspage.py
+++ b/src/firetower/slack_app/tests/handlers/test_statuspage.py
@@ -1,16 +1,453 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
-from firetower.slack_app.handlers.statuspage import handle_statuspage_command
+import pytest
+
+from firetower.incidents.models import ExternalLink, ExternalLinkType
+from firetower.slack_app.handlers.statuspage import (
+    _build_statuspage_modal,
+    handle_statuspage_command,
+    handle_statuspage_submission,
+)
+
+from .conftest import CHANNEL_ID
 
 
+class TestBuildStatuspageModal:
+    def test_new_post_has_title_input(self):
+        with patch(
+            "firetower.slack_app.handlers.statuspage.StatuspageService"
+        ) as MockService:
+            MockService.return_value.configured = False
+            modal = _build_statuspage_modal(
+                channel_id=CHANNEL_ID,
+                incident_title="Test Outage",
+                incident_severity="P1",
+            )
+
+        assert modal["callback_id"] == "statuspage_modal"
+        assert modal["title"]["text"] == "New Statuspage Post"
+        block_ids = [b.get("block_id") for b in modal["blocks"]]
+        assert "title_block" in block_ids
+        assert "message_block" in block_ids
+        assert "status_block" in block_ids
+        assert "impact_block" in block_ids
+
+    def test_new_post_prefills_title(self):
+        with patch(
+            "firetower.slack_app.handlers.statuspage.StatuspageService"
+        ) as MockService:
+            MockService.return_value.configured = False
+            modal = _build_statuspage_modal(
+                channel_id=CHANNEL_ID,
+                incident_title="Database Issues",
+                incident_severity="P2",
+            )
+
+        title_block = next(
+            b for b in modal["blocks"] if b.get("block_id") == "title_block"
+        )
+        assert title_block["element"]["initial_value"] == "Database Issues"
+
+    def test_new_post_derives_impact_from_severity(self):
+        with patch(
+            "firetower.slack_app.handlers.statuspage.StatuspageService"
+        ) as MockService:
+            MockService.return_value.configured = False
+            modal = _build_statuspage_modal(
+                channel_id=CHANNEL_ID,
+                incident_title="Outage",
+                incident_severity="P0",
+            )
+
+        impact_block = next(
+            b for b in modal["blocks"] if b.get("block_id") == "impact_block"
+        )
+        assert impact_block["element"]["initial_option"]["value"] == "critical"
+
+    def test_update_shows_title_as_text(self):
+        sp_incident = {
+            "name": "Existing Issue",
+            "impact": "major",
+            "incident_updates": [
+                {
+                    "status": "identified",
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "affected_components": [],
+                }
+            ],
+        }
+        with patch(
+            "firetower.slack_app.handlers.statuspage.StatuspageService"
+        ) as MockService:
+            MockService.return_value.configured = False
+            modal = _build_statuspage_modal(
+                channel_id=CHANNEL_ID,
+                incident_title="Test",
+                incident_severity="P1",
+                statuspage_incident=sp_incident,
+            )
+
+        assert modal["title"]["text"] == "Update Statuspage"
+        block_ids = [b.get("block_id") for b in modal["blocks"]]
+        assert "title_block" not in block_ids
+        assert "impact_block" not in block_ids
+
+        section_blocks = [b for b in modal["blocks"] if b.get("type") == "section"]
+        assert any("Existing Issue" in b["text"]["text"] for b in section_blocks)
+
+    def test_update_prefills_current_status(self):
+        sp_incident = {
+            "name": "Issue",
+            "impact": "minor",
+            "incident_updates": [
+                {
+                    "status": "monitoring",
+                    "created_at": "2024-01-02T00:00:00Z",
+                    "affected_components": [],
+                },
+                {
+                    "status": "investigating",
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "affected_components": [],
+                },
+            ],
+        }
+        with patch(
+            "firetower.slack_app.handlers.statuspage.StatuspageService"
+        ) as MockService:
+            MockService.return_value.configured = False
+            modal = _build_statuspage_modal(
+                channel_id=CHANNEL_ID,
+                incident_title="Test",
+                incident_severity="P1",
+                statuspage_incident=sp_incident,
+            )
+
+        status_block = next(
+            b for b in modal["blocks"] if b.get("block_id") == "status_block"
+        )
+        assert status_block["element"]["initial_option"]["value"] == "monitoring"
+
+    def test_components_rendered_when_service_configured(self):
+        mock_components = [
+            {"id": "c1", "name": "API", "group_id": None, "position": 1},
+            {"id": "c2", "name": "Dashboard", "group_id": None, "position": 2},
+        ]
+        with patch(
+            "firetower.slack_app.handlers.statuspage.StatuspageService"
+        ) as MockService:
+            instance = MockService.return_value
+            instance.configured = True
+            instance.get_components.return_value = (mock_components, {})
+            modal = _build_statuspage_modal(
+                channel_id=CHANNEL_ID,
+                incident_title="Test",
+                incident_severity="P1",
+            )
+
+        component_blocks = [
+            b for b in modal["blocks"] if b.get("block_id") in ("c1", "c2")
+        ]
+        assert len(component_blocks) == 2
+
+
+@pytest.mark.django_db
 class TestStatuspageCommand:
-    def test_returns_not_implemented(self):
+    def test_opens_modal_for_new_post(self, incident):
         ack = MagicMock()
-        respond = MagicMock()
+        body = {"channel_id": CHANNEL_ID, "trigger_id": "T123"}
         command = {"command": "/ft"}
+        respond = MagicMock()
 
-        handle_statuspage_command(ack, command, respond)
+        with (
+            patch(
+                "firetower.slack_app.handlers.statuspage.StatuspageService"
+            ) as MockService,
+            patch("firetower.slack_app.bolt.get_bolt_app") as mock_app,
+        ):
+            MockService.return_value.configured = False
+            handle_statuspage_command(ack, body, command, respond)
+
+            ack.assert_called_once()
+            mock_app.return_value.client.views_open.assert_called_once()
+            view = mock_app.return_value.client.views_open.call_args[1]["view"]
+            assert view["callback_id"] == "statuspage_modal"
+            assert view["title"]["text"] == "New Statuspage Post"
+
+    def test_opens_modal_for_existing_post(self, incident):
+        ExternalLink.objects.create(
+            incident=incident,
+            type=ExternalLinkType.STATUSPAGE,
+            url="https://test.statuspage.io/incidents/sp123",
+        )
+
+        ack = MagicMock()
+        body = {"channel_id": CHANNEL_ID, "trigger_id": "T123"}
+        command = {"command": "/ft"}
+        respond = MagicMock()
+
+        sp_data = {
+            "id": "sp123",
+            "name": "Existing",
+            "impact": "major",
+            "incident_updates": [
+                {
+                    "status": "investigating",
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "affected_components": [],
+                }
+            ],
+        }
+
+        with (
+            patch(
+                "firetower.slack_app.handlers.statuspage.StatuspageService"
+            ) as MockService,
+            patch("firetower.slack_app.bolt.get_bolt_app") as mock_app,
+        ):
+            instance = MockService.return_value
+            instance.configured = False
+            instance.extract_incident_id_from_url.return_value = "sp123"
+            instance.get_incident.return_value = sp_data
+
+            handle_statuspage_command(ack, body, command, respond)
+
+            view = mock_app.return_value.client.views_open.call_args[1]["view"]
+            assert view["title"]["text"] == "Update Statuspage"
+
+    def test_no_incident_responds_error(self, db):
+        ack = MagicMock()
+        body = {"channel_id": "C_UNKNOWN", "trigger_id": "T123"}
+        command = {"command": "/ft"}
+        respond = MagicMock()
+
+        handle_statuspage_command(ack, body, command, respond)
 
         ack.assert_called_once()
-        respond.assert_called_once()
-        assert "not yet implemented" in respond.call_args[0][0]
+        assert "Could not find" in respond.call_args[0][0]
+
+    def test_no_trigger_id(self, incident):
+        ack = MagicMock()
+        body = {"channel_id": CHANNEL_ID}
+        command = {"command": "/ft"}
+        respond = MagicMock()
+
+        handle_statuspage_command(ack, body, command, respond)
+
+        ack.assert_called_once()
+        assert "trigger_id" in respond.call_args[0][0]
+
+
+@pytest.mark.django_db
+class TestStatuspageSubmission:
+    def _make_view(
+        self,
+        *,
+        status="investigating",
+        message="Looking into it",
+        title="Outage",
+        impact="major",
+        channel_id=CHANNEL_ID,
+        components=None,
+    ):
+        values: dict = {
+            "status_block": {
+                "status_select": {
+                    "selected_option": {"value": status},
+                }
+            },
+            "message_block": {
+                "message_input": {"value": message},
+            },
+            "title_block": {
+                "title_input": {"value": title},
+            },
+            "impact_block": {
+                "impact_select": {
+                    "selected_option": {"value": impact},
+                }
+            },
+        }
+        if components:
+            for comp_id, comp_status in components.items():
+                values[comp_id] = {
+                    "component_impact_select": {
+                        "selected_option": {"value": comp_status},
+                    }
+                }
+        return {
+            "state": {"values": values},
+            "private_metadata": channel_id,
+        }
+
+    def test_creates_new_statuspage_incident(self, incident):
+        ack = MagicMock()
+        body = {}
+        view = self._make_view()
+        client = MagicMock()
+
+        with patch(
+            "firetower.slack_app.handlers.statuspage.StatuspageService"
+        ) as MockService:
+            instance = MockService.return_value
+            instance.configured = True
+            instance.create_incident.return_value = {"id": "new_sp_123"}
+            instance.get_incident_url.return_value = (
+                "https://test.statuspage.io/incidents/new_sp_123"
+            )
+
+            handle_statuspage_submission(ack, body, view, client)
+
+        ack.assert_called_once()
+        instance.create_incident.assert_called_once_with(
+            title="Outage",
+            status="investigating",
+            message="Looking into it",
+            impact="major",
+            components=None,
+        )
+
+        link = ExternalLink.objects.get(
+            incident=incident, type=ExternalLinkType.STATUSPAGE
+        )
+        assert link.url == "https://test.statuspage.io/incidents/new_sp_123"
+
+        assert "created" in client.chat_postMessage.call_args[1]["text"]
+
+    def test_creates_with_components(self, incident):
+        ack = MagicMock()
+        body = {}
+        view = self._make_view(components={"comp1": "major_outage"})
+        client = MagicMock()
+
+        with patch(
+            "firetower.slack_app.handlers.statuspage.StatuspageService"
+        ) as MockService:
+            instance = MockService.return_value
+            instance.configured = True
+            instance.create_incident.return_value = {"id": "new_sp_456"}
+            instance.get_incident_url.return_value = (
+                "https://test.statuspage.io/incidents/new_sp_456"
+            )
+
+            handle_statuspage_submission(ack, body, view, client)
+
+        instance.create_incident.assert_called_once_with(
+            title="Outage",
+            status="investigating",
+            message="Looking into it",
+            impact="major",
+            components={"comp1": "major_outage"},
+        )
+
+    def test_updates_existing_statuspage_incident(self, incident):
+        ExternalLink.objects.create(
+            incident=incident,
+            type=ExternalLinkType.STATUSPAGE,
+            url="https://test.statuspage.io/incidents/existing_sp",
+        )
+
+        ack = MagicMock()
+        body = {}
+        view = self._make_view(status="identified", message="Found the cause")
+        client = MagicMock()
+
+        with patch(
+            "firetower.slack_app.handlers.statuspage.StatuspageService"
+        ) as MockService:
+            instance = MockService.return_value
+            instance.configured = True
+            instance.extract_incident_id_from_url.return_value = "existing_sp"
+            instance.update_incident.return_value = {"id": "existing_sp"}
+            instance.get_incident_url.return_value = (
+                "https://test.statuspage.io/incidents/existing_sp"
+            )
+
+            handle_statuspage_submission(ack, body, view, client)
+
+        instance.update_incident.assert_called_once_with(
+            incident_id="existing_sp",
+            status="identified",
+            message="Found the cause",
+            components=None,
+        )
+        assert "updated" in client.chat_postMessage.call_args[1]["text"]
+
+    def test_empty_message_returns_error(self, incident):
+        ack = MagicMock()
+        body = {}
+        view = self._make_view(message="")
+        client = MagicMock()
+
+        handle_statuspage_submission(ack, body, view, client)
+
+        ack.assert_called_once_with(
+            response_action="errors",
+            errors={"message_block": "Message is required."},
+        )
+        client.chat_postMessage.assert_not_called()
+
+    def test_unconfigured_service_responds_error(self, incident):
+        ack = MagicMock()
+        body = {}
+        view = self._make_view()
+        client = MagicMock()
+
+        with patch(
+            "firetower.slack_app.handlers.statuspage.StatuspageService"
+        ) as MockService:
+            instance = MockService.return_value
+            instance.configured = False
+
+            handle_statuspage_submission(ack, body, view, client)
+
+        assert "not configured" in client.chat_postMessage.call_args[1]["text"]
+
+    def test_api_error_sends_failure_message(self, incident):
+        ack = MagicMock()
+        body = {}
+        view = self._make_view()
+        client = MagicMock()
+
+        with patch(
+            "firetower.slack_app.handlers.statuspage.StatuspageService"
+        ) as MockService:
+            instance = MockService.return_value
+            instance.configured = True
+            instance.create_incident.side_effect = Exception("API error")
+
+            handle_statuspage_submission(ack, body, view, client)
+
+        assert "went wrong" in client.chat_postMessage.call_args[1]["text"]
+
+    def test_no_incident_for_channel(self, db):
+        ack = MagicMock()
+        body = {}
+        view = self._make_view(channel_id="C_NONEXISTENT")
+        client = MagicMock()
+
+        handle_statuspage_submission(ack, body, view, client)
+
+        ack.assert_called_once()
+        client.chat_postMessage.assert_not_called()
+
+    def test_uses_incident_title_when_no_title_in_form(self, incident):
+        ack = MagicMock()
+        body = {}
+        view = self._make_view(title="")
+        client = MagicMock()
+
+        with patch(
+            "firetower.slack_app.handlers.statuspage.StatuspageService"
+        ) as MockService:
+            instance = MockService.return_value
+            instance.configured = True
+            instance.create_incident.return_value = {"id": "sp_new"}
+            instance.get_incident_url.return_value = (
+                "https://test.statuspage.io/incidents/sp_new"
+            )
+
+            handle_statuspage_submission(ack, body, view, client)
+
+        call_kwargs = instance.create_incident.call_args[1]
+        assert call_kwargs["title"] == "Test Incident"

--- a/src/firetower/slack_app/tests/handlers/test_statuspage.py
+++ b/src/firetower/slack_app/tests/handlers/test_statuspage.py
@@ -295,7 +295,6 @@ class TestStatuspageSubmission:
         impact="major",
         channel_id=CHANNEL_ID,
         components=None,
-        component_names=None,
     ):
         values: dict = {
             "status_block": {
@@ -324,12 +323,7 @@ class TestStatuspageSubmission:
                 }
         return {
             "state": {"values": values},
-            "private_metadata": json.dumps(
-                {
-                    "channel_id": channel_id,
-                    "component_names": component_names or {},
-                }
-            ),
+            "private_metadata": json.dumps({"channel_id": channel_id}),
         }
 
     def test_creates_new_statuspage_incident(self, incident):
@@ -529,7 +523,6 @@ class TestStatuspageResetAndResolve:
             "message": "Resolved",
             "impact": "major",
             "components": {"c1": "major_outage", "c2": "degraded_performance"},
-            "component_names": {"c1": "API", "c2": "Web"},
         }
         ack = MagicMock()
         body = self._make_body(data)
@@ -564,7 +557,6 @@ class TestStatuspageResetAndResolve:
             "message": "Resolved",
             "impact": "major",
             "components": {"c1": "major_outage"},
-            "component_names": {"c1": "API"},
         }
         ack = MagicMock()
         body = self._make_body(data)
@@ -602,7 +594,6 @@ class TestStatuspageResolveAnyway:
             "message": "Resolved",
             "impact": "major",
             "components": {"c1": "major_outage", "c2": "degraded_performance"},
-            "component_names": {"c1": "API", "c2": "Web"},
         }
         ack = MagicMock()
         body = self._make_body(data)
@@ -640,7 +631,6 @@ class TestStatuspageResolveAnyway:
             "message": "Resolved",
             "impact": "major",
             "components": {"c1": "major_outage"},
-            "component_names": {"c1": "API"},
         }
         ack = MagicMock()
         body = self._make_body(data)
@@ -670,7 +660,6 @@ class TestStatuspageConfirmResolve:
             "message": "Resolved anyway",
             "impact": "major",
             "components": {"c1": "major_outage"},
-            "component_names": {"c1": "API"},
         }
         ack = MagicMock()
         body = {}
@@ -692,24 +681,24 @@ class TestParsePrivateMetadata:
         "raw,expected",
         [
             (
-                json.dumps({"channel_id": "C123", "component_names": {"a": "A"}}),
-                {"channel_id": "C123", "component_names": {"a": "A"}},
+                json.dumps({"channel_id": "C123"}),
+                {"channel_id": "C123"},
             ),
             (
                 "C_12345",
-                {"channel_id": "C_12345", "component_names": {}},
+                {"channel_id": "C_12345"},
             ),
             (
                 json.dumps("hello"),
-                {"channel_id": "", "component_names": {}},
+                {"channel_id": ""},
             ),
             (
                 json.dumps(None),
-                {"channel_id": "", "component_names": {}},
+                {"channel_id": ""},
             ),
             (
                 json.dumps(123),
-                {"channel_id": "", "component_names": {}},
+                {"channel_id": ""},
             ),
             ("", {}),
             (None, {}),

--- a/src/firetower/slack_app/tests/handlers/test_statuspage.py
+++ b/src/firetower/slack_app/tests/handlers/test_statuspage.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 from firetower.incidents.models import ExternalLink, ExternalLinkType
 from firetower.slack_app.handlers.statuspage import (
@@ -128,6 +129,25 @@ class TestBuildStatuspageModal:
         )
         assert status_block["element"]["initial_option"]["value"] == "monitoring"
 
+    def test_component_fetch_failure_shows_warning(self):
+        with patch(
+            "firetower.slack_app.handlers.statuspage.StatuspageService"
+        ) as MockService:
+            instance = MockService.return_value
+            instance.configured = True
+            instance.get_components.side_effect = requests.RequestException("boom")
+            modal = _build_statuspage_modal(
+                channel_id=CHANNEL_ID,
+                incident_title="Test",
+                incident_severity="P1",
+            )
+
+        section_blocks = [b for b in modal["blocks"] if b.get("type") == "section"]
+        assert any(
+            "Could not load Statuspage components" in b["text"]["text"]
+            for b in section_blocks
+        )
+
     def test_components_rendered_when_service_configured(self):
         mock_components = [
             {"id": "c1", "name": "API", "group_id": None, "position": 1},
@@ -146,7 +166,9 @@ class TestBuildStatuspageModal:
             )
 
         component_blocks = [
-            b for b in modal["blocks"] if b.get("block_id") in ("c1", "c2")
+            b
+            for b in modal["blocks"]
+            if b.get("block_id") in ("component_c1", "component_c2")
         ]
         assert len(component_blocks) == 2
 
@@ -165,7 +187,9 @@ class TestStatuspageCommand:
             ) as MockService,
             patch("firetower.slack_app.bolt.get_bolt_app") as mock_app,
         ):
-            MockService.return_value.configured = False
+            instance = MockService.return_value
+            instance.configured = True
+            instance.get_components.return_value = ([], {})
             handle_statuspage_command(ack, body, command, respond)
 
             ack.assert_called_once()
@@ -173,6 +197,21 @@ class TestStatuspageCommand:
             view = mock_app.return_value.client.views_open.call_args[1]["view"]
             assert view["callback_id"] == "statuspage_modal"
             assert view["title"]["text"] == "New Statuspage Post"
+
+    def test_unconfigured_service_responds_error(self, incident):
+        ack = MagicMock()
+        body = {"channel_id": CHANNEL_ID, "trigger_id": "T123"}
+        command = {"command": "/ft"}
+        respond = MagicMock()
+
+        with patch(
+            "firetower.slack_app.handlers.statuspage.StatuspageService"
+        ) as MockService:
+            MockService.return_value.configured = False
+            handle_statuspage_command(ack, body, command, respond)
+
+        ack.assert_called_once()
+        assert "not configured" in respond.call_args[0][0]
 
     def test_opens_modal_for_existing_post(self, incident):
         ExternalLink.objects.create(
@@ -206,9 +245,10 @@ class TestStatuspageCommand:
             patch("firetower.slack_app.bolt.get_bolt_app") as mock_app,
         ):
             instance = MockService.return_value
-            instance.configured = False
+            instance.configured = True
             instance.extract_incident_id_from_url.return_value = "sp123"
             instance.get_incident.return_value = sp_data
+            instance.get_components.return_value = ([], {})
 
             handle_statuspage_command(ack, body, command, respond)
 
@@ -270,7 +310,7 @@ class TestStatuspageSubmission:
         }
         if components:
             for comp_id, comp_status in components.items():
-                values[comp_id] = {
+                values[f"component_{comp_id}"] = {
                     "component_impact_select": {
                         "selected_option": {"value": comp_status},
                     }
@@ -401,6 +441,8 @@ class TestStatuspageSubmission:
 
             handle_statuspage_submission(ack, body, view, client)
 
+        ack.assert_called_once_with()
+        client.chat_postMessage.assert_called_once()
         assert "not configured" in client.chat_postMessage.call_args[1]["text"]
 
     def test_api_error_sends_failure_message(self, incident):
@@ -414,10 +456,13 @@ class TestStatuspageSubmission:
         ) as MockService:
             instance = MockService.return_value
             instance.configured = True
-            instance.create_incident.side_effect = Exception("API error")
+            instance.create_incident.side_effect = requests.RequestException(
+                "API error"
+            )
 
             handle_statuspage_submission(ack, body, view, client)
 
+        ack.assert_called_once()
         assert "went wrong" in client.chat_postMessage.call_args[1]["text"]
 
     def test_no_incident_for_channel(self, db):
@@ -426,10 +471,17 @@ class TestStatuspageSubmission:
         view = self._make_view(channel_id="C_NONEXISTENT")
         client = MagicMock()
 
-        handle_statuspage_submission(ack, body, view, client)
+        with patch(
+            "firetower.slack_app.handlers.statuspage.StatuspageService"
+        ) as MockService:
+            MockService.return_value.configured = True
+            handle_statuspage_submission(ack, body, view, client)
 
         ack.assert_called_once()
-        client.chat_postMessage.assert_not_called()
+        client.chat_postMessage.assert_called_once()
+        assert (
+            "Could not find an incident" in client.chat_postMessage.call_args[1]["text"]
+        )
 
     def test_uses_incident_title_when_no_title_in_form(self, incident):
         ack = MagicMock()

--- a/src/firetower/slack_app/tests/handlers/test_statuspage.py
+++ b/src/firetower/slack_app/tests/handlers/test_statuspage.py
@@ -11,6 +11,7 @@ from firetower.slack_app.handlers.statuspage import (
     handle_statuspage_command,
     handle_statuspage_confirm_resolve,
     handle_statuspage_reset_and_resolve,
+    handle_statuspage_resolve_anyway,
     handle_statuspage_submission,
 )
 
@@ -577,6 +578,76 @@ class TestStatuspageResetAndResolve:
             patch("firetower.slack_app.bolt.get_bolt_app") as mock_app,
         ):
             handle_statuspage_reset_and_resolve(ack, body, client)
+
+        update_kwargs = mock_app.return_value.client.views_update.call_args[1]
+        assert update_kwargs["view"]["clear_on_close"] is True
+        section_text = update_kwargs["view"]["blocks"][0]["text"]["text"]
+        assert "went wrong" in section_text
+
+
+class TestStatuspageResolveAnyway:
+    def _make_body(self, data: dict) -> dict:
+        return {
+            "view": {
+                "id": "V_WARNING",
+                "private_metadata": json.dumps(data),
+            }
+        }
+
+    def test_processes_submission_and_shows_success(self):
+        data = {
+            "channel_id": CHANNEL_ID,
+            "status": "resolved",
+            "title": "Outage",
+            "message": "Resolved",
+            "impact": "major",
+            "components": {"c1": "major_outage", "c2": "degraded_performance"},
+            "component_names": {"c1": "API", "c2": "Web"},
+        }
+        ack = MagicMock()
+        body = self._make_body(data)
+        client = MagicMock()
+
+        with (
+            patch(
+                "firetower.slack_app.handlers.statuspage._process_statuspage_submission",
+                return_value=True,
+            ) as mock_process,
+            patch("firetower.slack_app.bolt.get_bolt_app") as mock_app,
+        ):
+            handle_statuspage_resolve_anyway(ack, body, client)
+
+        ack.assert_called_once_with()
+        mock_process.assert_called_once_with(data, client)
+        mock_app.return_value.client.views_update.assert_called_once()
+        update_kwargs = mock_app.return_value.client.views_update.call_args[1]
+        assert update_kwargs["view_id"] == "V_WARNING"
+        assert update_kwargs["view"]["clear_on_close"] is True
+        section_text = update_kwargs["view"]["blocks"][0]["text"]["text"]
+        assert "resolved" in section_text
+
+    def test_failure_shows_failure_message(self):
+        data = {
+            "channel_id": CHANNEL_ID,
+            "status": "resolved",
+            "title": "Outage",
+            "message": "Resolved",
+            "impact": "major",
+            "components": {"c1": "major_outage"},
+            "component_names": {"c1": "API"},
+        }
+        ack = MagicMock()
+        body = self._make_body(data)
+        client = MagicMock()
+
+        with (
+            patch(
+                "firetower.slack_app.handlers.statuspage._process_statuspage_submission",
+                return_value=False,
+            ),
+            patch("firetower.slack_app.bolt.get_bolt_app") as mock_app,
+        ):
+            handle_statuspage_resolve_anyway(ack, body, client)
 
         update_kwargs = mock_app.return_value.client.views_update.call_args[1]
         assert update_kwargs["view"]["clear_on_close"] is True

--- a/src/firetower/slack_app/tests/handlers/test_statuspage.py
+++ b/src/firetower/slack_app/tests/handlers/test_statuspage.py
@@ -7,6 +7,7 @@ import requests
 from firetower.incidents.models import ExternalLink, ExternalLinkType
 from firetower.slack_app.handlers.statuspage import (
     _build_statuspage_modal,
+    _parse_private_metadata,
     handle_statuspage_command,
     handle_statuspage_confirm_resolve,
     handle_statuspage_reset_and_resolve,
@@ -607,3 +608,35 @@ class TestStatuspageConfirmResolve:
 
         ack.assert_called_once_with(response_action="clear")
         mock_process.assert_called_once_with(data, client)
+
+
+class TestParsePrivateMetadata:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            (
+                json.dumps({"channel_id": "C123", "component_names": {"a": "A"}}),
+                {"channel_id": "C123", "component_names": {"a": "A"}},
+            ),
+            (
+                "C_12345",
+                {"channel_id": "C_12345", "component_names": {}},
+            ),
+            (
+                json.dumps("hello"),
+                {"channel_id": "", "component_names": {}},
+            ),
+            (
+                json.dumps(None),
+                {"channel_id": "", "component_names": {}},
+            ),
+            (
+                json.dumps(123),
+                {"channel_id": "", "component_names": {}},
+            ),
+            ("", {}),
+            (None, {}),
+        ],
+    )
+    def test_parse_private_metadata(self, raw, expected):
+        assert _parse_private_metadata(raw) == expected

--- a/src/firetower/slack_app/tests/handlers/test_statuspage.py
+++ b/src/firetower/slack_app/tests/handlers/test_statuspage.py
@@ -619,12 +619,18 @@ class TestStatuspageResolveAnyway:
 
         ack.assert_called_once_with()
         mock_process.assert_called_once_with(data, client)
+        passed_data = mock_process.call_args[0][0]
+        assert passed_data["components"] == {
+            "c1": "major_outage",
+            "c2": "degraded_performance",
+        }
         mock_app.return_value.client.views_update.assert_called_once()
         update_kwargs = mock_app.return_value.client.views_update.call_args[1]
         assert update_kwargs["view_id"] == "V_WARNING"
         assert update_kwargs["view"]["clear_on_close"] is True
         section_text = update_kwargs["view"]["blocks"][0]["text"]["text"]
-        assert "resolved" in section_text
+        assert ":white_check_mark:" in section_text
+        assert "left as-is" in section_text
 
     def test_failure_shows_failure_message(self):
         data = {

--- a/src/firetower/slack_app/tests/handlers/test_statuspage.py
+++ b/src/firetower/slack_app/tests/handlers/test_statuspage.py
@@ -9,7 +9,6 @@ from firetower.slack_app.handlers.statuspage import (
     _build_statuspage_modal,
     _parse_private_metadata,
     handle_statuspage_command,
-    handle_statuspage_confirm_resolve,
     handle_statuspage_reset_and_resolve,
     handle_statuspage_resolve_anyway,
     handle_statuspage_submission,
@@ -649,31 +648,6 @@ class TestStatuspageResolveAnyway:
         assert update_kwargs["view"]["clear_on_close"] is True
         section_text = update_kwargs["view"]["blocks"][0]["text"]["text"]
         assert "went wrong" in section_text
-
-
-class TestStatuspageConfirmResolve:
-    def test_clears_modal_stack_and_processes_submission(self):
-        data = {
-            "channel_id": CHANNEL_ID,
-            "status": "resolved",
-            "title": "Outage",
-            "message": "Resolved anyway",
-            "impact": "major",
-            "components": {"c1": "major_outage"},
-        }
-        ack = MagicMock()
-        body = {}
-        view = {"private_metadata": json.dumps(data)}
-        client = MagicMock()
-
-        with patch(
-            "firetower.slack_app.handlers.statuspage._process_statuspage_submission",
-            return_value=True,
-        ) as mock_process:
-            handle_statuspage_confirm_resolve(ack, body, view, client)
-
-        ack.assert_called_once_with(response_action="clear")
-        mock_process.assert_called_once_with(data, client)
 
 
 class TestParsePrivateMetadata:

--- a/src/firetower/slack_app/tests/handlers/test_statuspage.py
+++ b/src/firetower/slack_app/tests/handlers/test_statuspage.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -290,6 +291,7 @@ class TestStatuspageSubmission:
         impact="major",
         channel_id=CHANNEL_ID,
         components=None,
+        component_names=None,
     ):
         values: dict = {
             "status_block": {
@@ -318,7 +320,12 @@ class TestStatuspageSubmission:
                 }
         return {
             "state": {"values": values},
-            "private_metadata": channel_id,
+            "private_metadata": json.dumps(
+                {
+                    "channel_id": channel_id,
+                    "component_names": component_names or {},
+                }
+            ),
         }
 
     def test_creates_new_statuspage_incident(self, incident):

--- a/src/firetower/slack_app/tests/handlers/test_statuspage.py
+++ b/src/firetower/slack_app/tests/handlers/test_statuspage.py
@@ -490,6 +490,55 @@ class TestStatuspageSubmission:
             "Could not find an incident" in client.chat_postMessage.call_args[1]["text"]
         )
 
+    def test_resolved_with_non_operational_components_pushes_warning_modal(
+        self, incident
+    ):
+        ack = MagicMock()
+        body = {}
+        view = self._make_view(
+            status="resolved",
+            components={"c1": "major_outage"},
+        )
+        client = MagicMock()
+
+        with patch(
+            "firetower.slack_app.handlers.statuspage.StatuspageService"
+        ) as MockService:
+            instance = MockService.return_value
+            instance.configured = True
+            instance.get_components.return_value = (
+                [{"id": "c1", "name": "API", "position": 1}],
+                {},
+            )
+
+            handle_statuspage_submission(ack, body, view, client)
+
+        ack.assert_called_once()
+        ack_kwargs = ack.call_args[1]
+        assert ack_kwargs["response_action"] == "push"
+        pushed_view = ack_kwargs["view"]
+
+        expected_data = {
+            "channel_id": CHANNEL_ID,
+            "status": "resolved",
+            "title": "Outage",
+            "message": "Looking into it",
+            "impact": "major",
+            "components": {"c1": "major_outage"},
+        }
+        assert pushed_view["private_metadata"] == json.dumps(expected_data)
+
+        actions_blocks = [
+            b for b in pushed_view["blocks"] if b.get("type") == "actions"
+        ]
+        assert len(actions_blocks) == 2
+
+        second_button = actions_blocks[1]["elements"][0]
+        assert second_button["text"]["text"] == "Resolve Without Updating Components"
+        assert second_button["style"] == "danger"
+
+        client.chat_postMessage.assert_not_called()
+
     def test_rejects_empty_title(self, incident):
         ack = MagicMock()
         body = {}

--- a/src/firetower/slack_app/tests/handlers/test_statuspage.py
+++ b/src/firetower/slack_app/tests/handlers/test_statuspage.py
@@ -7,7 +7,6 @@ import requests
 from firetower.incidents.models import ExternalLink, ExternalLinkType
 from firetower.slack_app.handlers.statuspage import (
     _build_statuspage_modal,
-    _parse_private_metadata,
     handle_statuspage_command,
     handle_statuspage_reset_and_resolve,
     handle_statuspage_resolve_anyway,
@@ -322,7 +321,7 @@ class TestStatuspageSubmission:
                 }
         return {
             "state": {"values": values},
-            "private_metadata": json.dumps({"channel_id": channel_id}),
+            "private_metadata": channel_id,
         }
 
     def test_creates_new_statuspage_incident(self, incident):
@@ -648,35 +647,3 @@ class TestStatuspageResolveAnyway:
         assert update_kwargs["view"]["clear_on_close"] is True
         section_text = update_kwargs["view"]["blocks"][0]["text"]["text"]
         assert "went wrong" in section_text
-
-
-class TestParsePrivateMetadata:
-    @pytest.mark.parametrize(
-        "raw,expected",
-        [
-            (
-                json.dumps({"channel_id": "C123"}),
-                {"channel_id": "C123"},
-            ),
-            (
-                "C_12345",
-                {"channel_id": "C_12345"},
-            ),
-            (
-                json.dumps("hello"),
-                {"channel_id": ""},
-            ),
-            (
-                json.dumps(None),
-                {"channel_id": ""},
-            ),
-            (
-                json.dumps(123),
-                {"channel_id": ""},
-            ),
-            ("", {}),
-            (None, {}),
-        ],
-    )
-    def test_parse_private_metadata(self, raw, expected):
-        assert _parse_private_metadata(raw) == expected

--- a/uv.lock
+++ b/uv.lock
@@ -515,6 +515,7 @@ dependencies = [
     { name = "google-auth" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pyserde", extra = ["toml"] },
+    { name = "requests" },
     { name = "slack-bolt" },
     { name = "slack-sdk" },
 ]
@@ -549,6 +550,7 @@ requires-dist = [
     { name = "google-auth", specifier = ">=2.37.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.11" },
     { name = "pyserde", extras = ["toml"], specifier = ">=0.28.0" },
+    { name = "requests", specifier = ">=2.32.0" },
     { name = "slack-bolt", specifier = ">=1.27.0" },
     { name = "slack-sdk", specifier = ">=3.31.0" },
 ]


### PR DESCRIPTION
Adds the Statuspage integration to Firetower. Users can create and update statuspage incidents from Slack via /ft statuspage, with component status selectors and severity-to-impact mapping. No hook automation — manual only for now.

- StatuspageService API client (create, update, get incidents, get components)
- Slack modal with status, impact, message, and per-component status dropdowns
- ExternalLink wiring to persist statuspage URLs on incidents
- Confirmation modal when resolving with non-operational components (go back, resolve anyway, or set all operational and resolve)
- API error response logging for easier debugging
- Tests for service and handler layers