### PR TITLE
feat: Annotate oncall roster with (paged) when PagerDuty page succeeds

### DIFF
--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -335,7 +335,11 @@ def _invite_oncall_to_channel(
 
             label = _oncall_role_label(policy_name, policy_label, escalation_level)
             paged_suffix = (
-                " (paged)" if paged_policies and policy_name in paged_policies else ""
+                " (paged)"
+                if paged_policies
+                and policy_name in paged_policies
+                and escalation_level == 1
+                else ""
             )
             sort_level = escalation_level if escalation_level is not None else 999
             role_entries.append(

--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -73,14 +73,19 @@ def page_for_channel(
     links: list[dict[str, str]] | None = None,
     channel_id: str | None = None,
     is_private: bool = False,
-) -> None:
-    """Trigger PD pages for pageable severities. No DB access."""
+) -> set[str]:
+    """Trigger PD pages for pageable severities. No DB access.
+
+    Returns the set of policy names that were successfully paged.
+    """
+    paged: set[str] = set()
+
     if severity not in PAGEABLE_SEVERITIES:
-        return
+        return paged
 
     pd_config = settings.PAGERDUTY
     if not pd_config:
-        return
+        return paged
 
     escalation_policies = pd_config.get("ESCALATION_POLICIES", {})
 
@@ -109,7 +114,7 @@ def page_for_channel(
                 pd_service = PagerDutyService()
             except Exception:
                 logger.exception("Failed to initialize PagerDutyService")
-                return
+                return paged
 
         dedup_key = f"firetower-{dedup_prefix}-{policy_name}"
         page_label = policy_info.page_label
@@ -120,12 +125,9 @@ def page_for_channel(
             success = pd_service.trigger_incident(
                 summary, dedup_key, integration_key, links=links or []
             )
-            if success and channel_id:
-                slack_service.post_message(
-                    channel_id,
-                    f":pager: Paged {page_label} via PagerDuty.",
-                )
-            elif not success and channel_id:
+            if success:
+                paged.add(policy_name)
+            elif channel_id:
                 slack_service.post_message(
                     channel_id,
                     f":warning: Failed to page {page_label} via PagerDuty. Please manually escalate if needed.",
@@ -133,8 +135,10 @@ def page_for_channel(
         except Exception:
             logger.exception(f"Failed to page {policy_name} for {dedup_prefix}")
 
+    return paged
 
-def _page_if_needed(incident: Incident, channel_id: str | None = None) -> None:
+
+def _page_if_needed(incident: Incident, channel_id: str | None = None) -> set[str]:
     links: list[dict[str, str]] = [
         {"href": _build_incident_url(incident), "text": "View in Firetower"}
     ]
@@ -145,7 +149,7 @@ def _page_if_needed(incident: Incident, channel_id: str | None = None) -> None:
                 "text": "Slack Channel",
             }
         )
-    page_for_channel(
+    return page_for_channel(
         incident.severity,
         incident.incident_number,
         incident.title,
@@ -246,6 +250,7 @@ def _invite_oncall_to_channel(
     slack_service: SlackService,
     *,
     is_private: bool = False,
+    paged_policies: set[str] | None = None,
 ) -> None:
     """Invite on-call users to a channel. No DB access."""
     if severity not in PAGEABLE_SEVERITIES:
@@ -329,12 +334,15 @@ def _invite_oncall_to_channel(
             slack_user_id = slack_profile["slack_user_id"]
 
             label = _oncall_role_label(policy_name, policy_label, escalation_level)
+            paged_suffix = (
+                " (paged)" if paged_policies and policy_name in paged_policies else ""
+            )
             sort_level = escalation_level if escalation_level is not None else 999
             role_entries.append(
                 (
                     policy_index,
                     sort_level,
-                    f"{label}: <@{slack_user_id}>",
+                    f"{label}: <@{slack_user_id}>{paged_suffix}",
                 )
             )
             users_to_invite.append((slack_user_id, email))
@@ -357,9 +365,17 @@ def _invite_oncall_to_channel(
             )
 
 
-def _invite_oncall_users(incident: Incident, channel_id: str) -> None:
+def _invite_oncall_users(
+    incident: Incident,
+    channel_id: str,
+    paged_policies: set[str] | None = None,
+) -> None:
     _invite_oncall_to_channel(
-        incident.severity, channel_id, _slack_service, is_private=incident.is_private
+        incident.severity,
+        channel_id,
+        _slack_service,
+        is_private=incident.is_private,
+        paged_policies=paged_policies,
     )
 
 
@@ -690,6 +706,7 @@ def decorate_incident_channel(
     *,
     skip_datadog: bool = False,
     skip_notion: bool = False,
+    paged_policies: set[str] | None = None,
 ) -> None:
     """
     Shared channel setup called by both the normal and fallback creation paths.
@@ -799,7 +816,11 @@ def decorate_incident_channel(
 
     try:
         _invite_oncall_to_channel(
-            ctx.severity, ctx.channel_id, slack_service, is_private=ctx.is_private
+            ctx.severity,
+            ctx.channel_id,
+            slack_service,
+            is_private=ctx.is_private,
+            paged_policies=paged_policies,
         )
     except Exception:
         logger.exception(f"Failed to invite oncall users to {ctx.channel_name}")
@@ -878,8 +899,9 @@ def on_incident_created(incident: Incident) -> None:
     # (already saved above), so the PD payload is complete even if channel_id
     # is None here; channel_id is only used to post a fallback warning back to
     # Slack if PD fails.
+    paged_policies: set[str] = set()
     try:
-        _page_if_needed(incident, channel_id=channel_id)
+        paged_policies = _page_if_needed(incident, channel_id=channel_id)
     except Exception:
         logger.exception(f"Failed to page for incident {incident.id}")
 
@@ -924,7 +946,11 @@ def on_incident_created(incident: Incident) -> None:
             incident_number=incident.incident_number,
         )
         decorate_incident_channel(
-            ctx, _slack_service, skip_datadog=True, skip_notion=True
+            ctx,
+            _slack_service,
+            skip_datadog=True,
+            skip_notion=True,
+            paged_policies=paged_policies,
         )
 
         # DB-dedup Datadog/Notion after shared decoration so the guide message
@@ -988,14 +1014,17 @@ def on_severity_changed(incident: Incident, old_severity: str) -> None:
             logger.exception(f"Failed to get channel id for incident {incident.id}")
             channel_id = None
 
+        paged_policies: set[str] = set()
         try:
-            _page_if_needed(incident, channel_id=channel_id)
+            paged_policies = _page_if_needed(incident, channel_id=channel_id)
         except Exception:
             logger.exception(f"Failed to page for incident {incident.id}")
 
         if channel_id:
             try:
-                _invite_oncall_users(incident, channel_id)
+                _invite_oncall_users(
+                    incident, channel_id, paged_policies=paged_policies
+                )
             except Exception:
                 logger.exception(
                     f"Failed to invite oncall users for incident {incident.id}"

--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -120,7 +120,12 @@ def page_for_channel(
             success = pd_service.trigger_incident(
                 summary, dedup_key, integration_key, links=links or []
             )
-            if not success and channel_id:
+            if success and channel_id:
+                slack_service.post_message(
+                    channel_id,
+                    f":pager: Paged {page_label} via PagerDuty.",
+                )
+            elif not success and channel_id:
                 slack_service.post_message(
                     channel_id,
                     f":warning: Failed to page {page_label} via PagerDuty. Please manually escalate if needed.",

--- a/src/firetower/incidents/tests/test_hooks.py
+++ b/src/firetower/incidents/tests/test_hooks.py
@@ -17,6 +17,7 @@ from firetower.incidents.hooks import (
     on_status_changed,
     on_title_changed,
     on_visibility_changed,
+    page_for_channel,
 )
 from firetower.incidents.models import (
     ExternalLink,
@@ -865,6 +866,69 @@ class TestPageIfNeeded:
 
         mock_pd.trigger_incident.assert_called_once()
         assert "IMOC" in mock_pd.trigger_incident.call_args[0][1]
+
+
+class TestPageForChannelSlackNotification:
+    @patch("firetower.incidents.hooks.PagerDutyService")
+    def test_posts_success_message_on_successful_page(self, mock_pd_cls, settings):
+        settings.PAGERDUTY = MOCK_PD_CONFIG
+        mock_pd = mock_pd_cls.return_value
+        mock_pd.trigger_incident.return_value = True
+        mock_slack = MagicMock()
+
+        page_for_channel(
+            IncidentSeverity.P0,
+            "INC-100",
+            "Major outage",
+            mock_slack,
+            channel_id="C12345",
+        )
+
+        success_calls = [
+            c for c in mock_slack.post_message.call_args_list if ":pager:" in c[0][1]
+        ]
+        assert len(success_calls) == 2
+        assert ":pager: Paged IMOC via PagerDuty." in success_calls[0][0][1]
+        assert ":pager: Paged PE On-Call via PagerDuty." in success_calls[1][0][1]
+
+    @patch("firetower.incidents.hooks.PagerDutyService")
+    def test_posts_failure_message_on_failed_page(self, mock_pd_cls, settings):
+        settings.PAGERDUTY = MOCK_PD_CONFIG
+        mock_pd = mock_pd_cls.return_value
+        mock_pd.trigger_incident.return_value = False
+        mock_slack = MagicMock()
+
+        page_for_channel(
+            IncidentSeverity.P0,
+            "INC-100",
+            "Major outage",
+            mock_slack,
+            channel_id="C12345",
+        )
+
+        warning_calls = [
+            c for c in mock_slack.post_message.call_args_list if ":warning:" in c[0][1]
+        ]
+        assert len(warning_calls) == 2
+        assert "Failed to page IMOC" in warning_calls[0][0][1]
+        assert "Failed to page PE On-Call" in warning_calls[1][0][1]
+
+    @patch("firetower.incidents.hooks.PagerDutyService")
+    def test_no_slack_message_when_channel_id_is_none(self, mock_pd_cls, settings):
+        settings.PAGERDUTY = MOCK_PD_CONFIG
+        mock_pd = mock_pd_cls.return_value
+        mock_pd.trigger_incident.return_value = True
+        mock_slack = MagicMock()
+
+        page_for_channel(
+            IncidentSeverity.P0,
+            "INC-100",
+            "Major outage",
+            mock_slack,
+            channel_id=None,
+        )
+
+        mock_slack.post_message.assert_not_called()
 
 
 @pytest.mark.django_db

--- a/src/firetower/incidents/tests/test_hooks.py
+++ b/src/firetower/incidents/tests/test_hooks.py
@@ -1096,7 +1096,9 @@ class TestOnSeverityChangedPagerDuty:
 
         on_severity_changed(incident, IncidentSeverity.P2)
 
-        mock_invite_oncall.assert_called_once_with(incident, "C12345")
+        mock_invite_oncall.assert_called_once_with(
+            incident, "C12345", paged_policies=mock_page.return_value
+        )
 
     @patch("firetower.incidents.hooks._invite_oncall_users")
     @patch("firetower.incidents.hooks._page_if_needed")

--- a/src/firetower/incidents/tests/test_hooks.py
+++ b/src/firetower/incidents/tests/test_hooks.py
@@ -1781,7 +1781,8 @@ class TestInviteOncallUsers:
         message = mock_slack.post_message.call_args[0][1]
         assert "On-Call Incident Manager: <@U_IMOC> (paged)" in message
         assert "On-Call Prod Eng (Primary): <@U_PRIMARY> (paged)" in message
-        assert "On-Call Prod Eng (Secondary): <@U_SECONDARY> (paged)" in message
+        assert "On-Call Prod Eng (Secondary): <@U_SECONDARY>" in message
+        assert "(paged)" not in message.split("\n")[2]
 
     @patch("firetower.incidents.hooks._slack_service")
     @patch("firetower.incidents.hooks.PagerDutyService")

--- a/src/firetower/incidents/tests/test_hooks.py
+++ b/src/firetower/incidents/tests/test_hooks.py
@@ -868,15 +868,15 @@ class TestPageIfNeeded:
         assert "IMOC" in mock_pd.trigger_incident.call_args[0][1]
 
 
-class TestPageForChannelSlackNotification:
+class TestPageForChannelReturnValue:
     @patch("firetower.incidents.hooks.PagerDutyService")
-    def test_posts_success_message_on_successful_page(self, mock_pd_cls, settings):
+    def test_returns_paged_policy_names(self, mock_pd_cls, settings):
         settings.PAGERDUTY = MOCK_PD_CONFIG
         mock_pd = mock_pd_cls.return_value
         mock_pd.trigger_incident.return_value = True
         mock_slack = MagicMock()
 
-        page_for_channel(
+        result = page_for_channel(
             IncidentSeverity.P0,
             "INC-100",
             "Major outage",
@@ -884,21 +884,16 @@ class TestPageForChannelSlackNotification:
             channel_id="C12345",
         )
 
-        success_calls = [
-            c for c in mock_slack.post_message.call_args_list if ":pager:" in c[0][1]
-        ]
-        assert len(success_calls) == 2
-        assert ":pager: Paged IMOC via PagerDuty." in success_calls[0][0][1]
-        assert ":pager: Paged PE On-Call via PagerDuty." in success_calls[1][0][1]
+        assert result == {"IMOC", "PROD_ENG"}
 
     @patch("firetower.incidents.hooks.PagerDutyService")
-    def test_posts_failure_message_on_failed_page(self, mock_pd_cls, settings):
+    def test_returns_empty_set_on_failure(self, mock_pd_cls, settings):
         settings.PAGERDUTY = MOCK_PD_CONFIG
         mock_pd = mock_pd_cls.return_value
         mock_pd.trigger_incident.return_value = False
         mock_slack = MagicMock()
 
-        page_for_channel(
+        result = page_for_channel(
             IncidentSeverity.P0,
             "INC-100",
             "Major outage",
@@ -906,29 +901,39 @@ class TestPageForChannelSlackNotification:
             channel_id="C12345",
         )
 
-        warning_calls = [
-            c for c in mock_slack.post_message.call_args_list if ":warning:" in c[0][1]
-        ]
-        assert len(warning_calls) == 2
-        assert "Failed to page IMOC" in warning_calls[0][0][1]
-        assert "Failed to page PE On-Call" in warning_calls[1][0][1]
+        assert result == set()
 
     @patch("firetower.incidents.hooks.PagerDutyService")
-    def test_no_slack_message_when_channel_id_is_none(self, mock_pd_cls, settings):
+    def test_returns_partial_set_on_mixed_results(self, mock_pd_cls, settings):
         settings.PAGERDUTY = MOCK_PD_CONFIG
         mock_pd = mock_pd_cls.return_value
-        mock_pd.trigger_incident.return_value = True
+        mock_pd.trigger_incident.side_effect = [True, False]
         mock_slack = MagicMock()
 
-        page_for_channel(
+        result = page_for_channel(
             IncidentSeverity.P0,
             "INC-100",
             "Major outage",
             mock_slack,
-            channel_id=None,
+            channel_id="C12345",
         )
 
-        mock_slack.post_message.assert_not_called()
+        assert result == {"IMOC"}
+
+    @patch("firetower.incidents.hooks.PagerDutyService")
+    def test_returns_empty_set_for_non_pageable_severity(self, mock_pd_cls, settings):
+        settings.PAGERDUTY = MOCK_PD_CONFIG
+        mock_slack = MagicMock()
+
+        result = page_for_channel(
+            IncidentSeverity.P3,
+            "INC-100",
+            "Minor issue",
+            mock_slack,
+        )
+
+        assert result == set()
+        mock_pd_cls.assert_not_called()
 
 
 @pytest.mark.django_db
@@ -1743,6 +1748,94 @@ class TestInviteOncallUsers:
         mock_pd.get_oncall_users.assert_called_once_with("PPE001")
         message = mock_slack.post_message.call_args[0][1]
         assert message == "On-Call Prod Eng (Primary): <@U_PE>"
+
+    @patch("firetower.incidents.hooks._slack_service")
+    @patch("firetower.incidents.hooks.PagerDutyService")
+    def test_paged_policies_annotated_in_roster(
+        self, mock_pd_cls, mock_slack, settings
+    ):
+        settings.PAGERDUTY = MOCK_PD_CONFIG
+        mock_pd = mock_pd_cls.return_value
+        mock_pd.get_oncall_users.side_effect = [
+            [{"email": "imoc@example.com", "escalation_level": 1}],
+            [
+                {"email": "primary@example.com", "escalation_level": 1},
+                {"email": "secondary@example.com", "escalation_level": 2},
+            ],
+        ]
+        mock_slack.get_user_profile_by_email.side_effect = [
+            {"slack_user_id": "U_IMOC"},
+            {"slack_user_id": "U_PRIMARY"},
+            {"slack_user_id": "U_SECONDARY"},
+        ]
+
+        incident = Incident.objects.create(
+            title="Major outage",
+            severity=IncidentSeverity.P0,
+        )
+
+        _invite_oncall_users(incident, "C99999", paged_policies={"IMOC", "PROD_ENG"})
+
+        message = mock_slack.post_message.call_args[0][1]
+        assert "On-Call Incident Manager: <@U_IMOC> (paged)" in message
+        assert "On-Call Prod Eng (Primary): <@U_PRIMARY> (paged)" in message
+        assert "On-Call Prod Eng (Secondary): <@U_SECONDARY> (paged)" in message
+
+    @patch("firetower.incidents.hooks._slack_service")
+    @patch("firetower.incidents.hooks.PagerDutyService")
+    def test_only_paged_policies_annotated(self, mock_pd_cls, mock_slack, settings):
+        settings.PAGERDUTY = MOCK_PD_CONFIG
+        mock_pd = mock_pd_cls.return_value
+        mock_pd.get_oncall_users.side_effect = [
+            [{"email": "imoc@example.com", "escalation_level": 1}],
+            [
+                {"email": "primary@example.com", "escalation_level": 1},
+            ],
+        ]
+        mock_slack.get_user_profile_by_email.side_effect = [
+            {"slack_user_id": "U_IMOC"},
+            {"slack_user_id": "U_PRIMARY"},
+        ]
+
+        incident = Incident.objects.create(
+            title="Major outage",
+            severity=IncidentSeverity.P0,
+        )
+
+        _invite_oncall_users(incident, "C99999", paged_policies={"IMOC"})
+
+        message = mock_slack.post_message.call_args[0][1]
+        assert "On-Call Incident Manager: <@U_IMOC> (paged)" in message
+        assert "On-Call Prod Eng (Primary): <@U_PRIMARY>" in message
+        assert "(paged)" not in message.split("\n")[1]
+
+    @patch("firetower.incidents.hooks._slack_service")
+    @patch("firetower.incidents.hooks.PagerDutyService")
+    def test_no_annotation_when_paged_policies_none(
+        self, mock_pd_cls, mock_slack, settings
+    ):
+        settings.PAGERDUTY = MOCK_PD_CONFIG
+        mock_pd = mock_pd_cls.return_value
+        mock_pd.get_oncall_users.side_effect = [
+            [{"email": "imoc@example.com", "escalation_level": 1}],
+            [
+                {"email": "primary@example.com", "escalation_level": 1},
+            ],
+        ]
+        mock_slack.get_user_profile_by_email.side_effect = [
+            {"slack_user_id": "U_IMOC"},
+            {"slack_user_id": "U_PRIMARY"},
+        ]
+
+        incident = Incident.objects.create(
+            title="Major outage",
+            severity=IncidentSeverity.P0,
+        )
+
+        _invite_oncall_users(incident, "C99999")
+
+        message = mock_slack.post_message.call_args[0][1]
+        assert "(paged)" not in message
 
 
 @pytest.mark.django_db

--- a/src/firetower/incidents/tests/test_hooks.py
+++ b/src/firetower/incidents/tests/test_hooks.py
@@ -1474,7 +1474,11 @@ class TestInviteOncallUsers:
         on_incident_created(incident)
 
         mock_invite_oncall.assert_called_once_with(
-            incident.severity, "C99999", mock_slack, is_private=False
+            incident.severity,
+            "C99999",
+            mock_slack,
+            is_private=False,
+            paged_policies=set(),
         )
 
     @patch("firetower.incidents.hooks._slack_service")


### PR DESCRIPTION
Adds a (paged) annotation to the oncall roster message in the Slack channel when a PagerDuty page is successfully sent. Only primary oncall (escalation level 1) gets the annotation since secondary is only paged if primary doesn't acknowledge.

Example roster message:
- On-Call Incident Manager: Spencer (paged)
- On-Call Prod Eng (Primary): Alice (paged)
- On-Call Prod Eng (Secondary): Bob