### PR TITLE
fix: Emit failed metric for background dumpslack errors

### DIFF
--- a/src/firetower/slack_app/handlers/dumpslack.py
+++ b/src/firetower/slack_app/handlers/dumpslack.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import requests
 import sentry_sdk
+from datadog import statsd
 from django.conf import settings
 from django.db import transaction
 
@@ -197,6 +198,10 @@ def trigger_slack_dump_async(client: Any, channel_id: str, incident: Any) -> Non
 
         try:
             _trigger_slack_dump(client, channel_id, incident)
+        except Exception:
+            logger.exception("Background dumpslack failed for incident %s", incident.id)
+            statsd.increment("slack_app.commands.failed", tags=["subcommand:dumpslack"])
+            sentry_sdk.capture_exception()
         finally:
             connection.close()
 


### PR DESCRIPTION
The dumpslack command runs in a background thread, so exceptions never reached the try/except in handle_command that emits the commands.failed metric. This adds error handling in the thread that logs, emits the failed metric, and captures to Sentry.