### PR TITLE
feat(slack): Add /ft backfill command for retroactive incident creation

### DIFF
--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -102,7 +102,7 @@ def _page_if_needed(incident: Incident, channel_id: str | None = None) -> None:
             logger.exception(f"Failed to page {policy_name} for incident {incident.id}")
 
 
-def _build_channel_name(incident: Incident) -> str:
+def build_channel_name(incident: Incident) -> str:
     return incident.incident_number.lower()
 
 
@@ -114,9 +114,7 @@ def _get_slack_user_id(user: User) -> str | None:
     return profile.external_id if profile else None
 
 
-def _build_channel_topic(
-    incident: Incident, captain_slack_id: str | None = None
-) -> str:
+def build_channel_topic(incident: Incident, captain_slack_id: str | None = None) -> str:
     base_url = settings.FIRETOWER_BASE_URL
     incident_url = f"{base_url}/{incident.incident_number}"
 
@@ -577,7 +575,7 @@ def on_incident_created(incident: Incident) -> None:
     elif created and slack_link is not None:
         try:
             channel_id = _slack_service.create_channel(
-                _build_channel_name(incident), is_private=incident.is_private
+                build_channel_name(incident), is_private=incident.is_private
             )
             if not channel_id:
                 slack_link.delete()
@@ -612,7 +610,7 @@ def on_incident_created(incident: Incident) -> None:
 
         try:
             _slack_service.set_channel_topic(
-                channel_id, _build_channel_topic(incident, captain_slack_id)
+                channel_id, build_channel_topic(incident, captain_slack_id)
             )
         except Exception:
             logger.exception(f"Failed to set channel topic for incident {incident.id}")
@@ -751,7 +749,7 @@ def on_severity_changed(incident: Incident, old_severity: str) -> None:
     try:
         channel_id = _get_channel_id(incident)
         if channel_id:
-            _slack_service.set_channel_topic(channel_id, _build_channel_topic(incident))
+            _slack_service.set_channel_topic(channel_id, build_channel_topic(incident))
             incident_url = _build_incident_url(incident)
             _slack_service.post_message(
                 channel_id,
@@ -798,7 +796,7 @@ def on_title_changed(incident: Incident) -> None:
         if not channel_id:
             return
 
-        _slack_service.set_channel_topic(channel_id, _build_channel_topic(incident))
+        _slack_service.set_channel_topic(channel_id, build_channel_topic(incident))
     except Exception:
         logger.exception(f"Error in on_title_changed for incident {incident.id}")
 
@@ -827,7 +825,7 @@ def on_captain_changed(incident: Incident) -> None:
         if not channel_id:
             return
 
-        _slack_service.set_channel_topic(channel_id, _build_channel_topic(incident))
+        _slack_service.set_channel_topic(channel_id, build_channel_topic(incident))
 
         incident_url = _build_incident_url(incident)
         if incident.captain:

--- a/src/firetower/incidents/serializers.py
+++ b/src/firetower/incidents/serializers.py
@@ -527,9 +527,7 @@ class IncidentWriteSerializer(serializers.ModelSerializer):
 
         self._auto_compute_downtime(incident, validated_data)
 
-        # Runs synchronously — Slack API calls may add latency to the response.
-        # Consider deferring to a background task if this becomes a problem.
-        if settings.HOOKS_ENABLED:
+        if settings.HOOKS_ENABLED and not self.context.get("skip_hooks"):
             on_incident_created(incident)
 
         return incident

--- a/src/firetower/incidents/tests/test_hooks.py
+++ b/src/firetower/incidents/tests/test_hooks.py
@@ -5,12 +5,12 @@ from django.contrib.auth.models import User
 
 from firetower.auth.models import ExternalProfile, ExternalProfileType
 from firetower.incidents.hooks import (
-    _build_channel_name,
-    _build_channel_topic,
     _create_status_channel,
     _create_troubleshooting_doc,
     _invite_oncall_users,
     _page_if_needed,
+    build_channel_name,
+    build_channel_topic,
     on_captain_changed,
     on_incident_created,
     on_severity_changed,
@@ -34,7 +34,7 @@ class TestBuildChannelName:
             title="Test",
             severity=IncidentSeverity.P1,
         )
-        assert _build_channel_name(incident) == incident.incident_number.lower()
+        assert build_channel_name(incident) == incident.incident_number.lower()
 
 
 @pytest.mark.django_db
@@ -56,7 +56,7 @@ class TestBuildChannelTopic:
             severity=IncidentSeverity.P1,
             captain=captain,
         )
-        topic = _build_channel_topic(incident)
+        topic = build_channel_topic(incident)
         assert topic.startswith("[P1] ")
         assert (
             f"|{incident.incident_number} Database connection pool exhausted>" in topic
@@ -75,7 +75,7 @@ class TestBuildChannelTopic:
             severity=IncidentSeverity.P1,
             captain=captain,
         )
-        topic = _build_channel_topic(incident)
+        topic = build_channel_topic(incident)
         assert "| IC: Jane Doe" in topic
 
     def test_format_without_captain(self):
@@ -83,7 +83,7 @@ class TestBuildChannelTopic:
             title="Test Incident",
             severity=IncidentSeverity.P2,
         )
-        topic = _build_channel_topic(incident)
+        topic = build_channel_topic(incident)
         assert topic.startswith("[P2] ")
         assert f"|{incident.incident_number} Test Incident>" in topic
         assert "IC:" not in topic
@@ -94,7 +94,7 @@ class TestBuildChannelTopic:
             title=long_title,
             severity=IncidentSeverity.P1,
         )
-        topic = _build_channel_topic(incident)
+        topic = build_channel_topic(incident)
         assert len(topic) <= 250
         assert "\u2026" in topic
 
@@ -106,7 +106,7 @@ class TestBuildChannelTopic:
             title=long_title,
             severity=IncidentSeverity.P1,
         )
-        topic = _build_channel_topic(incident)
+        topic = build_channel_topic(incident)
         assert len(topic) <= 250
         # The topic must be a well-formed Slack link — closing '>' must be present.
         assert ">" in topic

--- a/src/firetower/integrations/services/slack.py
+++ b/src/firetower/integrations/services/slack.py
@@ -289,6 +289,26 @@ class SlackService:
     def build_channel_url(self, channel_id: str) -> str:
         return f"https://{self.team_id}.slack.com/archives/{channel_id}"
 
+    def get_channel_info(self, channel_id: str) -> dict | None:
+        if not self.client:
+            logger.warning("Cannot fetch channel info - Slack client not initialized")
+            return None
+
+        try:
+            response = self.client.conversations_info(channel=channel_id)
+            channel: dict[str, Any] = response.get("channel", {})
+            return {
+                "id": channel.get("id", ""),
+                "name": channel.get("name", ""),
+                "is_private": channel.get("is_private", False),
+            }
+        except SlackApiError as e:
+            logger.error(
+                f"Error fetching channel info: {e}",
+                extra={"channel_id": channel_id},
+            )
+            return None
+
     def get_user_info(self, slack_user_id: str) -> dict | None:
         """
         Get user information from Slack by user ID.

--- a/src/firetower/integrations/services/slack.py
+++ b/src/firetower/integrations/services/slack.py
@@ -186,6 +186,21 @@ class SlackService:
             )
             return None
 
+    def rename_channel(self, channel_id: str, name: str) -> bool:
+        if not self.client:
+            logger.warning("Cannot rename channel - Slack client not initialized")
+            return False
+
+        try:
+            self.client.conversations_rename(channel=channel_id, name=name)
+            return True
+        except SlackApiError as e:
+            logger.error(
+                f"Error renaming channel: {e}",
+                extra={"channel_id": channel_id, "new_name": name},
+            )
+            return False
+
     def set_channel_topic(self, channel_id: str, topic: str) -> bool:
         if not self.client:
             logger.warning("Cannot set topic - Slack client not initialized")

--- a/src/firetower/slack_app/bolt.py
+++ b/src/firetower/slack_app/bolt.py
@@ -6,6 +6,10 @@ from django.conf import settings
 from django.db import close_old_connections
 from slack_bolt import App
 
+from firetower.slack_app.handlers.backfill_incident import (
+    handle_backfill_command,
+    handle_backfill_submission,
+)
 from firetower.slack_app.handlers.captain import (
     handle_captain_command,
     handle_captain_submission,
@@ -47,6 +51,7 @@ METRICS_PREFIX = "slack_app.commands"
 KNOWN_SUBCOMMANDS = {
     "help",
     "new",
+    "backfill",
     "mitigated",
     "mit",
     "resolved",
@@ -120,6 +125,8 @@ def handle_command(
     try:
         if subcommand == "new":
             handle_new_command(ack, body, command, respond)
+        elif subcommand == "backfill":
+            handle_backfill_command(ack, body, command, respond)
         elif subcommand in ("help", ""):
             handle_help_command(ack, command, respond)
         elif subcommand in ("mitigated", "mit"):
@@ -166,6 +173,7 @@ def handle_command(
 def _register_views(app: App) -> None:
     """Register view handlers (modals, etc.) on the Bolt app."""
     app.view("new_incident_modal")(handle_new_incident_submission)
+    app.view("backfill_incident_modal")(handle_backfill_submission)
     app.view("update_incident_modal")(handle_update_incident_submission)
     app.view("mitigated_incident_modal")(handle_mitigated_submission)
     app.view("resolved_incident_modal")(handle_resolved_submission)

--- a/src/firetower/slack_app/handlers/backfill_incident.py
+++ b/src/firetower/slack_app/handlers/backfill_incident.py
@@ -7,10 +7,8 @@ from django.conf import settings
 from firetower.auth.services import get_or_create_user_from_slack_id
 from firetower.incidents.hooks import _build_channel_topic
 from firetower.incidents.models import (
-    INCIDENT_ID_START,
     ExternalLink,
     ExternalLinkType,
-    IncidentCounter,
     IncidentSeverity,
 )
 from firetower.incidents.serializers import IncidentWriteSerializer
@@ -21,14 +19,6 @@ logger = logging.getLogger(__name__)
 _slack_service = SlackService()
 
 _DEFAULT_SEVERITY = IncidentSeverity.P3
-
-
-def _peek_next_incident_id() -> int:
-    try:
-        counter = IncidentCounter.objects.get(pk=1)
-        return counter.next_id
-    except IncidentCounter.DoesNotExist:
-        return INCIDENT_ID_START
 
 
 def _expected_channel_name(incident_id: int) -> str:
@@ -219,24 +209,6 @@ def handle_backfill_command(ack: Any, body: dict, command: dict, respond: Any) -
         )
         return
 
-    channel_info = _slack_service.get_channel_info(channel_id)
-    if not channel_info:
-        respond(
-            f"Could not fetch info for channel <#{channel_id}>. Is the bot a member?"
-        )
-        return
-
-    channel_name = channel_info["name"]
-    next_id = _peek_next_incident_id()
-    expected_name = _expected_channel_name(next_id)
-
-    if channel_name != expected_name:
-        respond(
-            f"Channel name `{channel_name}` does not match the next expected "
-            f"incident channel `{expected_name}`. Please rename the channel first."
-        )
-        return
-
     existing_link = ExternalLink.objects.filter(
         type=ExternalLinkType.SLACK,
         url__endswith=f"/archives/{channel_id}",
@@ -378,26 +350,6 @@ def handle_backfill_submission(ack: Any, body: dict, view: dict, client: Any) ->
         )
         return
 
-    actual_channel_name = _expected_channel_name(incident.id)
-    channel_info = _slack_service.get_channel_info(channel_id)
-    if channel_info and channel_info["name"] != actual_channel_name:
-        logger.error(
-            "Backfill channel name mismatch after creation: channel=%s expected=%s incident=%s",
-            channel_info["name"],
-            actual_channel_name,
-            incident.id,
-        )
-        client.chat_postMessage(
-            channel=slack_user_id,
-            text=(
-                f"The incident was created as {incident.incident_number}, but the channel "
-                f"name `{channel_info['name']}` no longer matches `{actual_channel_name}`. "
-                f"Another incident may have been created concurrently. Please verify and "
-                f"rename the channel if needed."
-            ),
-        )
-        return
-
     joined = _slack_service.join_channel(channel_id)
     if not joined:
         base_url = settings.FIRETOWER_BASE_URL
@@ -411,6 +363,18 @@ def handle_backfill_submission(ack: Any, body: dict, view: dict, client: Any) ->
             ),
         )
         return
+
+    expected_name = _expected_channel_name(incident.id)
+    channel_info = _slack_service.get_channel_info(channel_id)
+    if channel_info and channel_info["name"] != expected_name:
+        renamed = _slack_service.rename_channel(channel_id, expected_name)
+        if not renamed:
+            logger.warning(
+                "Failed to rename channel %s to %s for incident %s",
+                channel_id,
+                expected_name,
+                incident.id,
+            )
 
     _slack_service.set_channel_topic(channel_id, _build_channel_topic(incident))
     base_url = settings.FIRETOWER_BASE_URL

--- a/src/firetower/slack_app/handlers/backfill_incident.py
+++ b/src/firetower/slack_app/handlers/backfill_incident.py
@@ -191,8 +191,8 @@ def handle_backfill_submission(ack: Any, body: dict, view: dict, client: Any) ->
             text=(
                 f"Backfill incident created: {incident_url}\n"
                 f"However, the bot could not join <#{channel_id}>. "
-                f"Please invite the Firetower bot to the channel, "
-                f"then run `/ft backfill` again from the channel to retry setup."
+                f"Please invite the Firetower bot to the channel and "
+                f"manually set the channel topic and bookmark."
             ),
         )
         return

--- a/src/firetower/slack_app/handlers/backfill_incident.py
+++ b/src/firetower/slack_app/handlers/backfill_incident.py
@@ -353,6 +353,7 @@ def handle_backfill_submission(ack: Any, body: dict, view: dict, client: Any) ->
         return
 
     expected_name = _expected_channel_name(incident.id)
+    channel_info = _slack_service.get_channel_info(channel_id)
     if channel_info and channel_info["name"] != expected_name:
         renamed = _slack_service.rename_channel(channel_id, expected_name)
         if not renamed:

--- a/src/firetower/slack_app/handlers/backfill_incident.py
+++ b/src/firetower/slack_app/handlers/backfill_incident.py
@@ -363,6 +363,13 @@ def handle_backfill_submission(ack: Any, body: dict, view: dict, client: Any) ->
                 expected_name,
                 incident.id,
             )
+            client.chat_postMessage(
+                channel=channel_id,
+                text=(
+                    f"The bot could not rename this channel to `{expected_name}`. "
+                    f"Please rename the channel manually."
+                ),
+            )
 
     _slack_service.set_channel_topic(channel_id, _build_channel_topic(incident))
     base_url = settings.FIRETOWER_BASE_URL

--- a/src/firetower/slack_app/handlers/backfill_incident.py
+++ b/src/firetower/slack_app/handlers/backfill_incident.py
@@ -5,7 +5,7 @@ from typing import Any
 from django.conf import settings
 
 from firetower.auth.services import get_or_create_user_from_slack_id
-from firetower.incidents.hooks import _build_channel_name, _build_channel_topic
+from firetower.incidents.hooks import build_channel_name, build_channel_topic
 from firetower.incidents.models import (
     ExternalLink,
     ExternalLinkType,
@@ -63,7 +63,7 @@ def _setup_channel_for_incident(
         )
         return
 
-    expected_name = _build_channel_name(incident)
+    expected_name = build_channel_name(incident)
     channel_info = _slack_service.get_channel_info(channel_id)
     if channel_info and channel_info["name"] != expected_name:
         renamed = _slack_service.rename_channel(channel_id, expected_name)
@@ -82,7 +82,7 @@ def _setup_channel_for_incident(
                 ),
             )
 
-    _slack_service.set_channel_topic(channel_id, _build_channel_topic(incident))
+    _slack_service.set_channel_topic(channel_id, build_channel_topic(incident))
     base_url = settings.FIRETOWER_BASE_URL
     incident_url = f"{base_url}/{incident.incident_number}"
     _slack_service.add_bookmark(channel_id, "Firetower Incident", incident_url)

--- a/src/firetower/slack_app/handlers/backfill_incident.py
+++ b/src/firetower/slack_app/handlers/backfill_incident.py
@@ -74,18 +74,33 @@ def _setup_channel_for_incident(
                 expected_name,
                 incident.id,
             )
-            client.chat_postMessage(
-                channel=channel_id,
-                text=(
-                    f"The bot could not rename this channel to `{expected_name}`. "
-                    f"Please rename the channel manually."
-                ),
-            )
+            try:
+                client.chat_postMessage(
+                    channel=channel_id,
+                    text=(
+                        f"The bot could not rename this channel to `{expected_name}`. "
+                        f"Please rename the channel manually."
+                    ),
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to post rename failure message for incident %s",
+                    incident.id,
+                )
 
-    _slack_service.set_channel_topic(channel_id, build_channel_topic(incident))
+    try:
+        _slack_service.set_channel_topic(channel_id, build_channel_topic(incident))
+    except Exception:
+        logger.exception(
+            "Failed to set channel topic for backfill incident %s", incident.id
+        )
+
     base_url = settings.FIRETOWER_BASE_URL
     incident_url = f"{base_url}/{incident.incident_number}"
-    _slack_service.add_bookmark(channel_id, "Firetower Incident", incident_url)
+    try:
+        _slack_service.add_bookmark(channel_id, "Firetower Incident", incident_url)
+    except Exception:
+        logger.exception("Failed to add bookmark for backfill incident %s", incident.id)
 
     try:
         sync_incident_participants_from_slack(incident, force=True)
@@ -94,10 +109,16 @@ def _setup_channel_for_incident(
             "Failed to sync participants for backfill incident %s", incident.id
         )
 
-    client.chat_postMessage(
-        channel=notify_user_id,
-        text=f"Channel setup complete for {incident.incident_number}: <#{channel_id}>",
-    )
+    try:
+        client.chat_postMessage(
+            channel=notify_user_id,
+            text=f"Channel setup complete for {incident.incident_number}: <#{channel_id}>",
+        )
+    except Exception:
+        logger.exception(
+            "Failed to send setup complete message for backfill incident %s",
+            incident.id,
+        )
 
 
 def handle_backfill_command(ack: Any, body: dict, command: dict, respond: Any) -> None:

--- a/src/firetower/slack_app/handlers/backfill_incident.py
+++ b/src/firetower/slack_app/handlers/backfill_incident.py
@@ -45,6 +45,61 @@ def _build_backfill_modal(channel_id: str, user_id: str = "") -> dict:
     }
 
 
+def _setup_channel_for_incident(
+    incident: Any, channel_id: str, notify_user_id: str, client: Any
+) -> None:
+    joined = _slack_service.join_channel(channel_id)
+    if not joined:
+        base_url = settings.FIRETOWER_BASE_URL
+        incident_url = f"{base_url}/{incident.incident_number}"
+        client.chat_postMessage(
+            channel=notify_user_id,
+            text=(
+                f"Incident: {incident_url}\n"
+                f"The bot could not join <#{channel_id}>. "
+                f"Please invite the Firetower bot to the channel, "
+                f"then run `/ft backfill` again to retry setup."
+            ),
+        )
+        return
+
+    expected_name = _build_channel_name(incident)
+    channel_info = _slack_service.get_channel_info(channel_id)
+    if channel_info and channel_info["name"] != expected_name:
+        renamed = _slack_service.rename_channel(channel_id, expected_name)
+        if not renamed:
+            logger.warning(
+                "Failed to rename channel %s to %s for incident %s",
+                channel_id,
+                expected_name,
+                incident.id,
+            )
+            client.chat_postMessage(
+                channel=channel_id,
+                text=(
+                    f"The bot could not rename this channel to `{expected_name}`. "
+                    f"Please rename the channel manually."
+                ),
+            )
+
+    _slack_service.set_channel_topic(channel_id, _build_channel_topic(incident))
+    base_url = settings.FIRETOWER_BASE_URL
+    incident_url = f"{base_url}/{incident.incident_number}"
+    _slack_service.add_bookmark(channel_id, "Firetower Incident", incident_url)
+
+    try:
+        sync_incident_participants_from_slack(incident, force=True)
+    except Exception:
+        logger.exception(
+            "Failed to sync participants for backfill incident %s", incident.id
+        )
+
+    client.chat_postMessage(
+        channel=notify_user_id,
+        text=f"Channel setup complete for {incident.incident_number}: <#{channel_id}>",
+    )
+
+
 def handle_backfill_command(ack: Any, body: dict, command: dict, respond: Any) -> None:
     ack()
 
@@ -79,8 +134,17 @@ def handle_backfill_command(ack: Any, body: dict, command: dict, respond: Any) -
         .first()
     )
     if existing_link:
+        from firetower.slack_app.bolt import get_bolt_app  # noqa: PLC0415
+
+        slack_user_id = body.get("user_id", "")
         respond(
-            f"This channel is already linked to {existing_link.incident.incident_number}."
+            f"This channel is already linked to {existing_link.incident.incident_number}. Retrying channel setup..."
+        )
+        _setup_channel_for_incident(
+            existing_link.incident,
+            channel_id,
+            slack_user_id,
+            get_bolt_app().client,
         )
         return
 
@@ -183,53 +247,4 @@ def handle_backfill_submission(ack: Any, body: dict, view: dict, client: Any) ->
         )
         return
 
-    joined = _slack_service.join_channel(channel_id)
-    if not joined:
-        base_url = settings.FIRETOWER_BASE_URL
-        incident_url = f"{base_url}/{incident.incident_number}"
-        client.chat_postMessage(
-            channel=slack_user_id,
-            text=(
-                f"Backfill incident created: {incident_url}\n"
-                f"However, the bot could not join <#{channel_id}>. "
-                f"Please invite the Firetower bot to the channel and "
-                f"manually set the channel topic and bookmark."
-            ),
-        )
-        return
-
-    expected_name = _build_channel_name(incident)
-    channel_info = _slack_service.get_channel_info(channel_id)
-    if channel_info and channel_info["name"] != expected_name:
-        renamed = _slack_service.rename_channel(channel_id, expected_name)
-        if not renamed:
-            logger.warning(
-                "Failed to rename channel %s to %s for incident %s",
-                channel_id,
-                expected_name,
-                incident.id,
-            )
-            client.chat_postMessage(
-                channel=channel_id,
-                text=(
-                    f"The bot could not rename this channel to `{expected_name}`. "
-                    f"Please rename the channel manually."
-                ),
-            )
-
-    _slack_service.set_channel_topic(channel_id, _build_channel_topic(incident))
-    base_url = settings.FIRETOWER_BASE_URL
-    incident_url = f"{base_url}/{incident.incident_number}"
-    _slack_service.add_bookmark(channel_id, "Firetower Incident", incident_url)
-
-    try:
-        sync_incident_participants_from_slack(incident, force=True)
-    except Exception:
-        logger.exception(
-            "Failed to sync participants for backfill incident %s", incident.id
-        )
-
-    dm_message = (
-        f"Backfill incident created: {incident_url}\nSlack channel: <#{channel_id}>"
-    )
-    client.chat_postMessage(channel=slack_user_id, text=dm_message)
+    _setup_channel_for_incident(incident, channel_id, slack_user_id, client)

--- a/src/firetower/slack_app/handlers/backfill_incident.py
+++ b/src/firetower/slack_app/handlers/backfill_incident.py
@@ -209,6 +209,14 @@ def handle_backfill_command(ack: Any, body: dict, command: dict, respond: Any) -
         )
         return
 
+    channel_info = _slack_service.get_channel_info(channel_id)
+    expected_prefix = f"{settings.PROJECT_KEY}-".lower()
+    if not channel_info or not channel_info["name"].startswith(expected_prefix):
+        respond(
+            f"Backfill is only allowed on incident channels (name must start with `{expected_prefix}`)."
+        )
+        return
+
     existing_link = ExternalLink.objects.filter(
         type=ExternalLinkType.SLACK,
         url__endswith=f"/archives/{channel_id}",

--- a/src/firetower/slack_app/handlers/backfill_incident.py
+++ b/src/firetower/slack_app/handlers/backfill_incident.py
@@ -1,0 +1,430 @@
+import logging
+import re
+from typing import Any
+
+from django.conf import settings
+
+from firetower.auth.services import get_or_create_user_from_slack_id
+from firetower.incidents.hooks import _build_channel_topic
+from firetower.incidents.models import (
+    INCIDENT_ID_START,
+    ExternalLink,
+    ExternalLinkType,
+    IncidentCounter,
+    IncidentSeverity,
+)
+from firetower.incidents.serializers import IncidentWriteSerializer
+from firetower.incidents.services import sync_incident_participants_from_slack
+from firetower.integrations.services import SlackService
+
+logger = logging.getLogger(__name__)
+_slack_service = SlackService()
+
+_DEFAULT_SEVERITY = IncidentSeverity.P3
+
+
+def _peek_next_incident_id() -> int:
+    try:
+        counter = IncidentCounter.objects.get(pk=1)
+        return counter.next_id
+    except IncidentCounter.DoesNotExist:
+        return INCIDENT_ID_START
+
+
+def _expected_channel_name(incident_id: int) -> str:
+    project_key = settings.PROJECT_KEY
+    return f"{project_key}-{incident_id}".lower()
+
+
+def _parse_channel_id_from_args(args: str) -> str | None:
+    match = re.search(r"<#(C[A-Z0-9]+)\|", args)
+    if match:
+        return match.group(1)
+    match = re.search(r"(C[A-Z0-9]+)", args)
+    if match:
+        return match.group(1)
+    return None
+
+
+def _build_backfill_modal(channel_id: str, user_id: str = "") -> dict:
+    severity_options = [
+        {
+            "text": {"type": "plain_text", "text": sev.label},
+            "value": sev.value,
+        }
+        for sev in IncidentSeverity
+    ]
+    default_option = {
+        "text": {"type": "plain_text", "text": _DEFAULT_SEVERITY.label},
+        "value": _DEFAULT_SEVERITY.value,
+    }
+
+    blocks = [
+        {
+            "type": "input",
+            "block_id": "captain_block",
+            "optional": True,
+            "element": {
+                "type": "users_select",
+                "action_id": "captain_select",
+                "placeholder": {
+                    "type": "plain_text",
+                    "text": "Select incident captain",
+                },
+                **({"initial_user": user_id} if user_id else {}),
+            },
+            "label": {"type": "plain_text", "text": "Incident Captain"},
+        },
+        {
+            "type": "input",
+            "block_id": "severity_block",
+            "element": {
+                "type": "static_select",
+                "action_id": "severity",
+                "placeholder": {"type": "plain_text", "text": "Select severity"},
+                "options": severity_options,
+                "initial_option": default_option,
+            },
+            "label": {"type": "plain_text", "text": "Severity"},
+        },
+        {
+            "type": "input",
+            "block_id": "title_block",
+            "element": {
+                "type": "plain_text_input",
+                "action_id": "title",
+                "placeholder": {"type": "plain_text", "text": "Brief incident title"},
+            },
+            "label": {"type": "plain_text", "text": "Title"},
+        },
+        {
+            "type": "input",
+            "block_id": "description_block",
+            "optional": True,
+            "element": {
+                "type": "plain_text_input",
+                "action_id": "description",
+                "multiline": True,
+                "placeholder": {
+                    "type": "plain_text",
+                    "text": "What's happening?",
+                },
+            },
+            "label": {"type": "plain_text", "text": "Description"},
+        },
+        {
+            "type": "input",
+            "block_id": "impact_summary_block",
+            "optional": True,
+            "element": {
+                "type": "plain_text_input",
+                "action_id": "impact_summary",
+                "multiline": True,
+                "placeholder": {
+                    "type": "plain_text",
+                    "text": "What is the user/business impact?",
+                },
+            },
+            "label": {"type": "plain_text", "text": "Impact Summary"},
+        },
+        {
+            "type": "input",
+            "block_id": "impact_type_block",
+            "optional": True,
+            "element": {
+                "type": "multi_external_select",
+                "action_id": "impact_type_tags",
+                "min_query_length": 0,
+                "placeholder": {
+                    "type": "plain_text",
+                    "text": "Select impact types",
+                },
+            },
+            "label": {"type": "plain_text", "text": "Impact Type"},
+        },
+        {
+            "type": "input",
+            "block_id": "affected_service_block",
+            "optional": True,
+            "element": {
+                "type": "multi_external_select",
+                "action_id": "affected_service_tags",
+                "min_query_length": 0,
+                "placeholder": {
+                    "type": "plain_text",
+                    "text": "Select affected services",
+                },
+            },
+            "label": {"type": "plain_text", "text": "Affected Service"},
+        },
+        {
+            "type": "input",
+            "block_id": "affected_region_block",
+            "optional": True,
+            "element": {
+                "type": "multi_external_select",
+                "action_id": "affected_region_tags",
+                "min_query_length": 0,
+                "placeholder": {
+                    "type": "plain_text",
+                    "text": "Select affected regions",
+                },
+            },
+            "label": {"type": "plain_text", "text": "Affected Region"},
+        },
+        {
+            "type": "input",
+            "block_id": "private_block",
+            "optional": True,
+            "element": {
+                "type": "checkboxes",
+                "action_id": "is_private",
+                "options": [
+                    {
+                        "text": {"type": "plain_text", "text": "Private incident"},
+                        "value": "private",
+                    }
+                ],
+            },
+            "label": {"type": "plain_text", "text": "Visibility"},
+        },
+    ]
+
+    modal = {
+        "type": "modal",
+        "callback_id": "backfill_incident_modal",
+        "title": {"type": "plain_text", "text": "Backfill Incident"},
+        "submit": {"type": "plain_text", "text": "Backfill"},
+        "close": {"type": "plain_text", "text": "Cancel"},
+        "blocks": blocks,
+        "private_metadata": channel_id,
+    }
+    return modal
+
+
+def handle_backfill_command(ack: Any, body: dict, command: dict, respond: Any) -> None:
+    ack()
+
+    raw_text = (body.get("text") or "").strip()
+    parts = raw_text.split(None, 1)
+    args = parts[1] if len(parts) > 1 else ""
+
+    channel_id = _parse_channel_id_from_args(args) if args else None
+    if not channel_id:
+        channel_id = body.get("channel_id", "")
+
+    if not channel_id:
+        respond(
+            "Could not determine channel. Run this from an incident channel or specify one: `/ft backfill #channel`"
+        )
+        return
+
+    channel_info = _slack_service.get_channel_info(channel_id)
+    if not channel_info:
+        respond(
+            f"Could not fetch info for channel <#{channel_id}>. Is the bot a member?"
+        )
+        return
+
+    channel_name = channel_info["name"]
+    next_id = _peek_next_incident_id()
+    expected_name = _expected_channel_name(next_id)
+
+    if channel_name != expected_name:
+        respond(
+            f"Channel name `{channel_name}` does not match the next expected "
+            f"incident channel `{expected_name}`. Please rename the channel first."
+        )
+        return
+
+    existing_link = ExternalLink.objects.filter(
+        type=ExternalLinkType.SLACK,
+        url__endswith=f"/archives/{channel_id}",
+    ).first()
+    if existing_link:
+        respond(
+            f"This channel is already linked to {existing_link.incident.incident_number}."
+        )
+        return
+
+    trigger_id = body.get("trigger_id")
+    if not trigger_id:
+        respond("Could not open modal -- missing trigger_id.")
+        return
+
+    user_id = body.get("user_id", "")
+
+    from firetower.slack_app.bolt import get_bolt_app  # noqa: PLC0415
+
+    get_bolt_app().client.views_open(
+        trigger_id=trigger_id,
+        view=_build_backfill_modal(channel_id=channel_id, user_id=user_id),
+    )
+
+
+def handle_backfill_submission(ack: Any, body: dict, view: dict, client: Any) -> None:
+    values = view.get("state", {}).get("values", {})
+
+    title = values.get("title_block", {}).get("title", {}).get("value", "").strip()
+    severity = (
+        values.get("severity_block", {})
+        .get("severity", {})
+        .get("selected_option", {})
+        .get("value", _DEFAULT_SEVERITY.value)
+    )
+    description = (
+        values.get("description_block", {}).get("description", {}).get("value") or ""
+    )
+    impact_summary = (
+        values.get("impact_summary_block", {}).get("impact_summary", {}).get("value")
+        or ""
+    )
+
+    impact_type_selections = (
+        values.get("impact_type_block", {})
+        .get("impact_type_tags", {})
+        .get("selected_options")
+        or []
+    )
+    impact_type_tags = [opt["value"] for opt in impact_type_selections]
+
+    affected_service_selections = (
+        values.get("affected_service_block", {})
+        .get("affected_service_tags", {})
+        .get("selected_options")
+        or []
+    )
+    affected_service_tags = [opt["value"] for opt in affected_service_selections]
+
+    affected_region_selections = (
+        values.get("affected_region_block", {})
+        .get("affected_region_tags", {})
+        .get("selected_options")
+        or []
+    )
+    affected_region_tags = [opt["value"] for opt in affected_region_selections]
+
+    captain_slack_id = (
+        values.get("captain_block", {}).get("captain_select", {}).get("selected_user")
+    )
+
+    private_selections = (
+        values.get("private_block", {}).get("is_private", {}).get("selected_options")
+        or []
+    )
+    is_private = any(opt.get("value") == "private" for opt in private_selections)
+
+    if not title:
+        ack(
+            response_action="errors",
+            errors={"title_block": "This field is required."},
+        )
+        return
+
+    ack()
+
+    channel_id = view.get("private_metadata", "")
+    slack_user_id = body.get("user", {}).get("id", "")
+
+    user = get_or_create_user_from_slack_id(slack_user_id)
+    if not user:
+        client.chat_postMessage(
+            channel=slack_user_id,
+            text="Could not identify your Firetower account. Please try again.",
+        )
+        return
+
+    captain_email = user.email
+    if captain_slack_id:
+        captain_user = get_or_create_user_from_slack_id(captain_slack_id)
+        if captain_user:
+            captain_email = captain_user.email
+
+    channel_url = _slack_service.build_channel_url(channel_id)
+
+    data: dict[str, Any] = {
+        "title": title,
+        "severity": severity,
+        "description": description,
+        "impact_summary": impact_summary,
+        "captain": captain_email,
+        "reporter": user.email,
+        "is_private": is_private,
+        "external_links": {"slack": channel_url},
+    }
+    if impact_type_tags:
+        data["impact_type_tags"] = impact_type_tags
+    if affected_service_tags:
+        data["affected_service_tags"] = affected_service_tags
+    if affected_region_tags:
+        data["affected_region_tags"] = affected_region_tags
+
+    serializer = IncidentWriteSerializer(data=data, context={"skip_hooks": True})
+    if not serializer.is_valid():
+        logger.error("Backfill incident validation failed: %s", serializer.errors)
+        client.chat_postMessage(
+            channel=slack_user_id,
+            text="Something went wrong validating the incident. Please try again.",
+        )
+        return
+
+    try:
+        incident = serializer.save()
+    except Exception:
+        logger.exception("Failed to create backfill incident from Slack modal")
+        client.chat_postMessage(
+            channel=slack_user_id,
+            text="Something went wrong creating the backfill incident. Please try again.",
+        )
+        return
+
+    actual_channel_name = _expected_channel_name(incident.id)
+    channel_info = _slack_service.get_channel_info(channel_id)
+    if channel_info and channel_info["name"] != actual_channel_name:
+        logger.error(
+            "Backfill channel name mismatch after creation: channel=%s expected=%s incident=%s",
+            channel_info["name"],
+            actual_channel_name,
+            incident.id,
+        )
+        client.chat_postMessage(
+            channel=slack_user_id,
+            text=(
+                f"The incident was created as {incident.incident_number}, but the channel "
+                f"name `{channel_info['name']}` no longer matches `{actual_channel_name}`. "
+                f"Another incident may have been created concurrently. Please verify and "
+                f"rename the channel if needed."
+            ),
+        )
+        return
+
+    joined = _slack_service.join_channel(channel_id)
+    if not joined:
+        base_url = settings.FIRETOWER_BASE_URL
+        incident_url = f"{base_url}/{incident.incident_number}"
+        client.chat_postMessage(
+            channel=slack_user_id,
+            text=(
+                f"Backfill incident created: {incident_url}\n"
+                f"However, the bot could not join <#{channel_id}>. "
+                f"Please invite the bot to the channel for topic/bookmark setup."
+            ),
+        )
+        return
+
+    _slack_service.set_channel_topic(channel_id, _build_channel_topic(incident))
+    base_url = settings.FIRETOWER_BASE_URL
+    incident_url = f"{base_url}/{incident.incident_number}"
+    _slack_service.add_bookmark(channel_id, "Firetower Incident", incident_url)
+
+    try:
+        sync_incident_participants_from_slack(incident, force=True)
+    except Exception:
+        logger.exception(
+            "Failed to sync participants for backfill incident %s", incident.id
+        )
+
+    dm_message = (
+        f"Backfill incident created: {incident_url}\nSlack channel: <#{channel_id}>"
+    )
+    client.chat_postMessage(channel=slack_user_id, text=dm_message)

--- a/src/firetower/slack_app/handlers/backfill_incident.py
+++ b/src/firetower/slack_app/handlers/backfill_incident.py
@@ -5,25 +5,21 @@ from typing import Any
 from django.conf import settings
 
 from firetower.auth.services import get_or_create_user_from_slack_id
-from firetower.incidents.hooks import _build_channel_topic
+from firetower.incidents.hooks import _build_channel_name, _build_channel_topic
 from firetower.incidents.models import (
     ExternalLink,
     ExternalLinkType,
-    IncidentSeverity,
 )
 from firetower.incidents.serializers import IncidentWriteSerializer
 from firetower.incidents.services import sync_incident_participants_from_slack
 from firetower.integrations.services import SlackService
+from firetower.slack_app.handlers.utils import (
+    build_incident_form_blocks,
+    parse_incident_form_values,
+)
 
 logger = logging.getLogger(__name__)
 _slack_service = SlackService()
-
-_DEFAULT_SEVERITY = IncidentSeverity.P3
-
-
-def _expected_channel_name(incident_id: int) -> str:
-    project_key = settings.PROJECT_KEY
-    return f"{project_key}-{incident_id}".lower()
 
 
 def _parse_channel_id_from_args(args: str) -> str | None:
@@ -37,143 +33,15 @@ def _parse_channel_id_from_args(args: str) -> str | None:
 
 
 def _build_backfill_modal(channel_id: str, user_id: str = "") -> dict:
-    severity_options = [
-        {
-            "text": {"type": "plain_text", "text": sev.label},
-            "value": sev.value,
-        }
-        for sev in IncidentSeverity
-    ]
-    default_option = {
-        "text": {"type": "plain_text", "text": _DEFAULT_SEVERITY.label},
-        "value": _DEFAULT_SEVERITY.value,
-    }
-
-    blocks = [
-        {
-            "type": "input",
-            "block_id": "captain_block",
-            "optional": True,
-            "element": {
-                "type": "users_select",
-                "action_id": "captain_select",
-                "placeholder": {
-                    "type": "plain_text",
-                    "text": "Select incident captain",
-                },
-                **({"initial_user": user_id} if user_id else {}),
-            },
-            "label": {"type": "plain_text", "text": "Incident Captain"},
-        },
-        {
-            "type": "input",
-            "block_id": "severity_block",
-            "element": {
-                "type": "static_select",
-                "action_id": "severity",
-                "placeholder": {"type": "plain_text", "text": "Select severity"},
-                "options": severity_options,
-                "initial_option": default_option,
-            },
-            "label": {"type": "plain_text", "text": "Severity"},
-        },
-        {
-            "type": "input",
-            "block_id": "title_block",
-            "element": {
-                "type": "plain_text_input",
-                "action_id": "title",
-                "placeholder": {"type": "plain_text", "text": "Brief incident title"},
-            },
-            "label": {"type": "plain_text", "text": "Title"},
-        },
-        {
-            "type": "input",
-            "block_id": "description_block",
-            "optional": True,
-            "element": {
-                "type": "plain_text_input",
-                "action_id": "description",
-                "multiline": True,
-                "placeholder": {
-                    "type": "plain_text",
-                    "text": "What's happening?",
-                },
-            },
-            "label": {"type": "plain_text", "text": "Description"},
-        },
-        {
-            "type": "input",
-            "block_id": "impact_summary_block",
-            "optional": True,
-            "element": {
-                "type": "plain_text_input",
-                "action_id": "impact_summary",
-                "multiline": True,
-                "placeholder": {
-                    "type": "plain_text",
-                    "text": "What is the user/business impact?",
-                },
-            },
-            "label": {"type": "plain_text", "text": "Impact Summary"},
-        },
-        {
-            "type": "input",
-            "block_id": "impact_type_block",
-            "optional": True,
-            "element": {
-                "type": "multi_external_select",
-                "action_id": "impact_type_tags",
-                "min_query_length": 0,
-                "placeholder": {
-                    "type": "plain_text",
-                    "text": "Select impact types",
-                },
-            },
-            "label": {"type": "plain_text", "text": "Impact Type"},
-        },
-        {
-            "type": "input",
-            "block_id": "affected_service_block",
-            "optional": True,
-            "element": {
-                "type": "multi_external_select",
-                "action_id": "affected_service_tags",
-                "min_query_length": 0,
-                "placeholder": {
-                    "type": "plain_text",
-                    "text": "Select affected services",
-                },
-            },
-            "label": {"type": "plain_text", "text": "Affected Service"},
-        },
-        {
-            "type": "input",
-            "block_id": "affected_region_block",
-            "optional": True,
-            "element": {
-                "type": "multi_external_select",
-                "action_id": "affected_region_tags",
-                "min_query_length": 0,
-                "placeholder": {
-                    "type": "plain_text",
-                    "text": "Select affected regions",
-                },
-            },
-            "label": {"type": "plain_text", "text": "Affected Region"},
-        },
-    ]
-
-    modal = {
+    return {
         "type": "modal",
         "callback_id": "backfill_incident_modal",
         "title": {"type": "plain_text", "text": "Backfill Incident"},
         "submit": {"type": "plain_text", "text": "Backfill"},
         "close": {"type": "plain_text", "text": "Cancel"},
-        "blocks": blocks,
+        "blocks": build_incident_form_blocks(user_id=user_id),
         "private_metadata": channel_id,
     }
-    return modal
 
 
 def handle_backfill_command(ack: Any, body: dict, command: dict, respond: Any) -> None:
@@ -201,10 +69,14 @@ def handle_backfill_command(ack: Any, body: dict, command: dict, respond: Any) -
         )
         return
 
-    existing_link = ExternalLink.objects.filter(
-        type=ExternalLinkType.SLACK,
-        url__endswith=f"/archives/{channel_id}",
-    ).first()
+    existing_link = (
+        ExternalLink.objects.filter(
+            type=ExternalLinkType.SLACK,
+            url__endswith=f"/archives/{channel_id}",
+        )
+        .select_related("incident")
+        .first()
+    )
     if existing_link:
         respond(
             f"This channel is already linked to {existing_link.incident.incident_number}."
@@ -227,52 +99,9 @@ def handle_backfill_command(ack: Any, body: dict, command: dict, respond: Any) -
 
 
 def handle_backfill_submission(ack: Any, body: dict, view: dict, client: Any) -> None:
-    values = view.get("state", {}).get("values", {})
+    form = parse_incident_form_values(view)
 
-    title = values.get("title_block", {}).get("title", {}).get("value", "").strip()
-    severity = (
-        values.get("severity_block", {})
-        .get("severity", {})
-        .get("selected_option", {})
-        .get("value", _DEFAULT_SEVERITY.value)
-    )
-    description = (
-        values.get("description_block", {}).get("description", {}).get("value") or ""
-    )
-    impact_summary = (
-        values.get("impact_summary_block", {}).get("impact_summary", {}).get("value")
-        or ""
-    )
-
-    impact_type_selections = (
-        values.get("impact_type_block", {})
-        .get("impact_type_tags", {})
-        .get("selected_options")
-        or []
-    )
-    impact_type_tags = [opt["value"] for opt in impact_type_selections]
-
-    affected_service_selections = (
-        values.get("affected_service_block", {})
-        .get("affected_service_tags", {})
-        .get("selected_options")
-        or []
-    )
-    affected_service_tags = [opt["value"] for opt in affected_service_selections]
-
-    affected_region_selections = (
-        values.get("affected_region_block", {})
-        .get("affected_region_tags", {})
-        .get("selected_options")
-        or []
-    )
-    affected_region_tags = [opt["value"] for opt in affected_region_selections]
-
-    captain_slack_id = (
-        values.get("captain_block", {}).get("captain_select", {}).get("selected_user")
-    )
-
-    if not title:
+    if not form["title"]:
         ack(
             response_action="errors",
             errors={"title_block": "This field is required."},
@@ -284,6 +113,21 @@ def handle_backfill_submission(ack: Any, body: dict, view: dict, client: Any) ->
     channel_id = view.get("private_metadata", "")
     slack_user_id = body.get("user", {}).get("id", "")
 
+    existing_link = (
+        ExternalLink.objects.filter(
+            type=ExternalLinkType.SLACK,
+            url__endswith=f"/archives/{channel_id}",
+        )
+        .select_related("incident")
+        .first()
+    )
+    if existing_link:
+        client.chat_postMessage(
+            channel=slack_user_id,
+            text=f"This channel is already linked to {existing_link.incident.incident_number}.",
+        )
+        return
+
     user = get_or_create_user_from_slack_id(slack_user_id)
     if not user:
         client.chat_postMessage(
@@ -293,8 +137,8 @@ def handle_backfill_submission(ack: Any, body: dict, view: dict, client: Any) ->
         return
 
     captain_email = user.email
-    if captain_slack_id:
-        captain_user = get_or_create_user_from_slack_id(captain_slack_id)
+    if form["captain_slack_id"]:
+        captain_user = get_or_create_user_from_slack_id(form["captain_slack_id"])
         if captain_user:
             captain_email = captain_user.email
 
@@ -303,21 +147,21 @@ def handle_backfill_submission(ack: Any, body: dict, view: dict, client: Any) ->
     is_private = bool(channel_info and channel_info.get("is_private"))
 
     data: dict[str, Any] = {
-        "title": title,
-        "severity": severity,
-        "description": description,
-        "impact_summary": impact_summary,
+        "title": form["title"],
+        "severity": form["severity"],
+        "description": form["description"],
+        "impact_summary": form["impact_summary"],
         "captain": captain_email,
         "reporter": user.email,
         "is_private": is_private,
         "external_links": {"slack": channel_url},
     }
-    if impact_type_tags:
-        data["impact_type_tags"] = impact_type_tags
-    if affected_service_tags:
-        data["affected_service_tags"] = affected_service_tags
-    if affected_region_tags:
-        data["affected_region_tags"] = affected_region_tags
+    if form["impact_type_tags"]:
+        data["impact_type_tags"] = form["impact_type_tags"]
+    if form["affected_service_tags"]:
+        data["affected_service_tags"] = form["affected_service_tags"]
+    if form["affected_region_tags"]:
+        data["affected_region_tags"] = form["affected_region_tags"]
 
     serializer = IncidentWriteSerializer(data=data, context={"skip_hooks": True})
     if not serializer.is_valid():
@@ -347,12 +191,13 @@ def handle_backfill_submission(ack: Any, body: dict, view: dict, client: Any) ->
             text=(
                 f"Backfill incident created: {incident_url}\n"
                 f"However, the bot could not join <#{channel_id}>. "
-                f"Please invite the bot to the channel for topic/bookmark setup."
+                f"Please invite the Firetower bot to the channel, "
+                f"then run `/ft backfill` again from the channel to retry setup."
             ),
         )
         return
 
-    expected_name = _expected_channel_name(incident.id)
+    expected_name = _build_channel_name(incident)
     channel_info = _slack_service.get_channel_info(channel_id)
     if channel_info and channel_info["name"] != expected_name:
         renamed = _slack_service.rename_channel(channel_id, expected_name)

--- a/src/firetower/slack_app/handlers/backfill_incident.py
+++ b/src/firetower/slack_app/handlers/backfill_incident.py
@@ -14,6 +14,7 @@ from firetower.incidents.serializers import IncidentWriteSerializer
 from firetower.incidents.services import sync_incident_participants_from_slack
 from firetower.integrations.services import SlackService
 from firetower.slack_app.handlers.utils import (
+    _DEFAULT_SEVERITY,
     build_incident_form_blocks,
     parse_incident_form_values,
 )
@@ -148,7 +149,7 @@ def handle_backfill_submission(ack: Any, body: dict, view: dict, client: Any) ->
 
     data: dict[str, Any] = {
         "title": form["title"],
-        "severity": form["severity"],
+        "severity": form["severity"] or _DEFAULT_SEVERITY.value,
         "description": form["description"],
         "impact_summary": form["impact_summary"],
         "captain": captain_email,

--- a/src/firetower/slack_app/handlers/backfill_incident.py
+++ b/src/firetower/slack_app/handlers/backfill_incident.py
@@ -52,15 +52,21 @@ def _setup_channel_for_incident(
     if not joined:
         base_url = settings.FIRETOWER_BASE_URL
         incident_url = f"{base_url}/{incident.incident_number}"
-        client.chat_postMessage(
-            channel=notify_user_id,
-            text=(
-                f"Incident: {incident_url}\n"
-                f"The bot could not join <#{channel_id}>. "
-                f"Please invite the Firetower bot to the channel, "
-                f"then run `/ft backfill` again to retry setup."
-            ),
-        )
+        try:
+            client.chat_postMessage(
+                channel=notify_user_id,
+                text=(
+                    f"Incident: {incident_url}\n"
+                    f"The bot could not join <#{channel_id}>. "
+                    f"Please invite the Firetower bot to the channel, "
+                    f"then run `/ft backfill` again to retry setup."
+                ),
+            )
+        except Exception:
+            logger.exception(
+                "Failed to notify user about join failure for backfill incident %s",
+                incident.id,
+            )
         return
 
     expected_name = build_channel_name(incident)

--- a/src/firetower/slack_app/handlers/backfill_incident.py
+++ b/src/firetower/slack_app/handlers/backfill_incident.py
@@ -209,7 +209,9 @@ def handle_backfill_submission(ack: Any, body: dict, view: dict, client: Any) ->
 
     channel_url = _slack_service.build_channel_url(channel_id)
     channel_info = _slack_service.get_channel_info(channel_id)
-    is_private = bool(channel_info and channel_info.get("is_private"))
+    # Default to private when channel info is unavailable to avoid leaking
+    # sensitive incident details if the Slack API call fails transiently.
+    is_private = channel_info.get("is_private", True) if channel_info else True
 
     data: dict[str, Any] = {
         "title": form["title"],

--- a/src/firetower/slack_app/handlers/backfill_incident.py
+++ b/src/firetower/slack_app/handlers/backfill_incident.py
@@ -162,22 +162,6 @@ def _build_backfill_modal(channel_id: str, user_id: str = "") -> dict:
             },
             "label": {"type": "plain_text", "text": "Affected Region"},
         },
-        {
-            "type": "input",
-            "block_id": "private_block",
-            "optional": True,
-            "element": {
-                "type": "checkboxes",
-                "action_id": "is_private",
-                "options": [
-                    {
-                        "text": {"type": "plain_text", "text": "Private incident"},
-                        "value": "private",
-                    }
-                ],
-            },
-            "label": {"type": "plain_text", "text": "Visibility"},
-        },
     ]
 
     modal = {
@@ -288,12 +272,6 @@ def handle_backfill_submission(ack: Any, body: dict, view: dict, client: Any) ->
         values.get("captain_block", {}).get("captain_select", {}).get("selected_user")
     )
 
-    private_selections = (
-        values.get("private_block", {}).get("is_private", {}).get("selected_options")
-        or []
-    )
-    is_private = any(opt.get("value") == "private" for opt in private_selections)
-
     if not title:
         ack(
             response_action="errors",
@@ -321,6 +299,8 @@ def handle_backfill_submission(ack: Any, body: dict, view: dict, client: Any) ->
             captain_email = captain_user.email
 
     channel_url = _slack_service.build_channel_url(channel_id)
+    channel_info = _slack_service.get_channel_info(channel_id)
+    is_private = bool(channel_info and channel_info.get("is_private"))
 
     data: dict[str, Any] = {
         "title": title,
@@ -373,7 +353,6 @@ def handle_backfill_submission(ack: Any, body: dict, view: dict, client: Any) ->
         return
 
     expected_name = _expected_channel_name(incident.id)
-    channel_info = _slack_service.get_channel_info(channel_id)
     if channel_info and channel_info["name"] != expected_name:
         renamed = _slack_service.rename_channel(channel_id, expected_name)
         if not renamed:

--- a/src/firetower/slack_app/handlers/help.py
+++ b/src/firetower/slack_app/handlers/help.py
@@ -10,6 +10,7 @@ def handle_help_command(ack: Any, command: dict, respond: Any) -> None:
         f"Available commands:\n"
         f"  `{cmd} help` - Show this help message\n"
         f"  `{cmd} new` - Create a new incident\n"
+        f"  `{cmd} backfill` - Backfill an incident from a manually-created channel\n"
         f"  `{cmd} severity <P0-P4>` - Change incident severity (alias: `{cmd} sev`)\n"
         f"  `{cmd} subject <title>` - Change incident title\n"
         f"  `{cmd} captain` - Set incident captain (alias: `{cmd} ic`)\n"

--- a/src/firetower/slack_app/handlers/new_incident.py
+++ b/src/firetower/slack_app/handlers/new_incident.py
@@ -9,6 +9,7 @@ from firetower.incidents.serializers import IncidentWriteSerializer
 from firetower.integrations.services import SlackService
 from firetower.integrations.services.slack import escape_slack_text
 from firetower.slack_app.handlers.utils import (
+    _DEFAULT_SEVERITY,
     build_incident_form_blocks,
     parse_incident_form_values,
 )
@@ -135,7 +136,7 @@ def handle_new_incident_submission(
 
     data: dict[str, Any] = {
         "title": form["title"],
-        "severity": form["severity"],
+        "severity": form["severity"] or _DEFAULT_SEVERITY.value,
         "description": form["description"],
         "impact_summary": form["impact_summary"],
         "captain": captain_email,

--- a/src/firetower/slack_app/handlers/new_incident.py
+++ b/src/firetower/slack_app/handlers/new_incident.py
@@ -4,144 +4,21 @@ from typing import Any
 from django.conf import settings
 
 from firetower.auth.services import get_or_create_user_from_slack_id
-from firetower.incidents.models import IncidentSeverity, Tag, TagType
+from firetower.incidents.models import Tag, TagType
 from firetower.incidents.serializers import IncidentWriteSerializer
 from firetower.integrations.services import SlackService
 from firetower.integrations.services.slack import escape_slack_text
+from firetower.slack_app.handlers.utils import (
+    build_incident_form_blocks,
+    parse_incident_form_values,
+)
 
 logger = logging.getLogger(__name__)
 _slack_service = SlackService()
 
-_DEFAULT_SEVERITY = IncidentSeverity.P3
-
 
 def _build_new_incident_modal(channel_id: str = "", user_id: str = "") -> dict:
-    severity_options = [
-        {
-            "text": {"type": "plain_text", "text": sev.label},
-            "value": sev.value,
-        }
-        for sev in IncidentSeverity
-    ]
-    default_option = {
-        "text": {"type": "plain_text", "text": _DEFAULT_SEVERITY.label},
-        "value": _DEFAULT_SEVERITY.value,
-    }
-
-    blocks = [
-        {
-            "type": "input",
-            "block_id": "captain_block",
-            "optional": True,
-            "element": {
-                "type": "users_select",
-                "action_id": "captain_select",
-                "placeholder": {
-                    "type": "plain_text",
-                    "text": "Select incident captain",
-                },
-                **({"initial_user": user_id} if user_id else {}),
-            },
-            "label": {"type": "plain_text", "text": "Incident Captain"},
-        },
-        {
-            "type": "input",
-            "block_id": "severity_block",
-            "element": {
-                "type": "static_select",
-                "action_id": "severity",
-                "placeholder": {"type": "plain_text", "text": "Select severity"},
-                "options": severity_options,
-                "initial_option": default_option,
-            },
-            "label": {"type": "plain_text", "text": "Severity"},
-        },
-        {
-            "type": "input",
-            "block_id": "title_block",
-            "element": {
-                "type": "plain_text_input",
-                "action_id": "title",
-                "placeholder": {"type": "plain_text", "text": "Brief incident title"},
-            },
-            "label": {"type": "plain_text", "text": "Title"},
-        },
-        {
-            "type": "input",
-            "block_id": "description_block",
-            "optional": True,
-            "element": {
-                "type": "plain_text_input",
-                "action_id": "description",
-                "multiline": True,
-                "placeholder": {
-                    "type": "plain_text",
-                    "text": "What's happening?",
-                },
-            },
-            "label": {"type": "plain_text", "text": "Description"},
-        },
-        {
-            "type": "input",
-            "block_id": "impact_summary_block",
-            "optional": True,
-            "element": {
-                "type": "plain_text_input",
-                "action_id": "impact_summary",
-                "multiline": True,
-                "placeholder": {
-                    "type": "plain_text",
-                    "text": "What is the user/business impact?",
-                },
-            },
-            "label": {"type": "plain_text", "text": "Impact Summary"},
-        },
-        {
-            "type": "input",
-            "block_id": "impact_type_block",
-            "optional": True,
-            "element": {
-                "type": "multi_external_select",
-                "action_id": "impact_type_tags",
-                "min_query_length": 0,
-                "placeholder": {
-                    "type": "plain_text",
-                    "text": "Select impact types",
-                },
-            },
-            "label": {"type": "plain_text", "text": "Impact Type"},
-        },
-        {
-            "type": "input",
-            "block_id": "affected_service_block",
-            "optional": True,
-            "element": {
-                "type": "multi_external_select",
-                "action_id": "affected_service_tags",
-                "min_query_length": 0,
-                "placeholder": {
-                    "type": "plain_text",
-                    "text": "Select affected services",
-                },
-            },
-            "label": {"type": "plain_text", "text": "Affected Service"},
-        },
-        {
-            "type": "input",
-            "block_id": "affected_region_block",
-            "optional": True,
-            "element": {
-                "type": "multi_external_select",
-                "action_id": "affected_region_tags",
-                "min_query_length": 0,
-                "placeholder": {
-                    "type": "plain_text",
-                    "text": "Select affected regions",
-                },
-            },
-            "label": {"type": "plain_text", "text": "Affected Region"},
-        },
-    ]
+    blocks = build_incident_form_blocks(user_id=user_id)
 
     blocks.append(
         {
@@ -162,7 +39,7 @@ def _build_new_incident_modal(channel_id: str = "", user_id: str = "") -> dict:
         }
     )
 
-    modal = {
+    modal: dict[str, Any] = {
         "type": "modal",
         "callback_id": "new_incident_modal",
         "title": {"type": "plain_text", "text": "New Incident"},
@@ -223,58 +100,16 @@ def handle_new_command(ack: Any, body: dict, command: dict, respond: Any) -> Non
 def handle_new_incident_submission(
     ack: Any, body: dict, view: dict, client: Any
 ) -> None:
+    form = parse_incident_form_values(view)
+
     values = view.get("state", {}).get("values", {})
-
-    title = values.get("title_block", {}).get("title", {}).get("value", "").strip()
-    severity = (
-        values.get("severity_block", {})
-        .get("severity", {})
-        .get("selected_option", {})
-        .get("value", _DEFAULT_SEVERITY.value)
-    )
-    description = (
-        values.get("description_block", {}).get("description", {}).get("value") or ""
-    )
-    impact_summary = (
-        values.get("impact_summary_block", {}).get("impact_summary", {}).get("value")
-        or ""
-    )
-
-    impact_type_selections = (
-        values.get("impact_type_block", {})
-        .get("impact_type_tags", {})
-        .get("selected_options")
-        or []
-    )
-    impact_type_tags = [opt["value"] for opt in impact_type_selections]
-
-    affected_service_selections = (
-        values.get("affected_service_block", {})
-        .get("affected_service_tags", {})
-        .get("selected_options")
-        or []
-    )
-    affected_service_tags = [opt["value"] for opt in affected_service_selections]
-
-    affected_region_selections = (
-        values.get("affected_region_block", {})
-        .get("affected_region_tags", {})
-        .get("selected_options")
-        or []
-    )
-    affected_region_tags = [opt["value"] for opt in affected_region_selections]
-
-    captain_slack_id = (
-        values.get("captain_block", {}).get("captain_select", {}).get("selected_user")
-    )
-
     private_selections = (
         values.get("private_block", {}).get("is_private", {}).get("selected_options")
         or []
     )
     is_private = any(opt.get("value") == "private" for opt in private_selections)
 
-    if not title:
+    if not form["title"]:
         ack(
             response_action="errors",
             errors={"title_block": "This field is required."},
@@ -293,26 +128,26 @@ def handle_new_incident_submission(
         return
 
     captain_email = user.email
-    if captain_slack_id:
-        captain_user = get_or_create_user_from_slack_id(captain_slack_id)
+    if form["captain_slack_id"]:
+        captain_user = get_or_create_user_from_slack_id(form["captain_slack_id"])
         if captain_user:
             captain_email = captain_user.email
 
-    data = {
-        "title": title,
-        "severity": severity,
-        "description": description,
-        "impact_summary": impact_summary,
+    data: dict[str, Any] = {
+        "title": form["title"],
+        "severity": form["severity"],
+        "description": form["description"],
+        "impact_summary": form["impact_summary"],
         "captain": captain_email,
         "reporter": user.email,
         "is_private": is_private,
     }
-    if impact_type_tags:
-        data["impact_type_tags"] = impact_type_tags
-    if affected_service_tags:
-        data["affected_service_tags"] = affected_service_tags
-    if affected_region_tags:
-        data["affected_region_tags"] = affected_region_tags
+    if form["impact_type_tags"]:
+        data["impact_type_tags"] = form["impact_type_tags"]
+    if form["affected_service_tags"]:
+        data["affected_service_tags"] = form["affected_service_tags"]
+    if form["affected_region_tags"]:
+        data["affected_region_tags"] = form["affected_region_tags"]
 
     serializer = IncidentWriteSerializer(data=data)
     if not serializer.is_valid():

--- a/src/firetower/slack_app/handlers/update_incident.py
+++ b/src/firetower/slack_app/handlers/update_incident.py
@@ -258,7 +258,6 @@ def handle_update_incident_submission(
 
     data: dict[str, Any] = {
         "title": form["title"],
-        "severity": form["severity"],
         "description": form["description"],
         "impact_summary": form["impact_summary"],
         "is_private": is_private,
@@ -266,6 +265,8 @@ def handle_update_incident_submission(
         "affected_service_tags": form["affected_service_tags"],
         "affected_region_tags": form["affected_region_tags"],
     }
+    if form["severity"]:
+        data["severity"] = form["severity"]
 
     if form["captain_slack_id"]:
         captain_user = get_or_create_user_from_slack_id(form["captain_slack_id"])

--- a/src/firetower/slack_app/handlers/update_incident.py
+++ b/src/firetower/slack_app/handlers/update_incident.py
@@ -5,7 +5,10 @@ from firetower.auth.models import ExternalProfileType
 from firetower.auth.services import get_or_create_user_from_slack_id
 from firetower.incidents.models import Incident, IncidentSeverity
 from firetower.incidents.serializers import IncidentWriteSerializer
-from firetower.slack_app.handlers.utils import get_incident_from_channel
+from firetower.slack_app.handlers.utils import (
+    get_incident_from_channel,
+    parse_incident_form_values,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -229,59 +232,17 @@ def handle_update_command(ack: Any, body: dict, command: dict, respond: Any) -> 
 def handle_update_incident_submission(
     ack: Any, body: dict, view: dict, client: Any
 ) -> None:
-    values = view.get("state", {}).get("values", {})
+    form = parse_incident_form_values(view)
     channel_id = view.get("private_metadata", "")
 
-    title = values.get("title_block", {}).get("title", {}).get("value", "").strip()
-    severity = (
-        values.get("severity_block", {})
-        .get("severity", {})
-        .get("selected_option", {})
-        .get("value")
-    )
-    description = (
-        values.get("description_block", {}).get("description", {}).get("value") or ""
-    )
-    impact_summary = (
-        values.get("impact_summary_block", {}).get("impact_summary", {}).get("value")
-        or ""
-    )
-
-    impact_type_selections = (
-        values.get("impact_type_block", {})
-        .get("impact_type_tags", {})
-        .get("selected_options")
-        or []
-    )
-    impact_type_tags = [opt["value"] for opt in impact_type_selections]
-
-    affected_service_selections = (
-        values.get("affected_service_block", {})
-        .get("affected_service_tags", {})
-        .get("selected_options")
-        or []
-    )
-    affected_service_tags = [opt["value"] for opt in affected_service_selections]
-
-    affected_region_selections = (
-        values.get("affected_region_block", {})
-        .get("affected_region_tags", {})
-        .get("selected_options")
-        or []
-    )
-    affected_region_tags = [opt["value"] for opt in affected_region_selections]
-
-    captain_slack_id = (
-        values.get("captain_block", {}).get("captain_select", {}).get("selected_user")
-    )
-
+    values = view.get("state", {}).get("values", {})
     private_selections = (
         values.get("private_block", {}).get("is_private", {}).get("selected_options")
         or []
     )
     is_private = any(opt.get("value") == "private" for opt in private_selections)
 
-    if not title:
+    if not form["title"]:
         ack(
             response_action="errors",
             errors={"title_block": "This field is required."},
@@ -296,18 +257,18 @@ def handle_update_incident_submission(
         return
 
     data: dict[str, Any] = {
-        "title": title,
-        "severity": severity,
-        "description": description,
-        "impact_summary": impact_summary,
+        "title": form["title"],
+        "severity": form["severity"],
+        "description": form["description"],
+        "impact_summary": form["impact_summary"],
         "is_private": is_private,
-        "impact_type_tags": impact_type_tags,
-        "affected_service_tags": affected_service_tags,
-        "affected_region_tags": affected_region_tags,
+        "impact_type_tags": form["impact_type_tags"],
+        "affected_service_tags": form["affected_service_tags"],
+        "affected_region_tags": form["affected_region_tags"],
     }
 
-    if captain_slack_id:
-        captain_user = get_or_create_user_from_slack_id(captain_slack_id)
+    if form["captain_slack_id"]:
+        captain_user = get_or_create_user_from_slack_id(form["captain_slack_id"])
         if captain_user:
             data["captain"] = captain_user.email
 

--- a/src/firetower/slack_app/handlers/utils.py
+++ b/src/firetower/slack_app/handlers/utils.py
@@ -157,12 +157,10 @@ def parse_incident_form_values(view: dict) -> dict[str, Any]:
     values = view.get("state", {}).get("values", {})
 
     title = values.get("title_block", {}).get("title", {}).get("value", "").strip()
-    severity = (
-        values.get("severity_block", {})
-        .get("severity", {})
-        .get("selected_option", {})
-        .get("value", _DEFAULT_SEVERITY.value)
+    selected_option = (
+        values.get("severity_block", {}).get("severity", {}).get("selected_option")
     )
+    severity = selected_option.get("value") if selected_option else None
     description = (
         values.get("description_block", {}).get("description", {}).get("value") or ""
     )

--- a/src/firetower/slack_app/handlers/utils.py
+++ b/src/firetower/slack_app/handlers/utils.py
@@ -1,11 +1,211 @@
-from firetower.incidents.models import ExternalLink, ExternalLinkType, Incident
+from typing import Any
+
+from firetower.incidents.models import (
+    ExternalLink,
+    ExternalLinkType,
+    Incident,
+    IncidentSeverity,
+)
+
+_DEFAULT_SEVERITY = IncidentSeverity.P3
 
 
 def get_incident_from_channel(channel_id: str) -> Incident | None:
-    link = ExternalLink.objects.filter(
-        type=ExternalLinkType.SLACK,
-        url__endswith=f"/archives/{channel_id}",
-    ).first()
+    link = (
+        ExternalLink.objects.filter(
+            type=ExternalLinkType.SLACK,
+            url__endswith=f"/archives/{channel_id}",
+        )
+        .select_related("incident")
+        .first()
+    )
     if link:
         return link.incident
     return None
+
+
+def build_incident_form_blocks(user_id: str = "") -> list[dict[str, Any]]:
+    severity_options = [
+        {
+            "text": {"type": "plain_text", "text": sev.label},
+            "value": sev.value,
+        }
+        for sev in IncidentSeverity
+    ]
+    default_option = {
+        "text": {"type": "plain_text", "text": _DEFAULT_SEVERITY.label},
+        "value": _DEFAULT_SEVERITY.value,
+    }
+
+    return [
+        {
+            "type": "input",
+            "block_id": "captain_block",
+            "optional": True,
+            "element": {
+                "type": "users_select",
+                "action_id": "captain_select",
+                "placeholder": {
+                    "type": "plain_text",
+                    "text": "Select incident captain",
+                },
+                **({"initial_user": user_id} if user_id else {}),
+            },
+            "label": {"type": "plain_text", "text": "Incident Captain"},
+        },
+        {
+            "type": "input",
+            "block_id": "severity_block",
+            "element": {
+                "type": "static_select",
+                "action_id": "severity",
+                "placeholder": {"type": "plain_text", "text": "Select severity"},
+                "options": severity_options,
+                "initial_option": default_option,
+            },
+            "label": {"type": "plain_text", "text": "Severity"},
+        },
+        {
+            "type": "input",
+            "block_id": "title_block",
+            "element": {
+                "type": "plain_text_input",
+                "action_id": "title",
+                "placeholder": {"type": "plain_text", "text": "Brief incident title"},
+            },
+            "label": {"type": "plain_text", "text": "Title"},
+        },
+        {
+            "type": "input",
+            "block_id": "description_block",
+            "optional": True,
+            "element": {
+                "type": "plain_text_input",
+                "action_id": "description",
+                "multiline": True,
+                "placeholder": {
+                    "type": "plain_text",
+                    "text": "What's happening?",
+                },
+            },
+            "label": {"type": "plain_text", "text": "Description"},
+        },
+        {
+            "type": "input",
+            "block_id": "impact_summary_block",
+            "optional": True,
+            "element": {
+                "type": "plain_text_input",
+                "action_id": "impact_summary",
+                "multiline": True,
+                "placeholder": {
+                    "type": "plain_text",
+                    "text": "What is the user/business impact?",
+                },
+            },
+            "label": {"type": "plain_text", "text": "Impact Summary"},
+        },
+        {
+            "type": "input",
+            "block_id": "impact_type_block",
+            "optional": True,
+            "element": {
+                "type": "multi_external_select",
+                "action_id": "impact_type_tags",
+                "min_query_length": 0,
+                "placeholder": {
+                    "type": "plain_text",
+                    "text": "Select impact types",
+                },
+            },
+            "label": {"type": "plain_text", "text": "Impact Type"},
+        },
+        {
+            "type": "input",
+            "block_id": "affected_service_block",
+            "optional": True,
+            "element": {
+                "type": "multi_external_select",
+                "action_id": "affected_service_tags",
+                "min_query_length": 0,
+                "placeholder": {
+                    "type": "plain_text",
+                    "text": "Select affected services",
+                },
+            },
+            "label": {"type": "plain_text", "text": "Affected Service"},
+        },
+        {
+            "type": "input",
+            "block_id": "affected_region_block",
+            "optional": True,
+            "element": {
+                "type": "multi_external_select",
+                "action_id": "affected_region_tags",
+                "min_query_length": 0,
+                "placeholder": {
+                    "type": "plain_text",
+                    "text": "Select affected regions",
+                },
+            },
+            "label": {"type": "plain_text", "text": "Affected Region"},
+        },
+    ]
+
+
+def parse_incident_form_values(view: dict) -> dict[str, Any]:
+    values = view.get("state", {}).get("values", {})
+
+    title = values.get("title_block", {}).get("title", {}).get("value", "").strip()
+    severity = (
+        values.get("severity_block", {})
+        .get("severity", {})
+        .get("selected_option", {})
+        .get("value", _DEFAULT_SEVERITY.value)
+    )
+    description = (
+        values.get("description_block", {}).get("description", {}).get("value") or ""
+    )
+    impact_summary = (
+        values.get("impact_summary_block", {}).get("impact_summary", {}).get("value")
+        or ""
+    )
+
+    impact_type_selections = (
+        values.get("impact_type_block", {})
+        .get("impact_type_tags", {})
+        .get("selected_options")
+        or []
+    )
+    impact_type_tags = [opt["value"] for opt in impact_type_selections]
+
+    affected_service_selections = (
+        values.get("affected_service_block", {})
+        .get("affected_service_tags", {})
+        .get("selected_options")
+        or []
+    )
+    affected_service_tags = [opt["value"] for opt in affected_service_selections]
+
+    affected_region_selections = (
+        values.get("affected_region_block", {})
+        .get("affected_region_tags", {})
+        .get("selected_options")
+        or []
+    )
+    affected_region_tags = [opt["value"] for opt in affected_region_selections]
+
+    captain_slack_id = (
+        values.get("captain_block", {}).get("captain_select", {}).get("selected_user")
+    )
+
+    return {
+        "title": title,
+        "severity": severity,
+        "description": description,
+        "impact_summary": impact_summary,
+        "impact_type_tags": impact_type_tags,
+        "affected_service_tags": affected_service_tags,
+        "affected_region_tags": affected_region_tags,
+        "captain_slack_id": captain_slack_id,
+    }

--- a/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
+++ b/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
@@ -114,20 +114,18 @@ class TestBackfillCommand:
         ack = MagicMock()
         body = {
             "trigger_id": "T12345",
-            "text": "backfill <#C_ARG|inc-2050>",
+            "text": "backfill <#CARG12345|inc-2050>",
             "channel_id": "C_OTHER",
             "user_id": "U_TEST",
         }
-        command = {"command": "/ft", "text": "backfill <#C_ARG|inc-2050>"}
+        command = {"command": "/ft", "text": "backfill <#CARG12345|inc-2050>"}
         respond = MagicMock()
 
-        with patch(
-            "firetower.slack_app.handlers.backfill_incident.get_bolt_app"
-        ) as mock_app:
+        with patch("firetower.slack_app.bolt.get_bolt_app") as mock_app:
             handle_backfill_command(ack, body, command, respond)
             mock_app.return_value.client.views_open.assert_called_once()
             view = mock_app.return_value.client.views_open.call_args[1]["view"]
-            assert view["private_metadata"] == "C_ARG"
+            assert view["private_metadata"] == "CARG12345"
 
     def test_no_channel_responds_with_usage(self):
         ack = MagicMock()
@@ -156,7 +154,7 @@ class TestBackfillSubmission:
             type=ExternalProfileType.SLACK,
             external_id="U_TEST",
         )
-        IncidentCounter.objects.create(pk=1, next_id=2050)
+        IncidentCounter.objects.update_or_create(pk=1, defaults={"next_id": 2050})
 
     def _build_view(self, channel_id="C_TEST", title="Test Backfill"):
         return {
@@ -310,18 +308,21 @@ class TestBackfillSubmission:
         )
         mock_slack_svc.join_channel.return_value = True
 
+        def channel_info_matching_incident(channel_id):
+            incident = Incident.objects.get(title="Test Backfill")
+            return {
+                "id": channel_id,
+                "name": f"inc-{incident.id}",
+                "is_private": False,
+            }
+
+        mock_slack_svc.get_channel_info.side_effect = channel_info_matching_incident
+
         ack = MagicMock()
         client = MagicMock()
         body = {"user": {"id": "U_TEST"}}
 
         handle_backfill_submission(ack, body, self._build_view(), client)
-
-        incident = Incident.objects.get(title="Test Backfill")
-        mock_slack_svc.get_channel_info.return_value = {
-            "id": "C_TEST",
-            "name": f"inc-{incident.id}",
-            "is_private": False,
-        }
 
         mock_slack_svc.rename_channel.assert_not_called()
 

--- a/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
+++ b/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
@@ -5,7 +5,6 @@ from django.contrib.auth.models import User
 
 from firetower.auth.models import ExternalProfile, ExternalProfileType
 from firetower.incidents.models import (
-    INCIDENT_ID_START,
     ExternalLink,
     ExternalLinkType,
     Incident,
@@ -16,7 +15,6 @@ from firetower.slack_app.bolt import handle_command
 from firetower.slack_app.handlers.backfill_incident import (
     _expected_channel_name,
     _parse_channel_id_from_args,
-    _peek_next_incident_id,
     handle_backfill_command,
     handle_backfill_submission,
 )
@@ -47,17 +45,6 @@ class TestExpectedChannelName:
 
 
 @pytest.mark.django_db
-class TestPeekNextIncidentId:
-    def test_returns_counter_value(self):
-        IncidentCounter.objects.create(pk=1, next_id=2050)
-        assert _peek_next_incident_id() == 2050
-
-    def test_returns_default_when_no_counter(self):
-        IncidentCounter.objects.filter(pk=1).delete()
-        assert _peek_next_incident_id() == INCIDENT_ID_START
-
-
-@pytest.mark.django_db
 class TestBackfillSubcommandRouting:
     def _make_body(self, text="", command="/ft"):
         return {"text": text, "command": command}
@@ -65,19 +52,9 @@ class TestBackfillSubcommandRouting:
     def _make_command(self, command="/ft", text=""):
         return {"command": command, "text": text}
 
-    @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
     @patch("firetower.slack_app.bolt.get_bolt_app")
     @patch("firetower.slack_app.bolt.statsd")
-    def test_backfill_routes_correctly(
-        self, mock_statsd, mock_get_bolt_app, mock_slack_svc
-    ):
-        IncidentCounter.objects.create(pk=1, next_id=2050)
-        mock_slack_svc.get_channel_info.return_value = {
-            "id": "C_TEST",
-            "name": "inc-2050",
-            "is_private": False,
-        }
-
+    def test_backfill_routes_correctly(self, mock_statsd, mock_get_bolt_app):
         ack = MagicMock()
         respond = MagicMock()
         body = self._make_body(text="backfill")
@@ -94,18 +71,8 @@ class TestBackfillSubcommandRouting:
 
 @pytest.mark.django_db
 class TestBackfillCommand:
-    def setup_method(self):
-        IncidentCounter.objects.create(pk=1, next_id=2050)
-
-    @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
     @patch("firetower.slack_app.bolt.get_bolt_app")
-    def test_opens_modal_when_channel_matches(self, mock_get_bolt_app, mock_slack_svc):
-        mock_slack_svc.get_channel_info.return_value = {
-            "id": "C_TEST",
-            "name": "inc-2050",
-            "is_private": False,
-        }
-
+    def test_opens_modal(self, mock_get_bolt_app):
         ack = MagicMock()
         body = {"trigger_id": "T12345", "channel_id": "C_TEST", "user_id": "U_TEST"}
         command = {"command": "/ft", "text": "backfill"}
@@ -118,34 +85,7 @@ class TestBackfillCommand:
         view = mock_get_bolt_app.return_value.client.views_open.call_args[1]["view"]
         assert view["callback_id"] == "backfill_incident_modal"
 
-    @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
-    def test_rejects_mismatched_channel_name(self, mock_slack_svc):
-        mock_slack_svc.get_channel_info.return_value = {
-            "id": "C_TEST",
-            "name": "wrong-channel",
-            "is_private": False,
-        }
-
-        ack = MagicMock()
-        body = {"channel_id": "C_TEST"}
-        command = {"command": "/ft", "text": "backfill"}
-        respond = MagicMock()
-
-        handle_backfill_command(ack, body, command, respond)
-
-        respond.assert_called_once()
-        msg = respond.call_args[0][0]
-        assert "does not match" in msg
-        assert "inc-2050" in msg
-
-    @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
-    def test_rejects_already_linked_channel(self, mock_slack_svc):
-        mock_slack_svc.get_channel_info.return_value = {
-            "id": "C_EXISTING",
-            "name": "inc-2050",
-            "is_private": False,
-        }
-
+    def test_rejects_already_linked_channel(self):
         user = User.objects.create_user(
             username="test@example.com", email="test@example.com"
         )
@@ -170,14 +110,7 @@ class TestBackfillCommand:
         msg = respond.call_args[0][0]
         assert "already linked" in msg
 
-    @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
-    def test_channel_from_args(self, mock_slack_svc):
-        mock_slack_svc.get_channel_info.return_value = {
-            "id": "C_ARG",
-            "name": "inc-2050",
-            "is_private": False,
-        }
-
+    def test_channel_from_args(self):
         ack = MagicMock()
         body = {
             "trigger_id": "T12345",
@@ -196,8 +129,7 @@ class TestBackfillCommand:
             view = mock_app.return_value.client.views_open.call_args[1]["view"]
             assert view["private_metadata"] == "C_ARG"
 
-    @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
-    def test_no_channel_responds_with_usage(self, mock_slack_svc):
+    def test_no_channel_responds_with_usage(self):
         ack = MagicMock()
         body = {"channel_id": ""}
         command = {"command": "/ft", "text": "backfill"}
@@ -327,13 +259,16 @@ class TestBackfillSubmission:
         msg = client.chat_postMessage.call_args[1]["text"]
         assert "could not join" in msg
 
+    @patch(
+        "firetower.slack_app.handlers.backfill_incident.sync_incident_participants_from_slack"
+    )
     @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
     @patch(
         "firetower.slack_app.handlers.backfill_incident.get_or_create_user_from_slack_id"
     )
     @patch("firetower.incidents.serializers.on_incident_created")
-    def test_channel_name_race_warns_user(
-        self, mock_hook, mock_get_user, mock_slack_svc
+    def test_renames_channel_when_name_does_not_match(
+        self, mock_hook, mock_get_user, mock_slack_svc, mock_sync
     ):
         mock_get_user.return_value = self.user
         mock_slack_svc.build_channel_url.return_value = (
@@ -341,9 +276,11 @@ class TestBackfillSubmission:
         )
         mock_slack_svc.get_channel_info.return_value = {
             "id": "C_TEST",
-            "name": "inc-2049",
+            "name": "wrong-name",
             "is_private": False,
         }
+        mock_slack_svc.join_channel.return_value = True
+        mock_slack_svc.rename_channel.return_value = True
 
         ack = MagicMock()
         client = MagicMock()
@@ -351,9 +288,42 @@ class TestBackfillSubmission:
 
         handle_backfill_submission(ack, body, self._build_view(), client)
 
-        client.chat_postMessage.assert_called_once()
-        msg = client.chat_postMessage.call_args[1]["text"]
-        assert "no longer matches" in msg
+        incident = Incident.objects.get(title="Test Backfill")
+        expected_name = f"inc-{incident.id}"
+        mock_slack_svc.rename_channel.assert_called_once_with("C_TEST", expected_name)
+        mock_slack_svc.set_channel_topic.assert_called_once()
+
+    @patch(
+        "firetower.slack_app.handlers.backfill_incident.sync_incident_participants_from_slack"
+    )
+    @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
+    @patch(
+        "firetower.slack_app.handlers.backfill_incident.get_or_create_user_from_slack_id"
+    )
+    @patch("firetower.incidents.serializers.on_incident_created")
+    def test_skips_rename_when_name_already_matches(
+        self, mock_hook, mock_get_user, mock_slack_svc, mock_sync
+    ):
+        mock_get_user.return_value = self.user
+        mock_slack_svc.build_channel_url.return_value = (
+            "https://T0000.slack.com/archives/C_TEST"
+        )
+        mock_slack_svc.join_channel.return_value = True
+
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_TEST"}}
+
+        handle_backfill_submission(ack, body, self._build_view(), client)
+
+        incident = Incident.objects.get(title="Test Backfill")
+        mock_slack_svc.get_channel_info.return_value = {
+            "id": "C_TEST",
+            "name": f"inc-{incident.id}",
+            "is_private": False,
+        }
+
+        mock_slack_svc.rename_channel.assert_not_called()
 
     def test_empty_title_returns_modal_error(self):
         ack = MagicMock()

--- a/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
+++ b/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
@@ -106,13 +106,20 @@ class TestBackfillCommand:
         msg = respond.call_args[0][0]
         assert "only allowed on incident channels" in msg
 
+    @patch(
+        "firetower.slack_app.handlers.backfill_incident.sync_incident_participants_from_slack"
+    )
     @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
-    def test_rejects_already_linked_channel(self, mock_slack_svc):
+    @patch("firetower.slack_app.bolt.get_bolt_app")
+    def test_retries_setup_on_already_linked_channel(
+        self, mock_get_bolt_app, mock_slack_svc, mock_sync
+    ):
         mock_slack_svc.get_channel_info.return_value = {
             "id": "C_EXISTING",
             "name": "inc-1234",
             "is_private": False,
         }
+        mock_slack_svc.join_channel.return_value = True
         user = User.objects.create_user(
             username="test@example.com", email="test@example.com"
         )
@@ -127,7 +134,7 @@ class TestBackfillCommand:
         )
 
         ack = MagicMock()
-        body = {"channel_id": "C_EXISTING"}
+        body = {"channel_id": "C_EXISTING", "user_id": "U_TEST"}
         command = {"command": "/ft", "text": "backfill"}
         respond = MagicMock()
 
@@ -136,6 +143,10 @@ class TestBackfillCommand:
         respond.assert_called_once()
         msg = respond.call_args[0][0]
         assert "already linked" in msg
+        assert "Retrying channel setup" in msg
+        mock_slack_svc.join_channel.assert_called_once_with("C_EXISTING")
+        mock_slack_svc.set_channel_topic.assert_called_once()
+        mock_slack_svc.add_bookmark.assert_called_once()
 
     @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
     def test_channel_from_args(self, mock_slack_svc):
@@ -288,6 +299,7 @@ class TestBackfillSubmission:
         client.chat_postMessage.assert_called_once()
         msg = client.chat_postMessage.call_args[1]["text"]
         assert "could not join" in msg
+        assert "/ft backfill" in msg
 
     @patch(
         "firetower.slack_app.handlers.backfill_incident.sync_incident_participants_from_slack"

--- a/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
+++ b/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
@@ -352,10 +352,14 @@ class TestBackfillSubmission:
         mock_slack_svc.join_channel.return_value = True
 
         def channel_info_matching_incident(channel_id):
-            incident = Incident.objects.get(title="Test Backfill")
+            try:
+                incident = Incident.objects.get(title="Test Backfill")
+                name = f"inc-{incident.id}"
+            except Incident.DoesNotExist:
+                name = "inc-unknown"
             return {
                 "id": channel_id,
-                "name": f"inc-{incident.id}",
+                "name": name,
                 "is_private": False,
             }
 

--- a/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
+++ b/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
@@ -52,9 +52,17 @@ class TestBackfillSubcommandRouting:
     def _make_command(self, command="/ft", text=""):
         return {"command": command, "text": text}
 
+    @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
     @patch("firetower.slack_app.bolt.get_bolt_app")
     @patch("firetower.slack_app.bolt.statsd")
-    def test_backfill_routes_correctly(self, mock_statsd, mock_get_bolt_app):
+    def test_backfill_routes_correctly(
+        self, mock_statsd, mock_get_bolt_app, mock_slack_svc
+    ):
+        mock_slack_svc.get_channel_info.return_value = {
+            "id": "C_TEST",
+            "name": "inc-2050",
+            "is_private": False,
+        }
         ack = MagicMock()
         respond = MagicMock()
         body = self._make_body(text="backfill")
@@ -72,7 +80,13 @@ class TestBackfillSubcommandRouting:
 @pytest.mark.django_db
 class TestBackfillCommand:
     @patch("firetower.slack_app.bolt.get_bolt_app")
-    def test_opens_modal(self, mock_get_bolt_app):
+    @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
+    def test_opens_modal(self, mock_slack_svc, mock_get_bolt_app):
+        mock_slack_svc.get_channel_info.return_value = {
+            "id": "C_TEST",
+            "name": "inc-2050",
+            "is_private": False,
+        }
         ack = MagicMock()
         body = {"trigger_id": "T12345", "channel_id": "C_TEST", "user_id": "U_TEST"}
         command = {"command": "/ft", "text": "backfill"}
@@ -85,7 +99,31 @@ class TestBackfillCommand:
         view = mock_get_bolt_app.return_value.client.views_open.call_args[1]["view"]
         assert view["callback_id"] == "backfill_incident_modal"
 
-    def test_rejects_already_linked_channel(self):
+    @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
+    def test_rejects_non_incident_channel(self, mock_slack_svc):
+        mock_slack_svc.get_channel_info.return_value = {
+            "id": "C_RANDOM",
+            "name": "random-channel",
+            "is_private": False,
+        }
+        ack = MagicMock()
+        body = {"channel_id": "C_RANDOM"}
+        command = {"command": "/ft", "text": "backfill"}
+        respond = MagicMock()
+
+        handle_backfill_command(ack, body, command, respond)
+
+        respond.assert_called_once()
+        msg = respond.call_args[0][0]
+        assert "only allowed on incident channels" in msg
+
+    @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
+    def test_rejects_already_linked_channel(self, mock_slack_svc):
+        mock_slack_svc.get_channel_info.return_value = {
+            "id": "C_EXISTING",
+            "name": "inc-1234",
+            "is_private": False,
+        }
         user = User.objects.create_user(
             username="test@example.com", email="test@example.com"
         )
@@ -110,7 +148,13 @@ class TestBackfillCommand:
         msg = respond.call_args[0][0]
         assert "already linked" in msg
 
-    def test_channel_from_args(self):
+    @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
+    def test_channel_from_args(self, mock_slack_svc):
+        mock_slack_svc.get_channel_info.return_value = {
+            "id": "CARG12345",
+            "name": "inc-2050",
+            "is_private": False,
+        }
         ack = MagicMock()
         body = {
             "trigger_id": "T12345",

--- a/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
+++ b/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
@@ -342,6 +342,47 @@ class TestBackfillSubmission:
         "firetower.slack_app.handlers.backfill_incident.get_or_create_user_from_slack_id"
     )
     @patch("firetower.incidents.serializers.on_incident_created")
+    def test_rename_failure_posts_in_channel(
+        self, mock_hook, mock_get_user, mock_slack_svc, mock_sync
+    ):
+        mock_get_user.return_value = self.user
+        mock_slack_svc.build_channel_url.return_value = (
+            "https://T0000.slack.com/archives/C_TEST"
+        )
+        mock_slack_svc.get_channel_info.return_value = {
+            "id": "C_TEST",
+            "name": "wrong-name",
+            "is_private": False,
+        }
+        mock_slack_svc.join_channel.return_value = True
+        mock_slack_svc.rename_channel.return_value = False
+
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_TEST"}}
+
+        handle_backfill_submission(ack, body, self._build_view(), client)
+
+        incident = Incident.objects.get(title="Test Backfill")
+        expected_name = f"inc-{incident.id}"
+        mock_slack_svc.rename_channel.assert_called_once_with("C_TEST", expected_name)
+        rename_msg_call = [
+            c
+            for c in client.chat_postMessage.call_args_list
+            if c[1].get("channel") == "C_TEST"
+            and "could not rename" in c[1].get("text", "")
+        ]
+        assert len(rename_msg_call) == 1
+        assert expected_name in rename_msg_call[0][1]["text"]
+
+    @patch(
+        "firetower.slack_app.handlers.backfill_incident.sync_incident_participants_from_slack"
+    )
+    @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
+    @patch(
+        "firetower.slack_app.handlers.backfill_incident.get_or_create_user_from_slack_id"
+    )
+    @patch("firetower.incidents.serializers.on_incident_created")
     def test_skips_rename_when_name_already_matches(
         self, mock_hook, mock_get_user, mock_slack_svc, mock_sync
     ):

--- a/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
+++ b/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
@@ -211,7 +211,6 @@ class TestBackfillSubmission:
                     },
                     "description_block": {"description": {"value": "Backfill desc"}},
                     "impact_summary_block": {"impact_summary": {"value": ""}},
-                    "private_block": {"is_private": {"selected_options": []}},
                 }
             },
         }

--- a/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
+++ b/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
@@ -13,7 +13,6 @@ from firetower.incidents.models import (
 )
 from firetower.slack_app.bolt import handle_command
 from firetower.slack_app.handlers.backfill_incident import (
-    _expected_channel_name,
     _parse_channel_id_from_args,
     handle_backfill_command,
     handle_backfill_submission,
@@ -32,16 +31,6 @@ class TestParseChannelIdFromArgs:
 
     def test_empty_string(self):
         assert _parse_channel_id_from_args("") is None
-
-
-class TestExpectedChannelName:
-    def test_formats_correctly(self, settings):
-        settings.PROJECT_KEY = "INC"
-        assert _expected_channel_name(2042) == "inc-2042"
-
-    def test_lowercase(self, settings):
-        settings.PROJECT_KEY = "FIRE"
-        assert _expected_channel_name(100) == "fire-100"
 
 
 @pytest.mark.django_db

--- a/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
+++ b/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
@@ -415,6 +415,33 @@ class TestBackfillSubmission:
 
         mock_slack_svc.rename_channel.assert_not_called()
 
+    @patch(
+        "firetower.slack_app.handlers.backfill_incident.sync_incident_participants_from_slack"
+    )
+    @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
+    @patch(
+        "firetower.slack_app.handlers.backfill_incident.get_or_create_user_from_slack_id"
+    )
+    @patch("firetower.incidents.serializers.on_incident_created")
+    def test_defaults_to_private_when_channel_info_unavailable(
+        self, mock_hook, mock_get_user, mock_slack_svc, mock_sync
+    ):
+        mock_get_user.return_value = self.user
+        mock_slack_svc.build_channel_url.return_value = (
+            "https://T0000.slack.com/archives/C_TEST"
+        )
+        mock_slack_svc.get_channel_info.return_value = None
+        mock_slack_svc.join_channel.return_value = True
+
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_TEST"}}
+
+        handle_backfill_submission(ack, body, self._build_view(), client)
+
+        incident = Incident.objects.get(title="Test Backfill")
+        assert incident.is_private is True
+
     def test_empty_title_returns_modal_error(self):
         ack = MagicMock()
         client = MagicMock()

--- a/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
+++ b/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
@@ -1,0 +1,385 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.contrib.auth.models import User
+
+from firetower.auth.models import ExternalProfile, ExternalProfileType
+from firetower.incidents.models import (
+    INCIDENT_ID_START,
+    ExternalLink,
+    ExternalLinkType,
+    Incident,
+    IncidentCounter,
+    IncidentSeverity,
+)
+from firetower.slack_app.bolt import handle_command
+from firetower.slack_app.handlers.backfill_incident import (
+    _expected_channel_name,
+    _parse_channel_id_from_args,
+    _peek_next_incident_id,
+    handle_backfill_command,
+    handle_backfill_submission,
+)
+
+
+class TestParseChannelIdFromArgs:
+    def test_slack_channel_mention(self):
+        assert _parse_channel_id_from_args("<#C12345ABC|general>") == "C12345ABC"
+
+    def test_raw_channel_id(self):
+        assert _parse_channel_id_from_args("C12345ABC") == "C12345ABC"
+
+    def test_no_channel(self):
+        assert _parse_channel_id_from_args("some random text") is None
+
+    def test_empty_string(self):
+        assert _parse_channel_id_from_args("") is None
+
+
+class TestExpectedChannelName:
+    def test_formats_correctly(self, settings):
+        settings.PROJECT_KEY = "INC"
+        assert _expected_channel_name(2042) == "inc-2042"
+
+    def test_lowercase(self, settings):
+        settings.PROJECT_KEY = "FIRE"
+        assert _expected_channel_name(100) == "fire-100"
+
+
+@pytest.mark.django_db
+class TestPeekNextIncidentId:
+    def test_returns_counter_value(self):
+        IncidentCounter.objects.create(pk=1, next_id=2050)
+        assert _peek_next_incident_id() == 2050
+
+    def test_returns_default_when_no_counter(self):
+        IncidentCounter.objects.filter(pk=1).delete()
+        assert _peek_next_incident_id() == INCIDENT_ID_START
+
+
+@pytest.mark.django_db
+class TestBackfillSubcommandRouting:
+    def _make_body(self, text="", command="/ft"):
+        return {"text": text, "command": command}
+
+    def _make_command(self, command="/ft", text=""):
+        return {"command": command, "text": text}
+
+    @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
+    @patch("firetower.slack_app.bolt.get_bolt_app")
+    @patch("firetower.slack_app.bolt.statsd")
+    def test_backfill_routes_correctly(
+        self, mock_statsd, mock_get_bolt_app, mock_slack_svc
+    ):
+        IncidentCounter.objects.create(pk=1, next_id=2050)
+        mock_slack_svc.get_channel_info.return_value = {
+            "id": "C_TEST",
+            "name": "inc-2050",
+            "is_private": False,
+        }
+
+        ack = MagicMock()
+        respond = MagicMock()
+        body = self._make_body(text="backfill")
+        body["trigger_id"] = "T12345"
+        body["channel_id"] = "C_TEST"
+        body["user_id"] = "U_TEST"
+        command = self._make_command()
+
+        handle_command(ack=ack, body=body, command=command, respond=respond)
+
+        ack.assert_called_once()
+        mock_get_bolt_app.return_value.client.views_open.assert_called_once()
+
+
+@pytest.mark.django_db
+class TestBackfillCommand:
+    def setup_method(self):
+        IncidentCounter.objects.create(pk=1, next_id=2050)
+
+    @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
+    @patch("firetower.slack_app.bolt.get_bolt_app")
+    def test_opens_modal_when_channel_matches(self, mock_get_bolt_app, mock_slack_svc):
+        mock_slack_svc.get_channel_info.return_value = {
+            "id": "C_TEST",
+            "name": "inc-2050",
+            "is_private": False,
+        }
+
+        ack = MagicMock()
+        body = {"trigger_id": "T12345", "channel_id": "C_TEST", "user_id": "U_TEST"}
+        command = {"command": "/ft", "text": "backfill"}
+        respond = MagicMock()
+
+        handle_backfill_command(ack, body, command, respond)
+
+        ack.assert_called_once()
+        mock_get_bolt_app.return_value.client.views_open.assert_called_once()
+        view = mock_get_bolt_app.return_value.client.views_open.call_args[1]["view"]
+        assert view["callback_id"] == "backfill_incident_modal"
+
+    @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
+    def test_rejects_mismatched_channel_name(self, mock_slack_svc):
+        mock_slack_svc.get_channel_info.return_value = {
+            "id": "C_TEST",
+            "name": "wrong-channel",
+            "is_private": False,
+        }
+
+        ack = MagicMock()
+        body = {"channel_id": "C_TEST"}
+        command = {"command": "/ft", "text": "backfill"}
+        respond = MagicMock()
+
+        handle_backfill_command(ack, body, command, respond)
+
+        respond.assert_called_once()
+        msg = respond.call_args[0][0]
+        assert "does not match" in msg
+        assert "inc-2050" in msg
+
+    @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
+    def test_rejects_already_linked_channel(self, mock_slack_svc):
+        mock_slack_svc.get_channel_info.return_value = {
+            "id": "C_EXISTING",
+            "name": "inc-2050",
+            "is_private": False,
+        }
+
+        user = User.objects.create_user(
+            username="test@example.com", email="test@example.com"
+        )
+        inc = Incident(
+            title="Existing", severity=IncidentSeverity.P2, captain=user, reporter=user
+        )
+        inc.save()
+        ExternalLink.objects.create(
+            incident=inc,
+            type=ExternalLinkType.SLACK,
+            url="https://T0000.slack.com/archives/C_EXISTING",
+        )
+
+        ack = MagicMock()
+        body = {"channel_id": "C_EXISTING"}
+        command = {"command": "/ft", "text": "backfill"}
+        respond = MagicMock()
+
+        handle_backfill_command(ack, body, command, respond)
+
+        respond.assert_called_once()
+        msg = respond.call_args[0][0]
+        assert "already linked" in msg
+
+    @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
+    def test_channel_from_args(self, mock_slack_svc):
+        mock_slack_svc.get_channel_info.return_value = {
+            "id": "C_ARG",
+            "name": "inc-2050",
+            "is_private": False,
+        }
+
+        ack = MagicMock()
+        body = {
+            "trigger_id": "T12345",
+            "text": "backfill <#C_ARG|inc-2050>",
+            "channel_id": "C_OTHER",
+            "user_id": "U_TEST",
+        }
+        command = {"command": "/ft", "text": "backfill <#C_ARG|inc-2050>"}
+        respond = MagicMock()
+
+        with patch(
+            "firetower.slack_app.handlers.backfill_incident.get_bolt_app"
+        ) as mock_app:
+            handle_backfill_command(ack, body, command, respond)
+            mock_app.return_value.client.views_open.assert_called_once()
+            view = mock_app.return_value.client.views_open.call_args[1]["view"]
+            assert view["private_metadata"] == "C_ARG"
+
+    @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
+    def test_no_channel_responds_with_usage(self, mock_slack_svc):
+        ack = MagicMock()
+        body = {"channel_id": ""}
+        command = {"command": "/ft", "text": "backfill"}
+        respond = MagicMock()
+
+        handle_backfill_command(ack, body, command, respond)
+
+        respond.assert_called_once()
+        msg = respond.call_args[0][0]
+        assert "Could not determine channel" in msg
+
+
+@pytest.mark.django_db
+class TestBackfillSubmission:
+    def setup_method(self):
+        self.user = User.objects.create_user(
+            username="test@example.com",
+            email="test@example.com",
+            first_name="Test",
+            last_name="User",
+        )
+        ExternalProfile.objects.create(
+            user=self.user,
+            type=ExternalProfileType.SLACK,
+            external_id="U_TEST",
+        )
+        IncidentCounter.objects.create(pk=1, next_id=2050)
+
+    def _build_view(self, channel_id="C_TEST", title="Test Backfill"):
+        return {
+            "private_metadata": channel_id,
+            "state": {
+                "values": {
+                    "title_block": {"title": {"value": title}},
+                    "severity_block": {
+                        "severity": {"selected_option": {"value": "P2"}}
+                    },
+                    "description_block": {"description": {"value": "Backfill desc"}},
+                    "impact_summary_block": {"impact_summary": {"value": ""}},
+                    "private_block": {"is_private": {"selected_options": []}},
+                }
+            },
+        }
+
+    @patch(
+        "firetower.slack_app.handlers.backfill_incident.sync_incident_participants_from_slack"
+    )
+    @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
+    @patch(
+        "firetower.slack_app.handlers.backfill_incident.get_or_create_user_from_slack_id"
+    )
+    @patch("firetower.incidents.serializers.on_incident_created")
+    def test_creates_incident_and_links_channel(
+        self, mock_hook, mock_get_user, mock_slack_svc, mock_sync
+    ):
+        mock_get_user.return_value = self.user
+        mock_slack_svc.build_channel_url.return_value = (
+            "https://T0000.slack.com/archives/C_TEST"
+        )
+        mock_slack_svc.get_channel_info.return_value = {
+            "id": "C_TEST",
+            "name": "inc-2050",
+            "is_private": False,
+        }
+        mock_slack_svc.join_channel.return_value = True
+
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_TEST"}}
+
+        handle_backfill_submission(ack, body, self._build_view(), client)
+
+        ack.assert_called_once_with()
+        incident = Incident.objects.get(title="Test Backfill")
+        assert incident.severity == IncidentSeverity.P2
+        assert incident.captain == self.user
+        assert incident.reporter == self.user
+
+        slack_link = ExternalLink.objects.get(
+            incident=incident, type=ExternalLinkType.SLACK
+        )
+        assert "C_TEST" in slack_link.url
+
+        mock_hook.assert_not_called()
+        mock_slack_svc.join_channel.assert_called_once_with("C_TEST")
+        mock_slack_svc.set_channel_topic.assert_called_once()
+        mock_slack_svc.add_bookmark.assert_called_once()
+        mock_sync.assert_called_once_with(incident, force=True)
+
+    @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
+    @patch(
+        "firetower.slack_app.handlers.backfill_incident.get_or_create_user_from_slack_id"
+    )
+    @patch("firetower.incidents.serializers.on_incident_created")
+    def test_bot_cant_join_still_creates_incident(
+        self, mock_hook, mock_get_user, mock_slack_svc
+    ):
+        mock_get_user.return_value = self.user
+        mock_slack_svc.build_channel_url.return_value = (
+            "https://T0000.slack.com/archives/C_TEST"
+        )
+        mock_slack_svc.get_channel_info.return_value = {
+            "id": "C_TEST",
+            "name": "inc-2050",
+            "is_private": False,
+        }
+        mock_slack_svc.join_channel.return_value = False
+
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_TEST"}}
+
+        handle_backfill_submission(ack, body, self._build_view(), client)
+
+        incident = Incident.objects.get(title="Test Backfill")
+        assert incident is not None
+
+        slack_link = ExternalLink.objects.get(
+            incident=incident, type=ExternalLinkType.SLACK
+        )
+        assert slack_link is not None
+
+        mock_slack_svc.set_channel_topic.assert_not_called()
+        mock_slack_svc.add_bookmark.assert_not_called()
+
+        client.chat_postMessage.assert_called_once()
+        msg = client.chat_postMessage.call_args[1]["text"]
+        assert "could not join" in msg
+
+    @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
+    @patch(
+        "firetower.slack_app.handlers.backfill_incident.get_or_create_user_from_slack_id"
+    )
+    @patch("firetower.incidents.serializers.on_incident_created")
+    def test_channel_name_race_warns_user(
+        self, mock_hook, mock_get_user, mock_slack_svc
+    ):
+        mock_get_user.return_value = self.user
+        mock_slack_svc.build_channel_url.return_value = (
+            "https://T0000.slack.com/archives/C_TEST"
+        )
+        mock_slack_svc.get_channel_info.return_value = {
+            "id": "C_TEST",
+            "name": "inc-2049",
+            "is_private": False,
+        }
+
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_TEST"}}
+
+        handle_backfill_submission(ack, body, self._build_view(), client)
+
+        client.chat_postMessage.assert_called_once()
+        msg = client.chat_postMessage.call_args[1]["text"]
+        assert "no longer matches" in msg
+
+    def test_empty_title_returns_modal_error(self):
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_TEST"}}
+
+        handle_backfill_submission(ack, body, self._build_view(title=""), client)
+
+        ack.assert_called_once()
+        call_kwargs = ack.call_args[1]
+        assert call_kwargs["response_action"] == "errors"
+        client.chat_postMessage.assert_not_called()
+
+    @patch(
+        "firetower.slack_app.handlers.backfill_incident.get_or_create_user_from_slack_id"
+    )
+    def test_unknown_user_sends_dm(self, mock_get_user):
+        mock_get_user.return_value = None
+
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_UNKNOWN"}}
+
+        handle_backfill_submission(ack, body, self._build_view(), client)
+
+        ack.assert_called_once_with()
+        client.chat_postMessage.assert_called_once()
+        msg = client.chat_postMessage.call_args[1]["text"]
+        assert "Could not identify" in msg


### PR DESCRIPTION
When Firetower is down and an incident Slack channel has to be created manually, there's no way to retroactively create the matching incident record. This adds a `/ft backfill` command to fill that gap.

**How it works:**

- Run `/ft backfill` from the manually-created incident channel (auto-detects channel), or `/ft backfill #channel` from anywhere
- Opens the same modal as `/ft new` (captain, severity, title, description, impact summary, tags, visibility)
- Creates the incident with all hooks skipped -- no PagerDuty paging, no Datadog notebook, no Notion doc, no feed notification, no status channel
- Bot joins the channel, renames it to match the assigned incident ID (e.g., `inc-2050`), sets topic with Firetower link, adds bookmark
- Syncs channel members as incident participants immediately

**Changes:**

- `backfill_incident.py` -- new handler with modal, channel rename, incident creation
- `slack.py` -- added `get_channel_info()` and `rename_channel()` methods
- `serializers.py` -- added `skip_hooks` context flag to `IncidentWriteSerializer.create()`
- `bolt.py` -- registered `backfill` subcommand and modal view handler
- `help.py` -- added backfill to help output
- `test_backfill_incident.py` -- 17 tests covering routing, validation, submission, rename, error paths