### PR TITLE
fix(dumpslack): Preserve auth header across Slack file redirects

### DIFF
--- a/slack-app-manifest.yaml
+++ b/slack-app-manifest.yaml
@@ -24,6 +24,7 @@ oauth_config:
       - groups:history
       - groups:read
       - groups:write
+      - files:read
       - users:read
       - users:read.email
   pkce_enabled: false

--- a/src/firetower/slack_app/handlers/dumpslack.py
+++ b/src/firetower/slack_app/handlers/dumpslack.py
@@ -343,7 +343,16 @@ def _download_image(url: str, slack_token: str) -> tuple[bytes, str] | None:
     if is_slack_url(url):
         headers["Authorization"] = f"Bearer {slack_token}"
     try:
-        resp = requests.get(url, headers=headers, timeout=30.0)
+        session = requests.Session()
+        if slack_token and is_slack_url(url):
+            # requests strips Authorization on redirect by default; re-add it for
+            # Slack-to-Slack redirects so files-pri URLs don't land on an HTML login page.
+            def _rebuild_auth(prepared_request: Any, response: Any) -> None:
+                if is_slack_url(prepared_request.url):
+                    prepared_request.headers["Authorization"] = f"Bearer {slack_token}"
+
+            session.rebuild_auth = _rebuild_auth  # type: ignore[method-assign]
+        resp = session.get(url, headers=headers, timeout=30.0)
         resp.raise_for_status()
         content_type = (
             resp.headers.get("content-type", "image/png").split(";")[0].strip()

--- a/src/firetower/slack_app/handlers/dumpslack.py
+++ b/src/firetower/slack_app/handlers/dumpslack.py
@@ -350,6 +350,8 @@ def _download_image(url: str, slack_token: str) -> tuple[bytes, str] | None:
             def _rebuild_auth(prepared_request: Any, response: Any) -> None:
                 if is_slack_url(prepared_request.url):
                     prepared_request.headers["Authorization"] = f"Bearer {slack_token}"
+                else:
+                    prepared_request.headers.pop("Authorization", None)
 
             session.rebuild_auth = _rebuild_auth  # type: ignore[method-assign]
         resp = session.get(url, headers=headers, timeout=30.0)

--- a/src/firetower/slack_app/tests/handlers/test_dumpslack.py
+++ b/src/firetower/slack_app/tests/handlers/test_dumpslack.py
@@ -373,22 +373,31 @@ class TestIsSlackUrl:
 
 
 class TestDownloadImage:
+    def _mock_session(self, response=None, side_effect=None):
+        mock_session = MagicMock()
+        if side_effect is not None:
+            mock_session.get.side_effect = side_effect
+        else:
+            mock_session.get.return_value = response
+        return mock_session
+
     def test_downloads_external_image_without_auth(self):
         mock_response = MagicMock()
         mock_response.content = b"PNG_DATA"
         mock_response.headers = {"content-type": "image/png"}
         mock_response.raise_for_status = MagicMock()
+        mock_session = self._mock_session(response=mock_response)
 
         with patch(
-            "firetower.slack_app.handlers.dumpslack.requests.get",
-            return_value=mock_response,
-        ) as mock_get:
+            "firetower.slack_app.handlers.dumpslack.requests.Session",
+            return_value=mock_session,
+        ):
             result = _download_image(
                 "https://p.datadoghq.com/img/graph.png", "xoxb-token"
             )
 
         assert result == (b"PNG_DATA", "image/png")
-        call_headers = mock_get.call_args.kwargs["headers"]
+        call_headers = mock_session.get.call_args.kwargs["headers"]
         assert "Authorization" not in call_headers
 
     def test_adds_slack_bearer_token_for_slack_urls(self):
@@ -396,22 +405,25 @@ class TestDownloadImage:
         mock_response.content = b"IMG"
         mock_response.headers = {"content-type": "image/jpeg"}
         mock_response.raise_for_status = MagicMock()
+        mock_session = self._mock_session(response=mock_response)
 
         with patch(
-            "firetower.slack_app.handlers.dumpslack.requests.get",
-            return_value=mock_response,
-        ) as mock_get:
+            "firetower.slack_app.handlers.dumpslack.requests.Session",
+            return_value=mock_session,
+        ):
             _download_image(
                 "https://files.slack.com/files-pri/T1/img.jpg", "xoxb-token"
             )
 
-        call_headers = mock_get.call_args.kwargs["headers"]
+        call_headers = mock_session.get.call_args.kwargs["headers"]
         assert call_headers["Authorization"] == "Bearer xoxb-token"
 
     def test_returns_none_on_request_failure(self):
+        mock_session = self._mock_session(side_effect=Exception("timeout"))
+
         with patch(
-            "firetower.slack_app.handlers.dumpslack.requests.get",
-            side_effect=Exception("timeout"),
+            "firetower.slack_app.handlers.dumpslack.requests.Session",
+            return_value=mock_session,
         ):
             result = _download_image("https://example.com/img.png", "token")
 
@@ -422,10 +434,11 @@ class TestDownloadImage:
         mock_response.content = b"<html>"
         mock_response.headers = {"content-type": "text/html"}
         mock_response.raise_for_status = MagicMock()
+        mock_session = self._mock_session(response=mock_response)
 
         with patch(
-            "firetower.slack_app.handlers.dumpslack.requests.get",
-            return_value=mock_response,
+            "firetower.slack_app.handlers.dumpslack.requests.Session",
+            return_value=mock_session,
         ):
             result = _download_image("https://example.com/page", "token")
 


### PR DESCRIPTION
Slack \`files-pri\` URLs redirect before serving the file content. The \`requests\` library
strips the \`Authorization\` header when following redirects to a different host, so the
redirect target receives an unauthenticated request and returns an HTML login page instead
of the image.

The fix overrides \`Session.rebuild_auth\` to re-add \`Bearer <token>\` whenever the redirect
destination is still a \`*.slack.com\` host, and explicitly strips it for any non-Slack
redirect target to prevent token leakage to third-party hosts (e.g. CDNs).

Root cause was confirmed in logs: the \`files-pri\` URL returned \`content-type: text/html\`,
triggering the content-type guard in \`_download_image\` and silently dropping the image
from the Notion postmortem doc.