### PR TITLE
feat: Add view handler metrics and DB health check to slack bot

### DIFF
--- a/src/firetower/slack_app/bolt.py
+++ b/src/firetower/slack_app/bolt.py
@@ -1,4 +1,6 @@
 import logging
+from collections.abc import Callable
+from functools import wraps
 from typing import Any
 
 from datadog import statsd
@@ -163,17 +165,59 @@ def handle_command(
         raise
 
 
+def _with_metrics(callback_id: str) -> Callable[..., Callable[..., Any]]:
+    """Wrap a Bolt handler to emit submitted/completed/failed metrics."""
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            tags = [f"callback_id:{callback_id}"]
+            statsd.increment("slack_app.views.submitted", tags=tags)
+            try:
+                result = func(*args, **kwargs)
+                statsd.increment("slack_app.views.completed", tags=tags)
+                return result
+            except Exception:
+                logger.exception("View handler failed: %s", callback_id)
+                statsd.increment("slack_app.views.failed", tags=tags)
+                raise
+
+        return wrapper
+
+    return decorator
+
+
 def _register_views(app: App) -> None:
     """Register view handlers (modals, etc.) on the Bolt app."""
-    app.view("new_incident_modal")(handle_new_incident_submission)
-    app.view("update_incident_modal")(handle_update_incident_submission)
-    app.view("mitigated_incident_modal")(handle_mitigated_submission)
-    app.view("resolved_incident_modal")(handle_resolved_submission)
-    app.view("captain_incident_modal")(handle_captain_submission)
-    app.view("statuspage_modal")(handle_statuspage_submission)
-    app.action("component_impact_select")(handle_component_impact_select)
-    app.action("statuspage_reset_and_resolve")(handle_statuspage_reset_and_resolve)
-    app.action("statuspage_resolve_anyway")(handle_statuspage_resolve_anyway)
+    app.view("new_incident_modal")(
+        _with_metrics("new_incident_modal")(handle_new_incident_submission)
+    )
+    app.view("update_incident_modal")(
+        _with_metrics("update_incident_modal")(handle_update_incident_submission)
+    )
+    app.view("mitigated_incident_modal")(
+        _with_metrics("mitigated_incident_modal")(handle_mitigated_submission)
+    )
+    app.view("resolved_incident_modal")(
+        _with_metrics("resolved_incident_modal")(handle_resolved_submission)
+    )
+    app.view("captain_incident_modal")(
+        _with_metrics("captain_incident_modal")(handle_captain_submission)
+    )
+    app.view("statuspage_modal")(
+        _with_metrics("statuspage_modal")(handle_statuspage_submission)
+    )
+    app.action("component_impact_select")(
+        _with_metrics("component_impact_select")(handle_component_impact_select)
+    )
+    app.action("statuspage_reset_and_resolve")(
+        _with_metrics("statuspage_reset_and_resolve")(
+            handle_statuspage_reset_and_resolve
+        )
+    )
+    app.action("statuspage_resolve_anyway")(
+        _with_metrics("statuspage_resolve_anyway")(handle_statuspage_resolve_anyway)
+    )
     for action_id in (
         "impact_type_tags",
         "affected_service_tags",

--- a/src/firetower/slack_app/management/commands/run_slack_bot.py
+++ b/src/firetower/slack_app/management/commands/run_slack_bot.py
@@ -8,6 +8,7 @@ from typing import Any
 from datadog import statsd
 from django.conf import settings
 from django.core.management.base import BaseCommand
+from django.db import close_old_connections, connection
 from slack_bolt.adapter.socket_mode import SocketModeHandler
 
 from firetower.slack_app.bolt import get_bolt_app
@@ -36,9 +37,20 @@ def _handle_shutdown(signum: int, frame: Any) -> None:
 class _HealthHandler(BaseHTTPRequestHandler):
     def do_GET(self, *args: Any) -> None:
         handler = _state.get("handler")
-        connected = handler is not None and handler.client.is_connected()
-        statsd.gauge("slack_bot.websocket.connected", 1 if connected else 0)
-        self.send_response(200 if connected else 503)
+        ws_ok = handler is not None and handler.client.is_connected()
+        statsd.gauge("slack_bot.websocket.connected", 1 if ws_ok else 0)
+
+        close_old_connections()
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT 1")
+            db_ok = True
+        except Exception:
+            db_ok = False
+        statsd.gauge("slack_bot.db.connected", 1 if db_ok else 0)
+
+        healthy = ws_ok and db_ok
+        self.send_response(200 if healthy else 503)
         self.end_headers()
 
     def log_message(self, format: str, *args: Any) -> None:

--- a/src/firetower/slack_app/management/commands/run_slack_bot.py
+++ b/src/firetower/slack_app/management/commands/run_slack_bot.py
@@ -8,7 +8,7 @@ from typing import Any
 from datadog import statsd
 from django.conf import settings
 from django.core.management.base import BaseCommand
-from django.db import close_old_connections, connection
+from django.db import close_old_connections, connection, transaction
 from slack_bolt.adapter.socket_mode import SocketModeHandler
 
 from firetower.slack_app.bolt import get_bolt_app
@@ -42,8 +42,10 @@ class _HealthHandler(BaseHTTPRequestHandler):
 
         close_old_connections()
         try:
-            with connection.cursor() as cursor:
-                cursor.execute("SELECT 1")
+            with transaction.atomic():
+                with connection.cursor() as cursor:
+                    cursor.execute("SET LOCAL statement_timeout = '2s'")
+                    cursor.execute("SELECT 1")
             db_ok = True
         except Exception:
             db_ok = False

--- a/src/firetower/slack_app/management/commands/run_slack_bot.py
+++ b/src/firetower/slack_app/management/commands/run_slack_bot.py
@@ -38,7 +38,7 @@ class _HealthHandler(BaseHTTPRequestHandler):
     def do_GET(self, *args: Any) -> None:
         handler = _state.get("handler")
         ws_ok = handler is not None and handler.client.is_connected()
-        statsd.gauge("slack_bot.websocket.connected", 1 if ws_ok else 0)
+        statsd.gauge("slack_app.websocket.connected", 1 if ws_ok else 0)
 
         close_old_connections()
         try:
@@ -49,7 +49,7 @@ class _HealthHandler(BaseHTTPRequestHandler):
             db_ok = True
         except Exception:
             db_ok = False
-        statsd.gauge("slack_bot.db.connected", 1 if db_ok else 0)
+        statsd.gauge("slack_app.db.connected", 1 if db_ok else 0)
 
         healthy = ws_ok and db_ok
         self.send_response(200 if healthy else 503)

--- a/src/firetower/slack_app/tests/test_bolt.py
+++ b/src/firetower/slack_app/tests/test_bolt.py
@@ -11,7 +11,7 @@ from firetower.incidents.models import (
     IncidentSeverity,
     IncidentStatus,
 )
-from firetower.slack_app.bolt import handle_command
+from firetower.slack_app.bolt import _with_metrics, handle_command
 
 CHANNEL_ID = "C_TEST_CHANNEL"
 
@@ -203,3 +203,48 @@ class TestRouting:
         with patch("firetower.slack_app.bolt.handle_dumpslack_command") as mock_handler:
             handle_command(ack=ack, body=body, command=command, respond=respond)
             mock_handler.assert_called_once()
+
+
+class TestWithMetrics:
+    @patch("firetower.slack_app.bolt.statsd")
+    def test_emits_completed_on_success(self, mock_statsd):
+        handler = MagicMock(return_value="ok")
+        wrapped = _with_metrics("test_modal")(handler)
+
+        result = wrapped("arg1", key="val")
+
+        assert result == "ok"
+        handler.assert_called_once_with("arg1", key="val")
+        mock_statsd.increment.assert_any_call(
+            "slack_app.views.submitted", tags=["callback_id:test_modal"]
+        )
+        mock_statsd.increment.assert_any_call(
+            "slack_app.views.completed", tags=["callback_id:test_modal"]
+        )
+        failed_calls = [
+            c
+            for c in mock_statsd.increment.call_args_list
+            if c[0][0] == "slack_app.views.failed"
+        ]
+        assert failed_calls == []
+
+    @patch("firetower.slack_app.bolt.statsd")
+    def test_emits_failed_on_error(self, mock_statsd):
+        handler = MagicMock(side_effect=RuntimeError("db gone"))
+        wrapped = _with_metrics("new_incident_modal")(handler)
+
+        with pytest.raises(RuntimeError):
+            wrapped()
+
+        mock_statsd.increment.assert_any_call(
+            "slack_app.views.submitted", tags=["callback_id:new_incident_modal"]
+        )
+        mock_statsd.increment.assert_any_call(
+            "slack_app.views.failed", tags=["callback_id:new_incident_modal"]
+        )
+        completed_calls = [
+            c
+            for c in mock_statsd.increment.call_args_list
+            if c[0][0] == "slack_app.views.completed"
+        ]
+        assert completed_calls == []


### PR DESCRIPTION
Adds submitted/completed/failed metrics to Bolt view and action handlers (tagged by callback_id), so we get visibility into modal submission failures like the DB connection drops this morning. Also adds a DB connectivity check to the slack bot health probe alongside the existing websocket check — the probe now returns 503 if either is down.