### PR TITLE
fix: Slack bot websocket health check and connection monitoring

### DIFF
--- a/src/firetower/slack_app/management/commands/run_slack_bot.py
+++ b/src/firetower/slack_app/management/commands/run_slack_bot.py
@@ -6,6 +6,7 @@ import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any
 
+from datadog import statsd
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from slack_bolt.adapter.socket_mode import SocketModeHandler
@@ -15,6 +16,7 @@ from firetower.slack_app.bolt import get_bolt_app
 logger = logging.getLogger(__name__)
 
 _shutdown = threading.Event()
+_state: dict[str, SocketModeHandler] = {}
 
 
 def _on_close(close_status_code: int, close_msg: str | None) -> None:
@@ -34,7 +36,10 @@ def _handle_shutdown(signum: int, frame: Any) -> None:
 
 class _HealthHandler(BaseHTTPRequestHandler):
     def do_GET(self, *args: Any) -> None:
-        self.send_response(200)
+        handler = _state.get("handler")
+        connected = handler is not None and handler.client.is_connected()
+        statsd.gauge("slack_bot.websocket.connected", 1 if connected else 0)
+        self.send_response(200 if connected else 503)
         self.end_headers()
 
     def log_message(self, format: str, *args: Any) -> None:
@@ -62,6 +67,7 @@ class Command(BaseCommand):
                 handler = SocketModeHandler(app=get_bolt_app(), app_token=app_token)
                 handler.client.on_close_listeners.append(_on_close)
                 handler.client.on_error_listeners.append(_on_error)
+                _state["handler"] = handler
                 logger.info("Starting Slack bot in Socket Mode")
                 handler.start()
             except Exception as e:

--- a/src/firetower/slack_app/management/commands/run_slack_bot.py
+++ b/src/firetower/slack_app/management/commands/run_slack_bot.py
@@ -1,6 +1,8 @@
 import logging
 import os
+import signal
 import threading
+import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any
 
@@ -11,6 +13,23 @@ from slack_bolt.adapter.socket_mode import SocketModeHandler
 from firetower.slack_app.bolt import get_bolt_app
 
 logger = logging.getLogger(__name__)
+
+_shutdown = threading.Event()
+
+
+def _on_close(close_status_code: int, close_msg: str | None) -> None:
+    logger.warning(
+        "Slack WebSocket connection closed (code=%s): %s", close_status_code, close_msg
+    )
+
+
+def _on_error(error: Exception) -> None:
+    logger.error("Slack WebSocket error: %s", error)
+
+
+def _handle_shutdown(signum: int, frame: Any) -> None:
+    logger.info("Received signal %d, shutting down", signum)
+    _shutdown.set()
 
 
 class _HealthHandler(BaseHTTPRequestHandler):
@@ -35,7 +54,18 @@ class Command(BaseCommand):
 
     def handle(self, *args: Any, **options: Any) -> None:
         _start_health_server()
+        signal.signal(signal.SIGTERM, _handle_shutdown)
+        signal.signal(signal.SIGINT, _handle_shutdown)
         app_token = settings.SLACK["APP_TOKEN"]
-        handler = SocketModeHandler(app=get_bolt_app(), app_token=app_token)
-        logger.info("Starting Slack bot in Socket Mode")
-        handler.start()
+        while not _shutdown.is_set():
+            try:
+                handler = SocketModeHandler(app=get_bolt_app(), app_token=app_token)
+                handler.client.on_close_listeners.append(_on_close)
+                handler.client.on_error_listeners.append(_on_error)
+                logger.info("Starting Slack bot in Socket Mode")
+                handler.start()
+            except Exception as e:
+                if _shutdown.is_set():
+                    break
+                logger.error("Slack bot crashed: %s, restarting in 5s", e)
+                time.sleep(5)

--- a/src/firetower/slack_app/management/commands/run_slack_bot.py
+++ b/src/firetower/slack_app/management/commands/run_slack_bot.py
@@ -65,11 +65,19 @@ class Command(BaseCommand):
         while not _shutdown.is_set():
             try:
                 handler = SocketModeHandler(app=get_bolt_app(), app_token=app_token)
+                # Each SocketModeHandler creates a fresh SocketModeClient with
+                # empty listener lists, so appending here won't accumulate.
                 handler.client.on_close_listeners.append(_on_close)
                 handler.client.on_error_listeners.append(_on_error)
                 _state["handler"] = handler
                 logger.info("Starting Slack bot in Socket Mode")
-                handler.start()
+                # Use connect() instead of start() so the thread isn't blocked
+                # forever — start() calls Event().wait() which prevents SIGTERM
+                # from triggering a graceful shutdown.
+                handler.connect()
+                _shutdown.wait()
+                logger.info("Shutdown requested, disconnecting handler")
+                handler.close()
             except Exception as e:
                 if _shutdown.is_set():
                     break

--- a/src/firetower/slack_app/management/commands/run_slack_bot.py
+++ b/src/firetower/slack_app/management/commands/run_slack_bot.py
@@ -2,7 +2,6 @@ import logging
 import os
 import signal
 import threading
-import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any
 
@@ -58,6 +57,7 @@ class Command(BaseCommand):
     help = "Start the Slack bot in Socket Mode"
 
     def handle(self, *args: Any, **options: Any) -> None:
+        _shutdown.clear()
         _start_health_server()
         signal.signal(signal.SIGTERM, _handle_shutdown)
         signal.signal(signal.SIGINT, _handle_shutdown)
@@ -82,4 +82,4 @@ class Command(BaseCommand):
                 if _shutdown.is_set():
                     break
                 logger.error("Slack bot crashed: %s, restarting in 5s", e)
-                time.sleep(5)
+                _shutdown.wait(timeout=5)


### PR DESCRIPTION
Fixes silent websocket disconnects in the Slack bot on Cloud Run. The health probe now checks is_connected() and returns 503 when the websocket is dead, so Cloud Run can restart the container. Also adds error/close listeners for logging, signal handling for graceful shutdown, and a Datadog gauge metric for websocket connection status.

There is a corresponding terraform pr to configure the probes.