### PR TITLE
fix(genai): Skip backfilling time_detected from AI-generated timelines

### DIFF
--- a/src/firetower/integrations/services/genai.py
+++ b/src/firetower/integrations/services/genai.py
@@ -72,7 +72,9 @@ def _detect_location() -> str:
 
 _KEY_TIMESTAMPS_LABEL_MAP = {
     "started": "time_started",
-    "detected": "time_detected",
+    # "detected" intentionally omitted: the AI infers detection time from
+    # channel creation, so it always equals time_started.  Skip until we
+    # have a real detection-time signal.
     "analyzed": "time_analyzed",
     "mitigation": "time_mitigated",
     "resolution": "time_recovered",

--- a/src/firetower/integrations/tests/test_genai.py
+++ b/src/firetower/integrations/tests/test_genai.py
@@ -312,7 +312,6 @@ class TestParseKeyTimestamps:
         result = parse_key_timestamps(md)
         assert result == {
             "time_started": datetime(2024, 1, 15, 14, 0, tzinfo=UTC),
-            "time_detected": datetime(2024, 1, 15, 14, 5, tzinfo=UTC),
             "time_analyzed": datetime(2024, 1, 15, 14, 30, tzinfo=UTC),
             "time_mitigated": datetime(2024, 1, 15, 15, 0, tzinfo=UTC),
             "time_recovered": datetime(2024, 1, 15, 16, 0, tzinfo=UTC),
@@ -358,22 +357,22 @@ class TestParseKeyTimestamps:
         md = (
             "## Key Timestamps\n"
             "- Started: 2024-01-15 14:00 UTC\n"
-            "- Detected: 2024-01-15 14:05 UTC\n"
+            "- Analyzed: 2024-01-15 14:05 UTC\n"
         )
         result = parse_key_timestamps(md)
         assert result == {
             "time_started": datetime(2024, 1, 15, 14, 0, tzinfo=UTC),
-            "time_detected": datetime(2024, 1, 15, 14, 5, tzinfo=UTC),
+            "time_analyzed": datetime(2024, 1, 15, 14, 5, tzinfo=UTC),
         }
 
     def test_normalizes_variable_whitespace_in_timestamps(self):
         md = (
             "## Key Timestamps\n"
             "- Started: [2024-01-15  14:00UTC]\n"
-            "- Detected: [2024-01-15 14:05  UTC]\n"
+            "- Analyzed: [2024-01-15 14:05  UTC]\n"
         )
         result = parse_key_timestamps(md)
         assert result == {
             "time_started": datetime(2024, 1, 15, 14, 0, tzinfo=UTC),
-            "time_detected": datetime(2024, 1, 15, 14, 5, tzinfo=UTC),
+            "time_analyzed": datetime(2024, 1, 15, 14, 5, tzinfo=UTC),
         }

--- a/src/firetower/slack_app/tests/handlers/test_dumpslack.py
+++ b/src/firetower/slack_app/tests/handlers/test_dumpslack.py
@@ -606,7 +606,6 @@ class TestBackfillMilestones:
     _TIMELINE_MD = (
         "## Key Timestamps\n"
         "- Started: [2024-01-15 14:00 UTC]\n"
-        "- Detected: [2024-01-15 14:05 UTC]\n"
         "- Analyzed: [2024-01-15 14:30 UTC]\n"
         "- Mitigation: [2024-01-15 15:00 UTC]\n"
         "- Resolution: [2024-01-15 16:00 UTC]\n"
@@ -628,12 +627,11 @@ class TestBackfillMilestones:
                     filter_fields.add(key.replace("__isnull", ""))
         assert filter_fields == {
             "time_started",
-            "time_detected",
             "time_analyzed",
             "time_mitigated",
             "time_recovered",
         }
-        assert mock_objects.filter.return_value.update.call_count == 5
+        assert mock_objects.filter.return_value.update.call_count == 4
 
     @patch("firetower.slack_app.handlers.dumpslack.Incident.objects")
     def test_skips_fields_that_are_not_null(self, mock_objects):
@@ -651,7 +649,7 @@ class TestBackfillMilestones:
 
         _backfill_milestones(incident, self._TIMELINE_MD)
 
-        assert mock_objects.filter.return_value.update.call_count == 5
+        assert mock_objects.filter.return_value.update.call_count == 4
 
     @patch("firetower.slack_app.handlers.dumpslack.Incident.objects")
     def test_no_update_when_all_fields_populated(self, mock_objects):
@@ -662,7 +660,7 @@ class TestBackfillMilestones:
 
         _backfill_milestones(incident, self._TIMELINE_MD)
 
-        assert mock_objects.filter.return_value.update.call_count == 5
+        assert mock_objects.filter.return_value.update.call_count == 4
 
     def test_no_update_when_no_timestamps_parsed(self):
         incident = MagicMock()


### PR DESCRIPTION
The AI-generated timeline infers detection time from the Slack channel creation timestamp, which is identical to `time_started`. This makes `time_detected` misleading in postmortem tickets -- it suggests we know when detection actually happened, but we don't.

Remove the `"detected"` entry from `_KEY_TIMESTAMPS_LABEL_MAP` so `parse_key_timestamps` silently drops the AI's "Detected" line. The mapping can be restored once we have a real detection-time signal (e.g., monitor alert timestamp).

No schema or model changes -- `time_detected` remains on the Incident model and can still be set manually or by a future integration.


Agent transcript: https://claudescope.sentry.dev/share/WbnSQzTgRiswcgESWr5e0FbiyzK7uYxSBGnWAd66czk