### PR TITLE
tests: Use dynamic project key in tests instead of hardcoded inc- prefix

### DIFF
--- a/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
+++ b/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.conf import settings
 from django.contrib.auth.models import User
 
 from firetower.auth.models import ExternalProfile, ExternalProfileType
@@ -49,7 +50,7 @@ class TestBackfillSubcommandRouting:
     ):
         mock_slack_svc.get_channel_info.return_value = {
             "id": "C_TEST",
-            "name": "inc-2050",
+            "name": f"{settings.PROJECT_KEY.lower()}-2050",
             "is_private": False,
         }
         ack = MagicMock()
@@ -73,7 +74,7 @@ class TestBackfillCommand:
     def test_opens_modal(self, mock_slack_svc, mock_get_bolt_app):
         mock_slack_svc.get_channel_info.return_value = {
             "id": "C_TEST",
-            "name": "inc-2050",
+            "name": f"{settings.PROJECT_KEY.lower()}-2050",
             "is_private": False,
         }
         ack = MagicMock()
@@ -116,7 +117,7 @@ class TestBackfillCommand:
     ):
         mock_slack_svc.get_channel_info.return_value = {
             "id": "C_EXISTING",
-            "name": "inc-1234",
+            "name": f"{settings.PROJECT_KEY.lower()}-1234",
             "is_private": False,
         }
         mock_slack_svc.join_channel.return_value = True
@@ -152,17 +153,20 @@ class TestBackfillCommand:
     def test_channel_from_args(self, mock_slack_svc):
         mock_slack_svc.get_channel_info.return_value = {
             "id": "CARG12345",
-            "name": "inc-2050",
+            "name": f"{settings.PROJECT_KEY.lower()}-2050",
             "is_private": False,
         }
         ack = MagicMock()
         body = {
             "trigger_id": "T12345",
-            "text": "backfill <#CARG12345|inc-2050>",
+            "text": f"backfill <#CARG12345|{settings.PROJECT_KEY.lower()}-2050>",
             "channel_id": "C_OTHER",
             "user_id": "U_TEST",
         }
-        command = {"command": "/ft", "text": "backfill <#CARG12345|inc-2050>"}
+        command = {
+            "command": "/ft",
+            "text": f"backfill <#CARG12345|{settings.PROJECT_KEY.lower()}-2050>",
+        }
         respond = MagicMock()
 
         with patch("firetower.slack_app.bolt.get_bolt_app") as mock_app:
@@ -232,7 +236,7 @@ class TestBackfillSubmission:
         )
         mock_slack_svc.get_channel_info.return_value = {
             "id": "C_TEST",
-            "name": "inc-2050",
+            "name": f"{settings.PROJECT_KEY.lower()}-2050",
             "is_private": False,
         }
         mock_slack_svc.join_channel.return_value = True
@@ -274,7 +278,7 @@ class TestBackfillSubmission:
         )
         mock_slack_svc.get_channel_info.return_value = {
             "id": "C_TEST",
-            "name": "inc-2050",
+            "name": f"{settings.PROJECT_KEY.lower()}-2050",
             "is_private": False,
         }
         mock_slack_svc.join_channel.return_value = False
@@ -331,7 +335,7 @@ class TestBackfillSubmission:
         handle_backfill_submission(ack, body, self._build_view(), client)
 
         incident = Incident.objects.get(title="Test Backfill")
-        expected_name = f"inc-{incident.id}"
+        expected_name = incident.incident_number.lower()
         mock_slack_svc.rename_channel.assert_called_once_with("C_TEST", expected_name)
         mock_slack_svc.set_channel_topic.assert_called_once()
 
@@ -365,7 +369,7 @@ class TestBackfillSubmission:
         handle_backfill_submission(ack, body, self._build_view(), client)
 
         incident = Incident.objects.get(title="Test Backfill")
-        expected_name = f"inc-{incident.id}"
+        expected_name = incident.incident_number.lower()
         mock_slack_svc.rename_channel.assert_called_once_with("C_TEST", expected_name)
         rename_msg_call = [
             c
@@ -396,9 +400,9 @@ class TestBackfillSubmission:
         def channel_info_matching_incident(channel_id):
             try:
                 incident = Incident.objects.get(title="Test Backfill")
-                name = f"inc-{incident.id}"
+                name = incident.incident_number.lower()
             except Incident.DoesNotExist:
-                name = "inc-unknown"
+                name = f"{settings.PROJECT_KEY.lower()}-unknown"
             return {
                 "id": channel_id,
                 "name": name,

--- a/src/firetower/slack_app/tests/handlers/test_new_incident.py
+++ b/src/firetower/slack_app/tests/handlers/test_new_incident.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import OperationalError
 
@@ -441,8 +442,9 @@ class TestFallbackChannel:
         # a second call may happen for the status channel (P0/P1).
         first_call = mock_slack_svc.create_channel.call_args_list[0]
         channel_name = first_call[0][0]
-        assert channel_name.startswith("inc-")
-        assert len(channel_name) == 12  # "inc-" + 8 hex chars
+        prefix = f"{settings.PROJECT_KEY.lower()}-"
+        assert channel_name.startswith(prefix)
+        assert len(channel_name) == len(prefix) + 8  # prefix + 8 hex chars
 
     @patch("firetower.slack_app.handlers.new_incident._slack_service")
     def test_posts_and_pins_metadata(self, mock_slack_svc):


### PR DESCRIPTION
Tests were hardcoding the inc- channel name prefix, which breaks when config uses a different project key (e.g. TESTINC). Updated to use incident.incident_number.lower() or settings.PROJECT_KEY.lower() inline.