### PR TITLE
feat(incidents): Auto-compute total_downtime from milestones

### DIFF
--- a/src/firetower/incidents/serializers.py
+++ b/src/firetower/incidents/serializers.py
@@ -461,6 +461,8 @@ class IncidentWriteSerializer(serializers.ModelSerializer):
             return
         if instance.time_started and instance.time_recovered:
             delta = instance.time_recovered - instance.time_started
+            if delta.total_seconds() < 0:
+                return
             instance.total_downtime = int(delta.total_seconds() / 60)
             instance.save(update_fields=["total_downtime"])
 
@@ -518,12 +520,13 @@ class IncidentWriteSerializer(serializers.ModelSerializer):
             )
             incident.impact_type_tags.set(tags)
 
+        self._auto_compute_downtime(incident, validated_data)
+
         # Runs synchronously — Slack API calls may add latency to the response.
         # Consider deferring to a background task if this becomes a problem.
         if settings.HOOKS_ENABLED:
             on_incident_created(incident)
 
-        self._auto_compute_downtime(incident, validated_data)
         return incident
 
     def update(self, instance: Incident, validated_data: dict) -> Incident:
@@ -603,6 +606,8 @@ class IncidentWriteSerializer(serializers.ModelSerializer):
             )
             instance.impact_type_tags.set(tags)
 
+        self._auto_compute_downtime(instance, validated_data)
+
         if settings.HOOKS_ENABLED:
             if instance.title != old_title:
                 on_title_changed(instance)
@@ -615,7 +620,6 @@ class IncidentWriteSerializer(serializers.ModelSerializer):
             if instance.is_private != old_is_private:
                 on_visibility_changed(instance)
 
-        self._auto_compute_downtime(instance, validated_data)
         return instance
 
 

--- a/src/firetower/incidents/serializers.py
+++ b/src/firetower/incidents/serializers.py
@@ -456,6 +456,14 @@ class IncidentWriteSerializer(serializers.ModelSerializer):
 
         return value
 
+    def _auto_compute_downtime(self, instance: Incident, validated_data: dict) -> None:
+        if "total_downtime" in validated_data:
+            return
+        if instance.time_started and instance.time_recovered:
+            delta = instance.time_recovered - instance.time_started
+            instance.total_downtime = int(delta.total_seconds() / 60)
+            instance.save(update_fields=["total_downtime"])
+
     def create(self, validated_data: dict) -> Incident:
         """Create incident with external links and tags"""
         external_links_data = validated_data.pop("external_links", None)
@@ -515,6 +523,7 @@ class IncidentWriteSerializer(serializers.ModelSerializer):
         if settings.HOOKS_ENABLED:
             on_incident_created(incident)
 
+        self._auto_compute_downtime(incident, validated_data)
         return incident
 
     def update(self, instance: Incident, validated_data: dict) -> Incident:
@@ -606,6 +615,7 @@ class IncidentWriteSerializer(serializers.ModelSerializer):
             if instance.is_private != old_is_private:
                 on_visibility_changed(instance)
 
+        self._auto_compute_downtime(instance, validated_data)
         return instance
 
 

--- a/src/firetower/incidents/serializers.py
+++ b/src/firetower/incidents/serializers.py
@@ -459,6 +459,11 @@ class IncidentWriteSerializer(serializers.ModelSerializer):
     def _auto_compute_downtime(self, instance: Incident, validated_data: dict) -> None:
         if "total_downtime" in validated_data:
             return
+        if (
+            "time_started" not in validated_data
+            and "time_recovered" not in validated_data
+        ):
+            return
         if instance.time_started and instance.time_recovered:
             delta = instance.time_recovered - instance.time_started
             if delta.total_seconds() < 0:

--- a/src/firetower/incidents/tests/test_serializers.py
+++ b/src/firetower/incidents/tests/test_serializers.py
@@ -416,3 +416,20 @@ class TestAutoComputeDowntime:
         assert serializer.is_valid(), serializer.errors
         updated = serializer.save()
         assert updated.total_downtime == 180
+
+    def test_no_auto_compute_when_recovered_before_started(self):
+        incident = Incident.objects.create(
+            title="Test",
+            severity=IncidentSeverity.P1,
+            captain=self.captain,
+            reporter=self.reporter,
+            time_started=datetime(2026, 1, 1, 12, 0, tzinfo=UTC),
+        )
+        serializer = IncidentWriteSerializer(
+            instance=incident,
+            data={"time_recovered": "2026-01-01T10:00:00Z"},
+            partial=True,
+        )
+        assert serializer.is_valid(), serializer.errors
+        updated = serializer.save()
+        assert updated.total_downtime is None

--- a/src/firetower/incidents/tests/test_serializers.py
+++ b/src/firetower/incidents/tests/test_serializers.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
@@ -305,3 +306,113 @@ class TestIncidentWriteSerializerHooks:
         msg = mock_slack.post_message.call_args[0][1]
         assert "Active" in msg
         assert "Mitigated" in msg
+
+
+@pytest.mark.django_db
+class TestAutoComputeDowntime:
+    @pytest.fixture(autouse=True)
+    def disable_hooks(self, settings):
+        settings.HOOKS_ENABLED = False
+
+    def setup_method(self):
+        self.captain = User.objects.create_user(
+            username="captain@example.com",
+            email="captain@example.com",
+        )
+        self.reporter = User.objects.create_user(
+            username="reporter@example.com",
+            email="reporter@example.com",
+        )
+
+    def _base_data(self, **overrides):
+        data = {
+            "title": "Test",
+            "severity": "P1",
+            "captain": "captain@example.com",
+            "reporter": "reporter@example.com",
+        }
+        data.update(overrides)
+        return data
+
+    def test_update_computes_downtime_when_both_milestones_set(self):
+        incident = Incident.objects.create(
+            title="Test",
+            severity=IncidentSeverity.P1,
+            captain=self.captain,
+            reporter=self.reporter,
+            time_started=datetime(2026, 1, 1, 10, 0, tzinfo=UTC),
+        )
+        serializer = IncidentWriteSerializer(
+            instance=incident,
+            data={"time_recovered": "2026-01-01T11:30:00Z"},
+            partial=True,
+        )
+        assert serializer.is_valid(), serializer.errors
+        updated = serializer.save()
+        assert updated.total_downtime == 90
+
+    def test_update_does_not_override_explicit_downtime(self):
+        incident = Incident.objects.create(
+            title="Test",
+            severity=IncidentSeverity.P1,
+            captain=self.captain,
+            reporter=self.reporter,
+            time_started=datetime(2026, 1, 1, 10, 0, tzinfo=UTC),
+        )
+        serializer = IncidentWriteSerializer(
+            instance=incident,
+            data={
+                "time_recovered": "2026-01-01T11:30:00Z",
+                "total_downtime": 45,
+            },
+            partial=True,
+        )
+        assert serializer.is_valid(), serializer.errors
+        updated = serializer.save()
+        assert updated.total_downtime == 45
+
+    def test_update_no_downtime_when_only_one_milestone(self):
+        incident = Incident.objects.create(
+            title="Test",
+            severity=IncidentSeverity.P1,
+            captain=self.captain,
+            reporter=self.reporter,
+        )
+        serializer = IncidentWriteSerializer(
+            instance=incident,
+            data={"time_started": "2026-01-01T10:00:00Z"},
+            partial=True,
+        )
+        assert serializer.is_valid(), serializer.errors
+        updated = serializer.save()
+        assert updated.total_downtime is None
+
+    def test_create_computes_downtime_when_both_milestones_provided(self):
+        serializer = IncidentWriteSerializer(
+            data=self._base_data(
+                time_started="2026-01-01T10:00:00Z",
+                time_recovered="2026-01-01T12:15:00Z",
+            )
+        )
+        assert serializer.is_valid(), serializer.errors
+        incident = serializer.save()
+        assert incident.total_downtime == 135
+
+    def test_update_computes_when_started_already_exists(self):
+        incident = Incident.objects.create(
+            title="Test",
+            severity=IncidentSeverity.P1,
+            captain=self.captain,
+            reporter=self.reporter,
+            time_started=datetime(2026, 1, 1, 10, 0, tzinfo=UTC),
+            time_recovered=datetime(2026, 1, 1, 11, 0, tzinfo=UTC),
+            total_downtime=60,
+        )
+        serializer = IncidentWriteSerializer(
+            instance=incident,
+            data={"time_recovered": "2026-01-01T13:00:00Z"},
+            partial=True,
+        )
+        assert serializer.is_valid(), serializer.errors
+        updated = serializer.save()
+        assert updated.total_downtime == 180

--- a/src/firetower/incidents/tests/test_serializers.py
+++ b/src/firetower/incidents/tests/test_serializers.py
@@ -433,3 +433,22 @@ class TestAutoComputeDowntime:
         assert serializer.is_valid(), serializer.errors
         updated = serializer.save()
         assert updated.total_downtime is None
+
+    def test_unrelated_update_preserves_manual_downtime(self):
+        incident = Incident.objects.create(
+            title="Test",
+            severity=IncidentSeverity.P1,
+            captain=self.captain,
+            reporter=self.reporter,
+            time_started=datetime(2026, 1, 1, 10, 0, tzinfo=UTC),
+            time_recovered=datetime(2026, 1, 1, 11, 30, tzinfo=UTC),
+            total_downtime=45,
+        )
+        serializer = IncidentWriteSerializer(
+            instance=incident,
+            data={"title": "Updated Title"},
+            partial=True,
+        )
+        assert serializer.is_valid(), serializer.errors
+        updated = serializer.save()
+        assert updated.total_downtime == 45


### PR DESCRIPTION
When both `time_started` and `time_recovered` milestones are set on an
incident, `total_downtime` is now automatically computed as the difference
in minutes. This removes the need to manually calculate and enter downtime
when the milestone timestamps already contain the information.

Explicit `total_downtime` values provided in the request are never
overridden -- the auto-computation only kicks in when the field is absent
from the payload.

The logic runs in both `create` and `update` paths on `IncidentWriteSerializer`.


Agent transcript: https://claudescope.sentry.dev/share/bPknSqMQSb4ZQw5Nzcqj7Le77OX6e0m12spmpbGb230