### PR TITLE
feat(dumpslack): Backfill incident milestones from AI-generated timeline

### DIFF
--- a/src/firetower/integrations/services/genai.py
+++ b/src/firetower/integrations/services/genai.py
@@ -1,4 +1,6 @@
 import logging
+import re
+from datetime import UTC, datetime
 from typing import Any
 
 import requests
@@ -39,7 +41,7 @@ Your response MUST follow this exact format:
 ## Key Timestamps
 - Started: [YYYY-MM-DD HH:MM UTC]
 - Detected: [YYYY-MM-DD HH:MM UTC]
-- Understanding: [YYYY-MM-DD HH:MM UTC]
+- Analyzed: [YYYY-MM-DD HH:MM UTC]
 - Mitigation: [YYYY-MM-DD HH:MM UTC]
 - Resolution: [YYYY-MM-DD HH:MM UTC]
 
@@ -66,6 +68,48 @@ def _detect_location() -> str:
             _DEFAULT_LOCATION,
         )
         return _DEFAULT_LOCATION
+
+
+_KEY_TIMESTAMPS_LABEL_MAP = {
+    "started": "time_started",
+    "detected": "time_detected",
+    "analyzed": "time_analyzed",
+    "mitigation": "time_mitigated",
+    "resolution": "time_recovered",
+}
+
+_KEY_TS_RE = re.compile(
+    r"-\s*(\w+):\s*\[?(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}(?::\d{2})?\s*UTC)\]?",
+    re.IGNORECASE,
+)
+
+
+def parse_key_timestamps(timeline_md: str) -> dict[str, datetime]:
+    """Extract Key Timestamps from the AI-generated timeline markdown.
+
+    Returns a dict mapping Incident model field names to parsed datetimes.
+    Only includes entries where the AI provided a real timestamp (not N/A).
+    """
+    section_match = re.search(
+        r"## Key Timestamps\s*\n((?:- .+\n?)+)", timeline_md, re.IGNORECASE
+    )
+    if not section_match:
+        return {}
+
+    results: dict[str, datetime] = {}
+    for match in _KEY_TS_RE.finditer(section_match.group(1)):
+        label = match.group(1).lower()
+        field = _KEY_TIMESTAMPS_LABEL_MAP.get(label)
+        if not field:
+            continue
+        raw_ts = match.group(2).strip()
+        for fmt in ("%Y-%m-%d %H:%M:%S UTC", "%Y-%m-%d %H:%M UTC"):
+            try:
+                results[field] = datetime.strptime(raw_ts, fmt).replace(tzinfo=UTC)
+                break
+            except ValueError:
+                continue
+    return results
 
 
 class GenAIService:

--- a/src/firetower/integrations/services/genai.py
+++ b/src/firetower/integrations/services/genai.py
@@ -102,7 +102,7 @@ def parse_key_timestamps(timeline_md: str) -> dict[str, datetime]:
         field = _KEY_TIMESTAMPS_LABEL_MAP.get(label)
         if not field:
             continue
-        raw_ts = match.group(2).strip()
+        raw_ts = " ".join(match.group(2).replace("UTC", " UTC").split())
         for fmt in ("%Y-%m-%d %H:%M:%S UTC", "%Y-%m-%d %H:%M UTC"):
             try:
                 results[field] = datetime.strptime(raw_ts, fmt).replace(tzinfo=UTC)

--- a/src/firetower/integrations/tests/test_genai.py
+++ b/src/firetower/integrations/tests/test_genai.py
@@ -4,7 +4,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 
-from firetower.integrations.services.genai import GenAIService, _detect_location
+from firetower.integrations.services.genai import (
+    GenAIService,
+    _detect_location,
+    parse_key_timestamps,
+)
 from firetower.integrations.services.notion import (
     NotionService,
     _convert_markdown_to_notion_blocks,
@@ -290,3 +294,74 @@ class TestGenAIService:
         ]
         assert "first reply" in contents
         assert "second reply" in contents
+
+
+class TestParseKeyTimestamps:
+    def test_parses_all_timestamps(self):
+        md = (
+            "## Timeline\n"
+            "- [2024-01-15 14:30 UTC] - Incident started\n"
+            "\n"
+            "## Key Timestamps\n"
+            "- Started: [2024-01-15 14:00 UTC]\n"
+            "- Detected: [2024-01-15 14:05 UTC]\n"
+            "- Analyzed: [2024-01-15 14:30 UTC]\n"
+            "- Mitigation: [2024-01-15 15:00 UTC]\n"
+            "- Resolution: [2024-01-15 16:00 UTC]\n"
+        )
+        result = parse_key_timestamps(md)
+        assert result == {
+            "time_started": datetime(2024, 1, 15, 14, 0, tzinfo=UTC),
+            "time_detected": datetime(2024, 1, 15, 14, 5, tzinfo=UTC),
+            "time_analyzed": datetime(2024, 1, 15, 14, 30, tzinfo=UTC),
+            "time_mitigated": datetime(2024, 1, 15, 15, 0, tzinfo=UTC),
+            "time_recovered": datetime(2024, 1, 15, 16, 0, tzinfo=UTC),
+        }
+
+    def test_skips_na_timestamps(self):
+        md = (
+            "## Key Timestamps\n"
+            "- Started: [2024-01-15 14:00 UTC]\n"
+            "- Detected: N/A\n"
+            "- Analyzed: N/A\n"
+            "- Mitigation: [2024-01-15 15:00 UTC]\n"
+            "- Resolution: N/A\n"
+        )
+        result = parse_key_timestamps(md)
+        assert result == {
+            "time_started": datetime(2024, 1, 15, 14, 0, tzinfo=UTC),
+            "time_mitigated": datetime(2024, 1, 15, 15, 0, tzinfo=UTC),
+        }
+
+    def test_handles_timestamps_with_seconds(self):
+        md = "## Key Timestamps\n- Started: [2024-01-15 14:00:30 UTC]\n"
+        result = parse_key_timestamps(md)
+        assert result["time_started"] == datetime(2024, 1, 15, 14, 0, 30, tzinfo=UTC)
+
+    def test_returns_empty_when_no_key_timestamps_section(self):
+        md = "## Timeline\n- [2024-01-15 14:30 UTC] - event\n"
+        assert parse_key_timestamps(md) == {}
+
+    def test_returns_empty_for_empty_string(self):
+        assert parse_key_timestamps("") == {}
+
+    def test_ignores_unknown_labels(self):
+        md = (
+            "## Key Timestamps\n"
+            "- Started: [2024-01-15 14:00 UTC]\n"
+            "- Escalated: [2024-01-15 14:10 UTC]\n"
+        )
+        result = parse_key_timestamps(md)
+        assert list(result.keys()) == ["time_started"]
+
+    def test_unbracketed_timestamps(self):
+        md = (
+            "## Key Timestamps\n"
+            "- Started: 2024-01-15 14:00 UTC\n"
+            "- Detected: 2024-01-15 14:05 UTC\n"
+        )
+        result = parse_key_timestamps(md)
+        assert result == {
+            "time_started": datetime(2024, 1, 15, 14, 0, tzinfo=UTC),
+            "time_detected": datetime(2024, 1, 15, 14, 5, tzinfo=UTC),
+        }

--- a/src/firetower/integrations/tests/test_genai.py
+++ b/src/firetower/integrations/tests/test_genai.py
@@ -365,3 +365,15 @@ class TestParseKeyTimestamps:
             "time_started": datetime(2024, 1, 15, 14, 0, tzinfo=UTC),
             "time_detected": datetime(2024, 1, 15, 14, 5, tzinfo=UTC),
         }
+
+    def test_normalizes_variable_whitespace_in_timestamps(self):
+        md = (
+            "## Key Timestamps\n"
+            "- Started: [2024-01-15  14:00UTC]\n"
+            "- Detected: [2024-01-15 14:05  UTC]\n"
+        )
+        result = parse_key_timestamps(md)
+        assert result == {
+            "time_started": datetime(2024, 1, 15, 14, 0, tzinfo=UTC),
+            "time_detected": datetime(2024, 1, 15, 14, 5, tzinfo=UTC),
+        }

--- a/src/firetower/slack_app/handlers/dumpslack.py
+++ b/src/firetower/slack_app/handlers/dumpslack.py
@@ -174,7 +174,7 @@ def _backfill_milestones(incident: Any, timeline_md: str) -> None:
     if fields_to_update:
         try:
             incident.save(update_fields=fields_to_update)
-            logger.info(
+            logger.debug(
                 "Backfilled milestone fields %s for incident %s",
                 fields_to_update,
                 incident.incident_number,

--- a/src/firetower/slack_app/handlers/dumpslack.py
+++ b/src/firetower/slack_app/handlers/dumpslack.py
@@ -11,7 +11,7 @@ from django.db import transaction
 
 from firetower.auth.models import ExternalProfile, ExternalProfileType
 from firetower.incidents.models import ExternalLink, ExternalLinkType
-from firetower.integrations.services.genai import GenAIService
+from firetower.integrations.services.genai import GenAIService, parse_key_timestamps
 from firetower.integrations.services.notion import NotionService
 from firetower.integrations.services.slack import SlackService, is_slack_url
 from firetower.slack_app.handlers.utils import get_incident_from_channel
@@ -133,6 +133,7 @@ def _trigger_slack_dump(client: Any, channel_id: str, incident: Any) -> None:
             )
             if timeline:
                 notion.add_timeline_to_page(page_id, timeline)
+                _backfill_milestones(incident, timeline)
     except Exception:
         logger.exception("Failed to add AI timeline to Notion page %s", page_id)
 
@@ -157,6 +158,32 @@ def _trigger_slack_dump(client: Any, channel_id: str, incident: Any) -> None:
             channel_id,
             page_url,
         )
+
+
+def _backfill_milestones(incident: Any, timeline_md: str) -> None:
+    timestamps = parse_key_timestamps(timeline_md)
+    if not timestamps:
+        return
+
+    fields_to_update: list[str] = []
+    for field, value in timestamps.items():
+        if getattr(incident, field, None) is None:
+            setattr(incident, field, value)
+            fields_to_update.append(field)
+
+    if fields_to_update:
+        try:
+            incident.save(update_fields=fields_to_update)
+            logger.info(
+                "Backfilled milestone fields %s for incident %s",
+                fields_to_update,
+                incident.incident_number,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to save milestone timestamps for incident %s",
+                incident.incident_number,
+            )
 
 
 def trigger_slack_dump_async(client: Any, channel_id: str, incident: Any) -> None:

--- a/src/firetower/slack_app/handlers/dumpslack.py
+++ b/src/firetower/slack_app/handlers/dumpslack.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.db import transaction
 
 from firetower.auth.models import ExternalProfile, ExternalProfileType
-from firetower.incidents.models import ExternalLink, ExternalLinkType
+from firetower.incidents.models import ExternalLink, ExternalLinkType, Incident
 from firetower.integrations.services.genai import GenAIService, parse_key_timestamps
 from firetower.integrations.services.notion import NotionService
 from firetower.integrations.services.slack import SlackService, is_slack_url
@@ -165,25 +165,30 @@ def _backfill_milestones(incident: Any, timeline_md: str) -> None:
     if not timestamps:
         return
 
-    fields_to_update: list[str] = []
+    fields_updated: list[str] = []
     for field, value in timestamps.items():
-        if getattr(incident, field, None) is None:
-            setattr(incident, field, value)
-            fields_to_update.append(field)
-
-    if fields_to_update:
         try:
-            incident.save(update_fields=fields_to_update)
-            logger.debug(
-                "Backfilled milestone fields %s for incident %s",
-                fields_to_update,
-                incident.incident_number,
-            )
+            # Atomic conditional update: only set the field if it is still NULL
+            # in the database, avoiding a TOCTOU race with user-set values.
+            updated = Incident.objects.filter(
+                pk=incident.pk,
+                **{f"{field}__isnull": True},
+            ).update(**{field: value})
+            if updated:
+                fields_updated.append(field)
         except Exception:
             logger.exception(
-                "Failed to save milestone timestamps for incident %s",
+                "Failed to backfill %s for incident %s",
+                field,
                 incident.incident_number,
             )
+
+    if fields_updated:
+        logger.debug(
+            "Backfilled milestone fields %s for incident %s",
+            fields_updated,
+            incident.incident_number,
+        )
 
 
 def trigger_slack_dump_async(client: Any, channel_id: str, incident: Any) -> None:

--- a/src/firetower/slack_app/tests/handlers/test_dumpslack.py
+++ b/src/firetower/slack_app/tests/handlers/test_dumpslack.py
@@ -1,9 +1,11 @@
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 from slack_sdk.errors import SlackApiError
 
 from firetower.integrations.services.slack import SlackService, is_slack_url
 from firetower.slack_app.handlers.dumpslack import (
+    _backfill_milestones,
     _download_image,
     _extract_image_urls,
     _extract_notion_page_id,
@@ -599,3 +601,83 @@ class TestHandleDumpslackCommand:
         ack.assert_called_once()
         respond.assert_called()
         mock_async.assert_called_once_with(client, "C123", mock_incident)
+
+
+class TestBackfillMilestones:
+    _TIMELINE_MD = (
+        "## Key Timestamps\n"
+        "- Started: [2024-01-15 14:00 UTC]\n"
+        "- Detected: [2024-01-15 14:05 UTC]\n"
+        "- Analyzed: [2024-01-15 14:30 UTC]\n"
+        "- Mitigation: [2024-01-15 15:00 UTC]\n"
+        "- Resolution: [2024-01-15 16:00 UTC]\n"
+    )
+
+    def test_sets_empty_fields(self):
+        incident = MagicMock()
+        incident.incident_number = "INC-1"
+        incident.time_started = None
+        incident.time_detected = None
+        incident.time_analyzed = None
+        incident.time_mitigated = None
+        incident.time_recovered = None
+
+        _backfill_milestones(incident, self._TIMELINE_MD)
+
+        incident.save.assert_called_once()
+        fields = set(incident.save.call_args[1]["update_fields"])
+        assert fields == {
+            "time_started",
+            "time_detected",
+            "time_analyzed",
+            "time_mitigated",
+            "time_recovered",
+        }
+        assert incident.time_started == datetime(2024, 1, 15, 14, 0, tzinfo=UTC)
+        assert incident.time_recovered == datetime(2024, 1, 15, 16, 0, tzinfo=UTC)
+
+    def test_skips_fields_that_already_have_values(self):
+        incident = MagicMock()
+        incident.incident_number = "INC-2"
+        incident.time_started = datetime(2024, 1, 15, 13, 50, tzinfo=UTC)
+        incident.time_detected = None
+        incident.time_analyzed = None
+        incident.time_mitigated = datetime(2024, 1, 15, 14, 55, tzinfo=UTC)
+        incident.time_recovered = None
+
+        _backfill_milestones(incident, self._TIMELINE_MD)
+
+        fields = set(incident.save.call_args[1]["update_fields"])
+        assert "time_started" not in fields
+        assert "time_mitigated" not in fields
+        assert fields == {"time_detected", "time_analyzed", "time_recovered"}
+
+    def test_no_save_when_all_fields_populated(self):
+        incident = MagicMock()
+        incident.incident_number = "INC-3"
+        incident.time_started = datetime(2024, 1, 15, 14, 0, tzinfo=UTC)
+        incident.time_detected = datetime(2024, 1, 15, 14, 5, tzinfo=UTC)
+        incident.time_analyzed = datetime(2024, 1, 15, 14, 30, tzinfo=UTC)
+        incident.time_mitigated = datetime(2024, 1, 15, 15, 0, tzinfo=UTC)
+        incident.time_recovered = datetime(2024, 1, 15, 16, 0, tzinfo=UTC)
+
+        _backfill_milestones(incident, self._TIMELINE_MD)
+
+        incident.save.assert_not_called()
+
+    def test_no_save_when_no_timestamps_parsed(self):
+        incident = MagicMock()
+        incident.incident_number = "INC-4"
+        incident.time_started = None
+
+        _backfill_milestones(incident, "## Timeline\n- some event\n")
+
+        incident.save.assert_not_called()
+
+    def test_save_exception_does_not_propagate(self):
+        incident = MagicMock()
+        incident.incident_number = "INC-5"
+        incident.time_started = None
+        incident.save.side_effect = RuntimeError("db error")
+
+        _backfill_milestones(incident, self._TIMELINE_MD)

--- a/src/firetower/slack_app/tests/handlers/test_dumpslack.py
+++ b/src/firetower/slack_app/tests/handlers/test_dumpslack.py
@@ -1,4 +1,3 @@
-from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 from slack_sdk.errors import SlackApiError
@@ -613,71 +612,69 @@ class TestBackfillMilestones:
         "- Resolution: [2024-01-15 16:00 UTC]\n"
     )
 
-    def test_sets_empty_fields(self):
+    @patch("firetower.slack_app.handlers.dumpslack.Incident.objects")
+    def test_sets_empty_fields(self, mock_objects):
+        mock_objects.filter.return_value.update.return_value = 1
         incident = MagicMock()
+        incident.pk = 1
         incident.incident_number = "INC-1"
-        incident.time_started = None
-        incident.time_detected = None
-        incident.time_analyzed = None
-        incident.time_mitigated = None
-        incident.time_recovered = None
 
         _backfill_milestones(incident, self._TIMELINE_MD)
 
-        incident.save.assert_called_once()
-        fields = set(incident.save.call_args[1]["update_fields"])
-        assert fields == {
+        filter_fields = set()
+        for call in mock_objects.filter.call_args_list:
+            for key in call[1]:
+                if key != "pk":
+                    filter_fields.add(key.replace("__isnull", ""))
+        assert filter_fields == {
             "time_started",
             "time_detected",
             "time_analyzed",
             "time_mitigated",
             "time_recovered",
         }
-        assert incident.time_started == datetime(2024, 1, 15, 14, 0, tzinfo=UTC)
-        assert incident.time_recovered == datetime(2024, 1, 15, 16, 0, tzinfo=UTC)
+        assert mock_objects.filter.return_value.update.call_count == 5
 
-    def test_skips_fields_that_already_have_values(self):
+    @patch("firetower.slack_app.handlers.dumpslack.Incident.objects")
+    def test_skips_fields_that_are_not_null(self, mock_objects):
+        # Simulate: time_started and time_mitigated already set (update returns 0)
+        def conditional_update(**kwargs):
+            field = list(kwargs.keys())[0]
+            if field in ("time_started", "time_mitigated"):
+                return 0
+            return 1
+
+        mock_objects.filter.return_value.update.side_effect = conditional_update
         incident = MagicMock()
+        incident.pk = 2
         incident.incident_number = "INC-2"
-        incident.time_started = datetime(2024, 1, 15, 13, 50, tzinfo=UTC)
-        incident.time_detected = None
-        incident.time_analyzed = None
-        incident.time_mitigated = datetime(2024, 1, 15, 14, 55, tzinfo=UTC)
-        incident.time_recovered = None
 
         _backfill_milestones(incident, self._TIMELINE_MD)
 
-        fields = set(incident.save.call_args[1]["update_fields"])
-        assert "time_started" not in fields
-        assert "time_mitigated" not in fields
-        assert fields == {"time_detected", "time_analyzed", "time_recovered"}
+        assert mock_objects.filter.return_value.update.call_count == 5
 
-    def test_no_save_when_all_fields_populated(self):
+    @patch("firetower.slack_app.handlers.dumpslack.Incident.objects")
+    def test_no_update_when_all_fields_populated(self, mock_objects):
+        mock_objects.filter.return_value.update.return_value = 0
         incident = MagicMock()
+        incident.pk = 3
         incident.incident_number = "INC-3"
-        incident.time_started = datetime(2024, 1, 15, 14, 0, tzinfo=UTC)
-        incident.time_detected = datetime(2024, 1, 15, 14, 5, tzinfo=UTC)
-        incident.time_analyzed = datetime(2024, 1, 15, 14, 30, tzinfo=UTC)
-        incident.time_mitigated = datetime(2024, 1, 15, 15, 0, tzinfo=UTC)
-        incident.time_recovered = datetime(2024, 1, 15, 16, 0, tzinfo=UTC)
 
         _backfill_milestones(incident, self._TIMELINE_MD)
 
-        incident.save.assert_not_called()
+        assert mock_objects.filter.return_value.update.call_count == 5
 
-    def test_no_save_when_no_timestamps_parsed(self):
+    def test_no_update_when_no_timestamps_parsed(self):
         incident = MagicMock()
         incident.incident_number = "INC-4"
-        incident.time_started = None
 
         _backfill_milestones(incident, "## Timeline\n- some event\n")
 
-        incident.save.assert_not_called()
-
-    def test_save_exception_does_not_propagate(self):
+    @patch("firetower.slack_app.handlers.dumpslack.Incident.objects")
+    def test_update_exception_does_not_propagate(self, mock_objects):
+        mock_objects.filter.return_value.update.side_effect = RuntimeError("db error")
         incident = MagicMock()
+        incident.pk = 5
         incident.incident_number = "INC-5"
-        incident.time_started = None
-        incident.save.side_effect = RuntimeError("db error")
 
         _backfill_milestones(incident, self._TIMELINE_MD)


### PR DESCRIPTION
When generating the AI timeline via Gemini during a Slack dump, parse the "Key Timestamps" section from the response and backfill empty milestone fields on the Firetower incident (`time_started`, `time_detected`, `time_analyzed`, `time_mitigated`, `time_recovered`). Fields that already have values are left untouched.

Also renames "Understanding" to "Analyzed" in the Gemini prompt so the
label matches the model field name consistently.

Changes:
- `genai.py`: Add `parse_key_timestamps()` to extract structured timestamps
  from the AI markdown response
- `dumpslack.py`: Add `_backfill_milestones()` called after timeline generation,
  only writes fields that are currently null
- Tests for both the parser (7 cases) and backfill logic (5 cases)


Agent transcript: https://claudescope.sentry.dev/share/wD65NNq5EincJoGVMkkU2mOrlJNh5bbBdIVV-AcFNNg