### PR TITLE
fix: Don't invite/page PE for high sev private incidents

### DIFF
--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -64,7 +64,12 @@ def _page_if_needed(incident: Incident, channel_id: str | None = None) -> None:
     if slack_link and slack_link.url:
         links.append({"href": slack_link.url, "text": "Slack Channel"})
 
-    for policy_name, policy_info in PAGING_POLICIES.items():
+    policies_to_page = (
+        {"IMOC": PAGING_POLICIES["IMOC"]} if incident.is_private else PAGING_POLICIES
+    )
+    title = "Private Incident" if incident.is_private else incident.title
+
+    for policy_name, policy_info in policies_to_page.items():
         policy = escalation_policies.get(policy_name)
         if not policy:
             logger.info(f"No {policy_name} escalation policy configured, skipping page")
@@ -86,7 +91,9 @@ def _page_if_needed(incident: Incident, channel_id: str | None = None) -> None:
 
         dedup_key = f"firetower-{incident.incident_number}-{policy_name}"
         page_label = policy_info.page_label
-        summary = f"[{page_label}] [{incident.severity}] {incident.incident_number}: {incident.title}"
+        summary = (
+            f"[{page_label}] [{incident.severity}] {incident.incident_number}: {title}"
+        )
         summary = summary[:PD_SUMMARY_MAX_LENGTH]
 
         try:
@@ -207,7 +214,13 @@ def _invite_oncall_users(incident: Incident, channel_id: str) -> None:
     role_entries: list[tuple[int, int, str]] = []
     users_to_invite: list[tuple[str, str]] = []
 
-    for policy_index, (policy_name, policy_info) in enumerate(PAGING_POLICIES.items()):
+    policies_to_invite = (
+        {"IMOC": PAGING_POLICIES["IMOC"]} if incident.is_private else PAGING_POLICIES
+    )
+
+    for policy_index, (policy_name, policy_info) in enumerate(
+        policies_to_invite.items()
+    ):
         policy_label = policy_info.label
         max_level = policy_info.max_level
         policy = escalation_policies.get(policy_name)

--- a/src/firetower/incidents/tests/test_hooks.py
+++ b/src/firetower/incidents/tests/test_hooks.py
@@ -823,6 +823,29 @@ class TestPageIfNeeded:
         assert "PROD_ENG" in mock_pd.trigger_incident.call_args[0][1]
 
     @patch("firetower.incidents.hooks.PagerDutyService")
+    def test_private_incident_pages_only_imoc(self, mock_pd_cls, settings):
+        settings.PAGERDUTY = MOCK_PD_CONFIG
+        settings.FIRETOWER_BASE_URL = "https://firetower.example.com"
+        mock_pd = mock_pd_cls.return_value
+        mock_pd.trigger_incident.return_value = True
+
+        incident = Incident.objects.create(
+            title="Sensitive issue",
+            severity=IncidentSeverity.P0,
+            is_private=True,
+        )
+
+        _page_if_needed(incident)
+
+        mock_pd.trigger_incident.assert_called_once()
+        summary = mock_pd.trigger_incident.call_args[0][0]
+        dedup_key = mock_pd.trigger_incident.call_args[0][1]
+        assert "IMOC" in dedup_key
+        assert "PROD_ENG" not in dedup_key
+        assert "Private Incident" in summary
+        assert "Sensitive issue" not in summary
+
+    @patch("firetower.incidents.hooks.PagerDutyService")
     def test_pages_only_configured_policies(self, mock_pd_cls, settings):
         settings.PAGERDUTY = {
             "API_TOKEN": "test-token",
@@ -1089,6 +1112,32 @@ class TestInviteOncallUsers:
         assert "On-Call Incident Manager: <@U_IMOC>" in message
         assert "On-Call Prod Eng (Primary): <@U_PRIMARY>" in message
         assert "On-Call Prod Eng (Secondary): <@U_SECONDARY>" in message
+
+    @patch("firetower.incidents.hooks._slack_service")
+    @patch("firetower.incidents.hooks.PagerDutyService")
+    def test_private_incident_invites_only_imoc(
+        self, mock_pd_cls, mock_slack, settings
+    ):
+        settings.PAGERDUTY = MOCK_PD_CONFIG
+        mock_pd = mock_pd_cls.return_value
+        mock_pd.get_oncall_users.return_value = [
+            {"email": "imoc@example.com", "escalation_level": 1},
+        ]
+        mock_slack.get_user_profile_by_email.return_value = {"slack_user_id": "U_IMOC"}
+
+        incident = Incident.objects.create(
+            title="Sensitive issue",
+            severity=IncidentSeverity.P0,
+            is_private=True,
+        )
+
+        _invite_oncall_users(incident, "C99999")
+
+        mock_pd.get_oncall_users.assert_called_once_with("PIMOC01")
+        mock_slack.invite_to_channel.assert_called_once_with("C99999", ["U_IMOC"])
+        message = mock_slack.post_message.call_args[0][1]
+        assert "On-Call Incident Manager: <@U_IMOC>" in message
+        assert "Prod Eng" not in message
 
     @patch("firetower.incidents.hooks._slack_service")
     @patch("firetower.incidents.hooks.PagerDutyService")


### PR DESCRIPTION
Currently, they get invited and paged. We're only going to invite/page IMOC for private high sev incs.