### PR TITLE
fix: Only initialize Datadog statsd when DD_API_KEY is present

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -35,10 +35,6 @@ integration_key = ""
 id = ""
 integration_key = ""
 
-[datadog]
-api_key = ""
-app_key = ""
-
 [notion]
 integration_token = ""
 database_id = ""

--- a/src/firetower/config.py
+++ b/src/firetower/config.py
@@ -21,12 +21,6 @@ class PostgresConfig:
 
 
 @deserialize
-class DatadogConfig:
-    api_key: str
-    app_key: str
-
-
-@deserialize
 class EscalationPolicy:
     id: str
     integration_key: str | None = None
@@ -81,7 +75,6 @@ class ConfigFile:
     """
 
     postgres: PostgresConfig
-    datadog: DatadogConfig | None
     slack: SlackConfig
     auth: AuthConfig
     pagerduty: PagerDutyConfig | None
@@ -153,7 +146,6 @@ class DummyConfigFile(ConfigFile):
             iap_enabled=False,
             iap_audience="",
         )
-        self.datadog = None
         self.notion = None
         self.genai = None
         self.pagerduty = None

--- a/src/firetower/integrations/services/datadog.py
+++ b/src/firetower/integrations/services/datadog.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 from datadog_api_client import ApiClient, Configuration
 from datadog_api_client.exceptions import ApiException
@@ -12,8 +13,6 @@ from datadog_api_client.v1.model.notebook_global_time import NotebookGlobalTime
 from datadog_api_client.v1.model.notebook_resource_type import NotebookResourceType
 from datadog_api_client.v1.model.widget_live_span import WidgetLiveSpan
 
-from firetower.settings import config
-
 logger = logging.getLogger(__name__)
 
 DATADOG_NOTEBOOK_BASE_URL = "https://app.datadoghq.com/notebook"
@@ -24,16 +23,8 @@ REQUEST_TIMEOUT_SECONDS = 15
 
 class DatadogService:
     def __init__(self) -> None:
-        datadog_config = config.datadog
-        if not datadog_config:
-            self.api_key = ""
-            self.app_key = ""
-            self.configured = False
-            logger.warning("DatadogService initialized without configuration")
-            return
-
-        self.api_key = datadog_config.api_key
-        self.app_key = datadog_config.app_key
+        self.api_key = os.environ.get("DD_API_KEY", "")
+        self.app_key = os.environ.get("DD_APP_KEY", "")
         self.configured = bool(self.api_key and self.app_key)
 
         if not self.configured:

--- a/src/firetower/integrations/tests/test_datadog.py
+++ b/src/firetower/integrations/tests/test_datadog.py
@@ -2,41 +2,38 @@ from unittest.mock import MagicMock, patch
 
 from datadog_api_client.exceptions import ApiException
 
-from firetower.config import DatadogConfig
 from firetower.integrations.services.datadog import (
     DATADOG_NOTEBOOK_BASE_URL,
     DatadogService,
 )
 
-MOCK_DATADOG_CONFIG = DatadogConfig(api_key="test-api-key", app_key="test-app-key")
+_DD_ENV = {"DD_API_KEY": "test-api-key", "DD_APP_KEY": "test-app-key"}
 
 
-def _patch_datadog(value: DatadogConfig | None):
-    return patch("firetower.integrations.services.datadog.config.datadog", value)
+def _patch_dd_env(env: dict[str, str] | None = None):
+    return patch.dict("os.environ", env or _DD_ENV, clear=False)
 
 
 class TestDatadogServiceInit:
     def test_init_with_config(self):
-        with _patch_datadog(MOCK_DATADOG_CONFIG):
+        with _patch_dd_env():
             service = DatadogService()
             assert service.configured is True
             assert service.api_key == "test-api-key"
             assert service.app_key == "test-app-key"
 
     def test_init_without_config(self):
-        with _patch_datadog(None):
+        with _patch_dd_env({"DD_API_KEY": "", "DD_APP_KEY": ""}):
             service = DatadogService()
             assert service.configured is False
-            assert service.api_key == ""
-            assert service.app_key == ""
 
     def test_init_with_empty_api_key(self):
-        with _patch_datadog(DatadogConfig(api_key="", app_key="test-app-key")):
+        with _patch_dd_env({"DD_API_KEY": "", "DD_APP_KEY": "test-app-key"}):
             service = DatadogService()
             assert service.configured is False
 
     def test_init_with_empty_app_key(self):
-        with _patch_datadog(DatadogConfig(api_key="test-api-key", app_key="")):
+        with _patch_dd_env({"DD_API_KEY": "test-api-key", "DD_APP_KEY": ""}):
             service = DatadogService()
             assert service.configured is False
 
@@ -48,7 +45,7 @@ class TestCreateNotebook:
         return response
 
     def test_create_notebook_success(self):
-        with _patch_datadog(MOCK_DATADOG_CONFIG):
+        with _patch_dd_env():
             service = DatadogService()
 
         mock_api = MagicMock()
@@ -68,7 +65,7 @@ class TestCreateNotebook:
         assert str(body.data.attributes.time.live_span) == "1h"
 
     def test_create_notebook_truncates_long_title(self):
-        with _patch_datadog(MOCK_DATADOG_CONFIG):
+        with _patch_dd_env():
             service = DatadogService()
 
         mock_api = MagicMock()
@@ -88,7 +85,7 @@ class TestCreateNotebook:
         assert name.endswith("...")
 
     def test_create_notebook_short_title_not_truncated(self):
-        with _patch_datadog(MOCK_DATADOG_CONFIG):
+        with _patch_dd_env():
             service = DatadogService()
 
         mock_api = MagicMock()
@@ -104,7 +101,7 @@ class TestCreateNotebook:
         assert body.data.attributes.name == "[INC-1] short"
 
     def test_create_notebook_returns_none_on_api_exception(self):
-        with _patch_datadog(MOCK_DATADOG_CONFIG):
+        with _patch_dd_env():
             service = DatadogService()
 
         mock_api = MagicMock()
@@ -121,7 +118,7 @@ class TestCreateNotebook:
         assert url is None
 
     def test_create_notebook_returns_none_on_unexpected_exception(self):
-        with _patch_datadog(MOCK_DATADOG_CONFIG):
+        with _patch_dd_env():
             service = DatadogService()
 
         mock_api = MagicMock()
@@ -136,7 +133,7 @@ class TestCreateNotebook:
         assert url is None
 
     def test_create_notebook_returns_none_when_unconfigured(self):
-        with _patch_datadog(None):
+        with _patch_dd_env({"DD_API_KEY": "", "DD_APP_KEY": ""}):
             service = DatadogService()
 
         with patch(
@@ -148,7 +145,7 @@ class TestCreateNotebook:
         mock_api_cls.assert_not_called()
 
     def test_truncate_notebook_name_helper(self):
-        with _patch_datadog(MOCK_DATADOG_CONFIG):
+        with _patch_dd_env():
             service = DatadogService()
         # exactly 80
         name = service._truncate_notebook_name("INC-9999", "x" * 100)

--- a/src/firetower/settings.py
+++ b/src/firetower/settings.py
@@ -330,19 +330,20 @@ DJK8S_READINESS_PROBES = [
     "djk8s.probes.DatabaseProbe",
 ]
 
-# Initialize Datadog statsd
-initialize(
-    statsd_host=os.environ.get("DATADOG_STATSD_HOST", "localhost"),
-    statsd_port=int(os.environ.get("DATADOG_STATSD_PORT", "8125")),
-    api_key=config.datadog.api_key if config.datadog else None,
-    app_key=config.datadog.app_key if config.datadog else None,
-    statsd_namespace="firetower",
-)
-statsd.constant_tags = [
-    f"env:{'production' if os.environ.get('DJANGO_ENV') == 'prod' else 'test'}",
-    "service:firetower",
-    f"version:{os.environ.get('K_REVISION', 'unknown')}",
-]
+# Initialize Datadog statsd (only when DD agent is available)
+if os.environ.get("DD_API_KEY"):
+    initialize(
+        statsd_host=os.environ.get("DATADOG_STATSD_HOST", "localhost"),
+        statsd_port=int(os.environ.get("DATADOG_STATSD_PORT", "8125")),
+        api_key=config.datadog.api_key if config.datadog else None,
+        app_key=config.datadog.app_key if config.datadog else None,
+        statsd_namespace="firetower",
+    )
+    statsd.constant_tags = [
+        f"env:{'production' if os.environ.get('DJANGO_ENV') == 'prod' else 'test'}",
+        "service:firetower",
+        f"version:{os.environ.get('K_REVISION', 'unknown')}",
+    ]
 
 # Logging configuration
 _log_level = os.environ.get("DJANGO_LOG_LEVEL", config.log_level)

--- a/src/firetower/settings.py
+++ b/src/firetower/settings.py
@@ -335,8 +335,8 @@ if os.environ.get("DD_API_KEY"):
     initialize(
         statsd_host=os.environ.get("DATADOG_STATSD_HOST", "localhost"),
         statsd_port=int(os.environ.get("DATADOG_STATSD_PORT", "8125")),
-        api_key=config.datadog.api_key if config.datadog else None,
-        app_key=config.datadog.app_key if config.datadog else None,
+        api_key=os.environ.get("DD_API_KEY"),
+        app_key=os.environ.get("DD_APP_KEY"),
         statsd_namespace="firetower",
     )
     statsd.constant_tags = [


### PR DESCRIPTION
Skips Datadog statsd initialization when DD_API_KEY is not set in the environment, and moves Datadog config (api_key, app_key) from config.toml to environment variables (DD_API_KEY, DD_APP_KEY). This avoids connection refused errors in environments without a DD agent, and removes a source of drift between config.toml and terraform env vars.