### PR TITLE
feat: Add Linear OAuth client and API service

### DIFF
--- a/config.ci.toml
+++ b/config.ci.toml
@@ -1,5 +1,6 @@
 project_key = "INC"
 django_secret_key = "django-insecure-gmj)qc*_dk&^i1=z7oy(ew7%5*fz^yowp8=4=0882_d=i3hl69"
+salt_key = "ci-test-salt-key"
 sentry_dsn = ""
 firetower_base_url = "http://localhost:5173"
 region_grouping = []
@@ -19,6 +20,13 @@ app_token = "xapp-test-token"
 incident_feed_channel_id = ""
 always_invited_ids = []
 incident_guide_message = ""
+
+[linear]
+client_id = "ci-test-client-id"
+client_secret = "ci-test-client-secret"
+action_item_sync_throttle_seconds = 300
+team_id = "ci-test-team-id"
+project_id = ""
 
 [auth]
 iap_enabled = false

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,6 +1,8 @@
 project_key = "INC"
 log_level = "INFO"
 django_secret_key = "django-insecure-gmj)qc*_dk&^i1=z7oy(ew7%5*fz^yowp8=4=0882_d=i3hl69"
+# Salt for django-fernet-encrypted-fields. In prod, use a unique value: python -c "import secrets; print(secrets.token_urlsafe(32))"
+salt_key = ""
 sentry_dsn = "https://your-sentry-dsn@o1.ingest.us.sentry.io/project-id"
 firetower_base_url = "http://localhost:5173"
 region_grouping = [["region-a", "region-b"], ["region-c", "region-d"]]
@@ -34,6 +36,15 @@ integration_key = ""
 [pagerduty.escalation_policies.PROD_ENG]
 id = ""
 integration_key = ""
+
+[linear]
+client_id = ""
+client_secret = ""
+action_item_sync_throttle_seconds = 300
+team_id = ""
+project_id = ""
+# When true, claim the Linear issue matching the incident number (e.g. INC-2160) instead of creating a new one.
+sync_identifiers = false
 
 [notion]
 integration_token = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "ddtrace==3.18.1",
     "django>=5.2.14,<6",
     "django-cors-headers>=4.9.0",
+    "django-fernet-encrypted-fields>=0.3.1",
     "django-kubernetes>=1.1.0",
     "djangorestframework>=3.15.2",
     "google-auth>=2.37.0",

--- a/src/firetower/config.py
+++ b/src/firetower/config.py
@@ -65,6 +65,16 @@ class StatuspageConfig:
 
 
 @deserialize
+class LinearConfig:
+    client_id: str
+    client_secret: str
+    action_item_sync_throttle_seconds: int
+    team_id: str = ""
+    project_id: str = ""
+    sync_identifiers: bool = False
+
+
+@deserialize
 class AuthConfig:
     iap_enabled: bool
     iap_audience: str | None
@@ -78,14 +88,16 @@ class ConfigFile:
 
     postgres: PostgresConfig
     slack: SlackConfig
+    linear: LinearConfig | None
     auth: AuthConfig
     pagerduty: PagerDutyConfig | None
     statuspage: StatuspageConfig | None
 
     project_key: str
-    django_secret_key: str
-    sentry_dsn: str
     firetower_base_url: str
+    django_secret_key: str
+    salt_key: str
+    sentry_dsn: str
     notion: NotionConfig | None = None
     genai: GenAIConfig | None = None
     log_level: str = "INFO"
@@ -148,14 +160,16 @@ class DummyConfigFile(ConfigFile):
             iap_enabled=False,
             iap_audience="",
         )
+        self.linear = None
         self.notion = None
         self.genai = None
         self.pagerduty = None
         self.statuspage = None
         self.project_key = ""
+        self.firetower_base_url = ""
         self.django_secret_key = ""
+        self.salt_key = ""
         self.sentry_dsn = ""
         self.region_grouping: list[list[str]] = []
-        self.firetower_base_url = ""
         self.log_level = "INFO"
         self.hooks_enabled = False

--- a/src/firetower/integrations/migrations/0001_linearoauthtoken.py
+++ b/src/firetower/integrations/migrations/0001_linearoauthtoken.py
@@ -1,0 +1,30 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = []
+
+    operations = [
+        migrations.CreateModel(
+            name="LinearOAuthToken",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("access_token", models.TextField()),
+                ("expires_at", models.DateTimeField()),
+                ("last_refreshed", models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                "verbose_name": "Linear OAuth Token",
+            },
+        ),
+    ]

--- a/src/firetower/integrations/migrations/0002_alter_linearoauthtoken_access_token.py
+++ b/src/firetower/integrations/migrations/0002_alter_linearoauthtoken_access_token.py
@@ -1,0 +1,16 @@
+import encrypted_fields.fields
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("integrations", "0001_linearoauthtoken"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="linearoauthtoken",
+            name="access_token",
+            field=encrypted_fields.fields.EncryptedTextField(),
+        ),
+    ]

--- a/src/firetower/integrations/models.py
+++ b/src/firetower/integrations/models.py
@@ -1,1 +1,18 @@
-# Create your models here.
+from django.db import models
+from encrypted_fields.fields import EncryptedTextField
+
+
+class LinearOAuthToken(models.Model):
+    access_token = EncryptedTextField()
+    expires_at = models.DateTimeField()
+    last_refreshed = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = "Linear OAuth Token"
+
+    def __str__(self) -> str:
+        return f"LinearOAuthToken (expires {self.expires_at})"
+
+    @classmethod
+    def get_singleton(cls) -> "LinearOAuthToken | None":
+        return cls.objects.first()

--- a/src/firetower/integrations/services/__init__.py
+++ b/src/firetower/integrations/services/__init__.py
@@ -1,12 +1,14 @@
 """Services package for external integrations."""
 
 from .datadog import DatadogService
+from .linear import LinearService
 from .pagerduty import PagerDutyService
 from .slack import SlackService
 from .statuspage import StatuspageService
 
 __all__ = [
     "DatadogService",
+    "LinearService",
     "PagerDutyService",
     "SlackService",
     "StatuspageService",

--- a/src/firetower/integrations/services/linear.py
+++ b/src/firetower/integrations/services/linear.py
@@ -79,13 +79,7 @@ class LinearService:
                 expires_at = timezone.now() + TOKEN_LIFETIME
 
             with transaction.atomic():
-                existing = list(LinearOAuthToken.objects.select_for_update().all())
-                if (
-                    existing
-                    and existing[0].expires_at > timezone.now() + TOKEN_REFRESH_BUFFER
-                ):
-                    return existing[0].access_token
-                LinearOAuthToken.objects.all().delete()
+                LinearOAuthToken.objects.select_for_update().all().delete()
                 LinearOAuthToken.objects.create(
                     access_token=access_token,
                     expires_at=expires_at,

--- a/src/firetower/integrations/services/linear.py
+++ b/src/firetower/integrations/services/linear.py
@@ -79,7 +79,13 @@ class LinearService:
                 expires_at = timezone.now() + TOKEN_LIFETIME
 
             with transaction.atomic():
-                LinearOAuthToken.objects.select_for_update().all().delete()
+                existing = list(LinearOAuthToken.objects.select_for_update().all())
+                if (
+                    existing
+                    and existing[0].expires_at > timezone.now() + TOKEN_REFRESH_BUFFER
+                ):
+                    return existing[0].access_token
+                LinearOAuthToken.objects.all().delete()
                 LinearOAuthToken.objects.create(
                     access_token=access_token,
                     expires_at=expires_at,
@@ -137,10 +143,9 @@ class LinearService:
                 response = self._make_graphql_request(query, variables, access_token)
 
             if not response.ok:
-                logger.error(
-                    f"Linear API returned {response.status_code}: {response.text}"
-                )
-            response.raise_for_status()
+                logger.error("Linear API returned %d", response.status_code)
+                return None
+
             data = response.json()
 
             if "errors" in data:
@@ -151,14 +156,14 @@ class LinearService:
                 return None
 
             return data.get("data")
-        except requests.RequestException as e:
-            logger.error(f"Linear API request failed: {e}")
+        except requests.RequestException:
+            logger.exception("Linear API request failed")
             return None
 
     def _parse_issue(
         self, issue: dict[str, Any], relation_type: str = "child"
     ) -> dict[str, Any]:
-        state_type = issue.get("state", {}).get("type", "")
+        state_type = (issue.get("state") or {}).get("type", "")
         status = LINEAR_STATE_TYPE_MAP.get(state_type, "Todo")
         assignee = issue.get("assignee") or {}
         return {

--- a/src/firetower/integrations/services/linear.py
+++ b/src/firetower/integrations/services/linear.py
@@ -1,0 +1,450 @@
+import logging
+from datetime import timedelta
+from typing import Any
+
+import requests
+from django.conf import settings
+from django.db import transaction
+from django.utils import timezone
+
+from firetower.integrations.models import LinearOAuthToken
+
+logger = logging.getLogger(__name__)
+
+LINEAR_API_URL = "https://api.linear.app/graphql"
+LINEAR_TOKEN_URL = "https://api.linear.app/oauth/token"
+
+LINEAR_STATE_TYPE_MAP = {
+    "triage": "Todo",
+    "backlog": "Todo",
+    "unstarted": "Todo",
+    "started": "In Progress",
+    "completed": "Done",
+    "cancelled": "Cancelled",
+}
+
+LINEAR_RELATION_TYPE_MAP = {
+    "related": "related",
+    "blocks": "blocks",
+    "blocked": "blocked_by",
+    "duplicate": "duplicate",
+}
+
+TOKEN_LIFETIME = timedelta(days=30)
+TOKEN_REFRESH_BUFFER = timedelta(days=1)
+
+ISSUE_FIELDS = """
+    id
+    identifier
+    title
+    url
+    state {
+        type
+    }
+    assignee {
+        id
+        email
+    }
+"""
+
+
+class LinearService:
+    def __init__(self) -> None:
+        linear_config = settings.LINEAR
+        self.client_id = linear_config.get("CLIENT_ID")
+        self.client_secret = linear_config.get("CLIENT_SECRET")
+        self._workflow_states_cache: dict[str, str] | None = None
+
+    def _request_new_token(self) -> str | None:
+        try:
+            response = requests.post(
+                LINEAR_TOKEN_URL,
+                data={
+                    "grant_type": "client_credentials",
+                    "client_id": self.client_id,
+                    "client_secret": self.client_secret,
+                    "scope": "read,write",
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                timeout=30,
+            )
+            response.raise_for_status()
+            data = response.json()
+            access_token = data["access_token"]
+
+            expires_in = data.get("expires_in")
+            if expires_in is not None:
+                expires_at = timezone.now() + timedelta(seconds=expires_in)
+            else:
+                expires_at = timezone.now() + TOKEN_LIFETIME
+
+            with transaction.atomic():
+                LinearOAuthToken.objects.select_for_update().all().delete()
+                LinearOAuthToken.objects.create(
+                    access_token=access_token,
+                    expires_at=expires_at,
+                )
+
+            logger.info("Obtained new Linear OAuth token")
+            return access_token
+        except requests.RequestException:
+            logger.exception("Failed to obtain Linear OAuth token")
+            return None
+        except (KeyError, ValueError):
+            logger.exception("Unexpected response from Linear token endpoint")
+            return None
+
+    def _get_access_token(self) -> str | None:
+        if not self.client_id or not self.client_secret:
+            return None
+
+        token = LinearOAuthToken.get_singleton()
+        if token and token.expires_at > timezone.now() + TOKEN_REFRESH_BUFFER:
+            return token.access_token
+
+        return self._request_new_token()
+
+    def _make_graphql_request(
+        self, query: str, variables: dict | None, access_token: str
+    ) -> requests.Response:
+        return requests.post(
+            LINEAR_API_URL,
+            json={"query": query, "variables": variables or {}},
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "Content-Type": "application/json",
+            },
+            timeout=30,
+        )
+
+    def _graphql(self, query: str, variables: dict | None = None) -> dict | None:
+        access_token = self._get_access_token()
+        if not access_token:
+            logger.warning(
+                "Cannot make Linear API call - no valid access token available"
+            )
+            return None
+
+        try:
+            response = self._make_graphql_request(query, variables, access_token)
+
+            if response.status_code == 401:
+                logger.info("Linear token expired, requesting new token")
+                access_token = self._request_new_token()
+                if not access_token:
+                    return None
+
+                response = self._make_graphql_request(query, variables, access_token)
+
+            if not response.ok:
+                logger.error(
+                    f"Linear API returned {response.status_code}: {response.text}"
+                )
+            response.raise_for_status()
+            data = response.json()
+
+            if "errors" in data:
+                logger.error(
+                    "Linear GraphQL errors",
+                    extra={"errors": data["errors"]},
+                )
+                return None
+
+            return data.get("data")
+        except requests.RequestException as e:
+            logger.error(f"Linear API request failed: {e}")
+            return None
+
+    def _parse_issue(
+        self, issue: dict[str, Any], relation_type: str = "child"
+    ) -> dict[str, Any]:
+        state_type = issue.get("state", {}).get("type", "")
+        status = LINEAR_STATE_TYPE_MAP.get(state_type, "Todo")
+        assignee = issue.get("assignee") or {}
+        return {
+            "id": issue["id"],
+            "identifier": issue["identifier"],
+            "title": issue["title"],
+            "url": issue["url"],
+            "status": status,
+            "assignee_email": assignee.get("email"),
+            "assignee_linear_id": assignee.get("id"),
+            "relation_type": relation_type,
+        }
+
+    def get_issue(self, identifier: str) -> dict[str, Any] | None:
+        query = f"""
+        query($id: String!) {{
+            issue(id: $id) {{
+                {ISSUE_FIELDS}
+            }}
+        }}
+        """
+        data = self._graphql(query, {"id": identifier})
+        if not data or not data.get("issue"):
+            return None
+        issue = data["issue"]
+        return {
+            "id": issue["id"],
+            "identifier": issue["identifier"],
+            "title": issue["title"],
+            "url": issue["url"],
+        }
+
+    def create_issue(
+        self,
+        title: str,
+        description: str,
+        team_id: str,
+        project_id: str | None = None,
+        state_id: str | None = None,
+    ) -> dict[str, Any] | None:
+        mutation = """
+        mutation($input: IssueCreateInput!) {
+            issueCreate(input: $input) {
+                success
+                issue {
+                    id
+                    identifier
+                    url
+                }
+            }
+        }
+        """
+        input_data: dict[str, Any] = {
+            "title": title,
+            "description": description,
+            "teamId": team_id,
+        }
+        if project_id:
+            input_data["projectId"] = project_id
+        if state_id:
+            input_data["stateId"] = state_id
+
+        data = self._graphql(mutation, {"input": input_data})
+        if not data:
+            return None
+
+        result = data.get("issueCreate", {})
+        if not result.get("success"):
+            logger.error("Linear issueCreate failed", extra={"result": result})
+            return None
+
+        issue = result.get("issue")
+        if not issue:
+            logger.error("Linear issueCreate returned no issue")
+            return None
+
+        return {
+            "id": issue["id"],
+            "identifier": issue["identifier"],
+            "url": issue["url"],
+        }
+
+    def create_attachment(self, issue_id: str, url: str, title: str) -> bool:
+        mutation = """
+        mutation($input: AttachmentCreateInput!) {
+            attachmentCreate(input: $input) {
+                success
+            }
+        }
+        """
+        data = self._graphql(
+            mutation,
+            {"input": {"issueId": issue_id, "url": url, "title": title}},
+        )
+        if not data:
+            return False
+
+        return data.get("attachmentCreate", {}).get("success", False)
+
+    def update_issue(
+        self,
+        issue_id: str,
+        title: str | None = None,
+        description: str | None = None,
+        state_id: str | None = None,
+    ) -> bool:
+        mutation = """
+        mutation($id: String!, $input: IssueUpdateInput!) {
+            issueUpdate(id: $id, input: $input) {
+                success
+            }
+        }
+        """
+        input_data: dict[str, Any] = {}
+        if title is not None:
+            input_data["title"] = title
+        if description is not None:
+            input_data["description"] = description
+        if state_id is not None:
+            input_data["stateId"] = state_id
+
+        if not input_data:
+            return True
+
+        data = self._graphql(mutation, {"id": issue_id, "input": input_data})
+        if not data:
+            return False
+
+        return data.get("issueUpdate", {}).get("success", False)
+
+    def get_workflow_states(self, team_id: str) -> dict[str, str] | None:
+        if self._workflow_states_cache is not None:
+            return self._workflow_states_cache
+
+        query = """
+        query($teamId: String!) {
+            team(id: $teamId) {
+                states {
+                    nodes {
+                        id
+                        name
+                        type
+                    }
+                }
+            }
+        }
+        """
+        data = self._graphql(query, {"teamId": team_id})
+        if not data:
+            return None
+
+        team = data.get("team")
+        if not team:
+            return None
+
+        states: dict[str, str] = {}
+        for node in team.get("states", {}).get("nodes", []):
+            state_type = node.get("type", "")
+            if state_type not in states:
+                states[state_type] = node["id"]
+
+        self._workflow_states_cache = states
+        return states
+
+    def get_child_issues(self, issue_id: str) -> list[dict[str, Any]] | None:
+        query = f"""
+        query($issueId: String!, $after: String) {{
+            issue(id: $issueId) {{
+                children(first: 50, after: $after) {{
+                    nodes {{
+                        {ISSUE_FIELDS}
+                    }}
+                    pageInfo {{
+                        hasNextPage
+                        endCursor
+                    }}
+                }}
+            }}
+        }}
+        """
+
+        issues: list[dict[str, Any]] = []
+        cursor: str | None = None
+        max_pages = 25
+
+        for _ in range(max_pages):
+            variables: dict[str, Any] = {"issueId": issue_id}
+            if cursor is not None:
+                variables["after"] = cursor
+
+            data = self._graphql(query, variables)
+            if data is None:
+                return None
+
+            issue = data.get("issue")
+            if not issue:
+                return None
+
+            children = issue.get("children", {})
+            issues.extend(
+                self._parse_issue(node, "child") for node in children.get("nodes", [])
+            )
+
+            page_info = children.get("pageInfo", {})
+            if not page_info.get("hasNextPage"):
+                break
+            cursor = page_info.get("endCursor")
+            if cursor is None:
+                break
+
+        return issues
+
+    def _fetch_relations(
+        self,
+        issue_id: str,
+        field: str,
+        issue_key: str,
+        seen_ids: set[str],
+    ) -> list[dict[str, Any]] | None:
+        query = f"""
+        query($issueId: String!, $after: String) {{
+            issue(id: $issueId) {{
+                {field}(first: 50, after: $after) {{
+                    nodes {{
+                        type
+                        {issue_key} {{
+                            {ISSUE_FIELDS}
+                        }}
+                    }}
+                    pageInfo {{
+                        hasNextPage
+                        endCursor
+                    }}
+                }}
+            }}
+        }}
+        """
+
+        issues: list[dict[str, Any]] = []
+        cursor: str | None = None
+        max_pages = 25
+
+        for _ in range(max_pages):
+            variables: dict[str, Any] = {"issueId": issue_id}
+            if cursor is not None:
+                variables["after"] = cursor
+
+            data = self._graphql(query, variables)
+            if data is None:
+                return None
+
+            issue = data.get("issue")
+            if not issue:
+                return None
+
+            relations = issue.get(field, {})
+            for node in relations.get("nodes", []):
+                related_issue = node.get(issue_key)
+                if not related_issue or "id" not in related_issue:
+                    continue
+                if related_issue["id"] in seen_ids:
+                    continue
+                seen_ids.add(related_issue["id"])
+
+                linear_type = node.get("type", "").lower()
+                relation_type = LINEAR_RELATION_TYPE_MAP.get(linear_type, "related")
+                issues.append(self._parse_issue(related_issue, relation_type))
+
+            page_info = relations.get("pageInfo", {})
+            if not page_info.get("hasNextPage"):
+                break
+            cursor = page_info.get("endCursor")
+            if cursor is None:
+                break
+
+        return issues
+
+    def get_related_issues(self, issue_id: str) -> list[dict[str, Any]] | None:
+        seen_ids: set[str] = set()
+
+        forward = self._fetch_relations(issue_id, "relations", "relatedIssue", seen_ids)
+        if forward is None:
+            return None
+
+        inverse = self._fetch_relations(issue_id, "inverseRelations", "issue", seen_ids)
+        if inverse is None:
+            return None
+
+        return forward + inverse

--- a/src/firetower/integrations/services/linear.py
+++ b/src/firetower/integrations/services/linear.py
@@ -49,9 +49,9 @@ ISSUE_FIELDS = """
 
 class LinearService:
     def __init__(self) -> None:
-        linear_config = settings.LINEAR
-        self.client_id = linear_config.get("CLIENT_ID")
-        self.client_secret = linear_config.get("CLIENT_SECRET")
+        assert settings.LINEAR is not None
+        self.client_id = settings.LINEAR.get("CLIENT_ID")
+        self.client_secret = settings.LINEAR.get("CLIENT_SECRET")
         self._workflow_states_cache: dict[str, str] | None = None
 
     def _request_new_token(self) -> str | None:

--- a/src/firetower/integrations/services/linear.py
+++ b/src/firetower/integrations/services/linear.py
@@ -77,11 +77,10 @@ class LinearService:
             else:
                 expires_at = timezone.now() + TOKEN_LIFETIME
 
-            LinearOAuthToken.objects.update_or_create(
-                defaults={
-                    "access_token": access_token,
-                    "expires_at": expires_at,
-                }
+            LinearOAuthToken.objects.all().delete()
+            LinearOAuthToken.objects.create(
+                access_token=access_token,
+                expires_at=expires_at,
             )
 
             logger.info("Obtained new Linear OAuth token")
@@ -170,7 +169,7 @@ class LinearService:
             "relation_type": relation_type,
         }
 
-    def get_issue(self, identifier: str) -> dict[str, Any] | None:
+    def get_issue(self, issue_id: str) -> dict[str, Any] | None:
         query = f"""
         query($id: String!) {{
             issue(id: $id) {{
@@ -178,7 +177,7 @@ class LinearService:
             }}
         }}
         """
-        data = self._graphql(query, {"id": identifier})
+        data = self._graphql(query, {"id": issue_id})
         if not data or not data.get("issue"):
             return None
         issue = data["issue"]

--- a/src/firetower/integrations/services/linear.py
+++ b/src/firetower/integrations/services/linear.py
@@ -4,7 +4,6 @@ from typing import Any
 
 import requests
 from django.conf import settings
-from django.db import transaction
 from django.utils import timezone
 
 from firetower.integrations.models import LinearOAuthToken
@@ -78,12 +77,12 @@ class LinearService:
             else:
                 expires_at = timezone.now() + TOKEN_LIFETIME
 
-            with transaction.atomic():
-                LinearOAuthToken.objects.select_for_update().all().delete()
-                LinearOAuthToken.objects.create(
-                    access_token=access_token,
-                    expires_at=expires_at,
-                )
+            LinearOAuthToken.objects.update_or_create(
+                defaults={
+                    "access_token": access_token,
+                    "expires_at": expires_at,
+                }
+            )
 
             logger.info("Obtained new Linear OAuth token")
             return access_token

--- a/src/firetower/integrations/tests/test_linear_service.py
+++ b/src/firetower/integrations/tests/test_linear_service.py
@@ -102,7 +102,8 @@ class TestRequestNewToken:
             headers={"Content-Type": "application/x-www-form-urlencoded"},
             timeout=30,
         )
-        mock_token_model.objects.update_or_create.assert_called_once()
+        mock_token_model.objects.all().delete.assert_called_once()
+        mock_token_model.objects.create.assert_called_once()
 
     @patch("firetower.integrations.services.linear.requests.post")
     def test_returns_none_on_request_error(self, mock_post, linear_service):

--- a/src/firetower/integrations/tests/test_linear_service.py
+++ b/src/firetower/integrations/tests/test_linear_service.py
@@ -76,11 +76,10 @@ class TestGetAccessToken:
 
 
 class TestRequestNewToken:
-    @patch("firetower.integrations.services.linear.transaction")
     @patch("firetower.integrations.services.linear.LinearOAuthToken")
     @patch("firetower.integrations.services.linear.requests.post")
     def test_stores_token_and_returns_access_token(
-        self, mock_post, mock_token_model, mock_transaction, linear_service
+        self, mock_post, mock_token_model, linear_service
     ):
         mock_response = MagicMock()
         mock_response.json.return_value = {
@@ -103,8 +102,7 @@ class TestRequestNewToken:
             headers={"Content-Type": "application/x-www-form-urlencoded"},
             timeout=30,
         )
-        mock_token_model.objects.select_for_update.assert_called_once()
-        mock_token_model.objects.create.assert_called_once()
+        mock_token_model.objects.update_or_create.assert_called_once()
 
     @patch("firetower.integrations.services.linear.requests.post")
     def test_returns_none_on_request_error(self, mock_post, linear_service):

--- a/src/firetower/integrations/tests/test_linear_service.py
+++ b/src/firetower/integrations/tests/test_linear_service.py
@@ -1,0 +1,387 @@
+from datetime import timedelta
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+import requests
+from django.utils import timezone
+
+from firetower.integrations.services.linear import (
+    LINEAR_TOKEN_URL,
+    LinearService,
+)
+
+
+@pytest.fixture
+def linear_service():
+    with patch("firetower.integrations.services.linear.settings") as mock_settings:
+        mock_settings.LINEAR = {
+            "CLIENT_ID": "test-client-id",
+            "CLIENT_SECRET": "test-client-secret",
+        }
+        svc = LinearService()
+    return svc
+
+
+@pytest.fixture
+def mock_token():
+    token = MagicMock()
+    token.access_token = "valid-token"
+    token.expires_at = timezone.now() + timedelta(days=15)
+    return token
+
+
+class TestGetAccessToken:
+    def test_returns_none_when_no_credentials(self):
+        with patch("firetower.integrations.services.linear.settings") as mock_settings:
+            mock_settings.LINEAR = {"CLIENT_ID": "", "CLIENT_SECRET": ""}
+            svc = LinearService()
+
+        assert svc._get_access_token() is None
+
+    @patch("firetower.integrations.services.linear.LinearOAuthToken")
+    def test_returns_cached_token_when_valid(
+        self, mock_token_model, linear_service, mock_token
+    ):
+        mock_token_model.get_singleton.return_value = mock_token
+
+        result = linear_service._get_access_token()
+
+        assert result == "valid-token"
+
+    @patch("firetower.integrations.services.linear.LinearOAuthToken")
+    def test_refreshes_when_token_expired(self, mock_token_model, linear_service):
+        expired_token = MagicMock()
+        expired_token.access_token = "expired-token"
+        expired_token.expires_at = timezone.now() - timedelta(hours=1)
+        mock_token_model.get_singleton.return_value = expired_token
+
+        with patch.object(
+            linear_service, "_request_new_token", return_value="new-token"
+        ) as mock_refresh:
+            result = linear_service._get_access_token()
+
+        assert result == "new-token"
+        mock_refresh.assert_called_once()
+
+    @patch("firetower.integrations.services.linear.LinearOAuthToken")
+    def test_refreshes_when_no_existing_token(self, mock_token_model, linear_service):
+        mock_token_model.get_singleton.return_value = None
+
+        with patch.object(
+            linear_service, "_request_new_token", return_value="new-token"
+        ):
+            result = linear_service._get_access_token()
+
+        assert result == "new-token"
+
+
+class TestRequestNewToken:
+    @patch("firetower.integrations.services.linear.transaction")
+    @patch("firetower.integrations.services.linear.LinearOAuthToken")
+    @patch("firetower.integrations.services.linear.requests.post")
+    def test_stores_token_and_returns_access_token(
+        self, mock_post, mock_token_model, mock_transaction, linear_service
+    ):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "access_token": "new-access-token",
+            "expires_in": 3600,
+        }
+        mock_post.return_value = mock_response
+
+        result = linear_service._request_new_token()
+
+        assert result == "new-access-token"
+        mock_post.assert_called_once_with(
+            LINEAR_TOKEN_URL,
+            data={
+                "grant_type": "client_credentials",
+                "client_id": "test-client-id",
+                "client_secret": "test-client-secret",
+                "scope": "read,write",
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=30,
+        )
+        mock_token_model.objects.select_for_update.assert_called_once()
+        mock_token_model.objects.create.assert_called_once()
+
+    @patch("firetower.integrations.services.linear.requests.post")
+    def test_returns_none_on_request_error(self, mock_post, linear_service):
+        mock_post.side_effect = requests.RequestException("connection error")
+
+        assert linear_service._request_new_token() is None
+
+
+class TestGraphql:
+    def test_returns_data_on_success(self, linear_service):
+        with (
+            patch.object(
+                linear_service, "_get_access_token", return_value="valid-token"
+            ),
+            patch.object(linear_service, "_make_graphql_request") as mock_request,
+        ):
+            mock_response = MagicMock()
+            mock_response.ok = True
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"data": {"viewer": {"id": "u1"}}}
+            mock_request.return_value = mock_response
+
+            result = linear_service._graphql("query { viewer { id } }")
+
+        assert result == {"viewer": {"id": "u1"}}
+
+    def test_returns_none_when_no_access_token(self, linear_service):
+        with patch.object(linear_service, "_get_access_token", return_value=None):
+            assert linear_service._graphql("query { viewer { id } }") is None
+
+    def test_retries_on_401(self, linear_service):
+        first_response = MagicMock()
+        first_response.status_code = 401
+        first_response.ok = False
+
+        second_response = MagicMock()
+        second_response.status_code = 200
+        second_response.ok = True
+        second_response.json.return_value = {"data": {"viewer": {"id": "u1"}}}
+
+        with (
+            patch.object(linear_service, "_get_access_token", return_value="old-token"),
+            patch.object(
+                linear_service,
+                "_request_new_token",
+                return_value="refreshed-token",
+            ) as mock_refresh,
+            patch.object(
+                linear_service,
+                "_make_graphql_request",
+                side_effect=[first_response, second_response],
+            ) as mock_request,
+        ):
+            result = linear_service._graphql("query { viewer { id } }")
+
+        assert result == {"viewer": {"id": "u1"}}
+        mock_refresh.assert_called_once()
+        assert mock_request.call_count == 2
+        assert mock_request.call_args_list[1] == call(
+            "query { viewer { id } }", None, "refreshed-token"
+        )
+
+    def test_returns_none_when_401_and_refresh_fails(self, linear_service):
+        first_response = MagicMock()
+        first_response.status_code = 401
+        first_response.ok = False
+
+        with (
+            patch.object(linear_service, "_get_access_token", return_value="old-token"),
+            patch.object(linear_service, "_request_new_token", return_value=None),
+            patch.object(
+                linear_service, "_make_graphql_request", return_value=first_response
+            ),
+        ):
+            assert linear_service._graphql("query { viewer { id } }") is None
+
+    def test_returns_none_on_graphql_errors(self, linear_service):
+        with (
+            patch.object(
+                linear_service, "_get_access_token", return_value="valid-token"
+            ),
+            patch.object(linear_service, "_make_graphql_request") as mock_request,
+        ):
+            mock_response = MagicMock()
+            mock_response.ok = True
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "errors": [{"message": "some error"}],
+                "data": None,
+            }
+            mock_request.return_value = mock_response
+
+            assert linear_service._graphql("query { viewer { id } }") is None
+
+
+class TestParseIssue:
+    def test_parses_full_issue(self, linear_service):
+        issue = {
+            "id": "issue-1",
+            "identifier": "ENG-123",
+            "title": "Fix bug",
+            "url": "https://linear.app/team/issue/ENG-123",
+            "state": {"type": "started"},
+            "assignee": {"id": "user-1", "email": "alice@sentry.io"},
+        }
+
+        result = linear_service._parse_issue(issue)
+
+        assert result == {
+            "id": "issue-1",
+            "identifier": "ENG-123",
+            "title": "Fix bug",
+            "url": "https://linear.app/team/issue/ENG-123",
+            "status": "In Progress",
+            "assignee_email": "alice@sentry.io",
+            "assignee_linear_id": "user-1",
+            "relation_type": "child",
+        }
+
+    def test_maps_all_state_types(self, linear_service):
+        for state_type, expected_status in [
+            ("triage", "Todo"),
+            ("backlog", "Todo"),
+            ("unstarted", "Todo"),
+            ("started", "In Progress"),
+            ("completed", "Done"),
+            ("cancelled", "Cancelled"),
+        ]:
+            issue = {
+                "id": "i1",
+                "identifier": "E-1",
+                "title": "t",
+                "url": "u",
+                "state": {"type": state_type},
+                "assignee": None,
+            }
+            assert linear_service._parse_issue(issue)["status"] == expected_status
+
+
+class TestGetChildIssues:
+    def test_paginates_through_multiple_pages(self, linear_service):
+        with patch.object(
+            linear_service,
+            "_graphql",
+            side_effect=[
+                {
+                    "issue": {
+                        "children": {
+                            "nodes": [
+                                {
+                                    "id": "c1",
+                                    "identifier": "E-1",
+                                    "title": "t",
+                                    "url": "u",
+                                    "state": {"type": "triage"},
+                                    "assignee": None,
+                                }
+                            ],
+                            "pageInfo": {"hasNextPage": True, "endCursor": "cursor1"},
+                        }
+                    }
+                },
+                {
+                    "issue": {
+                        "children": {
+                            "nodes": [
+                                {
+                                    "id": "c2",
+                                    "identifier": "E-2",
+                                    "title": "t2",
+                                    "url": "u2",
+                                    "state": {"type": "completed"},
+                                    "assignee": None,
+                                }
+                            ],
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        }
+                    }
+                },
+            ],
+        ) as mock_gql:
+            result = linear_service.get_child_issues("parent-id")
+
+        assert len(result) == 2
+        assert result[0]["identifier"] == "E-1"
+        assert result[1]["identifier"] == "E-2"
+        second_call_vars = mock_gql.call_args_list[1][0][1]
+        assert second_call_vars["after"] == "cursor1"
+
+
+class TestGetRelatedIssues:
+    def test_combines_forward_and_inverse_relations(self, linear_service):
+        forward_response = {
+            "issue": {
+                "relations": {
+                    "nodes": [
+                        {
+                            "type": "related",
+                            "relatedIssue": {
+                                "id": "r1",
+                                "identifier": "E-1",
+                                "title": "Related",
+                                "url": "u1",
+                                "state": {"type": "started"},
+                                "assignee": None,
+                            },
+                        }
+                    ],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
+        }
+        inverse_response = {
+            "issue": {
+                "inverseRelations": {
+                    "nodes": [
+                        {
+                            "type": "blocks",
+                            "issue": {
+                                "id": "r2",
+                                "identifier": "E-2",
+                                "title": "Blocker",
+                                "url": "u2",
+                                "state": {"type": "unstarted"},
+                                "assignee": None,
+                            },
+                        }
+                    ],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
+        }
+
+        with patch.object(
+            linear_service,
+            "_graphql",
+            side_effect=[forward_response, inverse_response],
+        ):
+            result = linear_service.get_related_issues("issue-1")
+
+        assert len(result) == 2
+        assert result[0]["identifier"] == "E-1"
+        assert result[0]["relation_type"] == "related"
+        assert result[1]["identifier"] == "E-2"
+        assert result[1]["relation_type"] == "blocks"
+
+    def test_deduplicates_across_forward_and_inverse(self, linear_service):
+        shared_issue = {
+            "id": "same-id",
+            "identifier": "E-1",
+            "title": "Same",
+            "url": "u",
+            "state": {"type": "started"},
+            "assignee": None,
+        }
+        forward_response = {
+            "issue": {
+                "relations": {
+                    "nodes": [{"type": "related", "relatedIssue": shared_issue}],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
+        }
+        inverse_response = {
+            "issue": {
+                "inverseRelations": {
+                    "nodes": [{"type": "related", "issue": shared_issue}],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
+        }
+
+        with patch.object(
+            linear_service,
+            "_graphql",
+            side_effect=[forward_response, inverse_response],
+        ):
+            result = linear_service.get_related_issues("issue-1")
+
+        assert len(result) == 1

--- a/src/firetower/settings.py
+++ b/src/firetower/settings.py
@@ -69,11 +69,15 @@ def _coerce_region_grouping(raw: list[Any]) -> list[list[str]]:
 # Global project settings
 PROJECT_KEY = config.project_key
 REGION_GROUPING = _coerce_region_grouping(config.region_grouping)
+FIRETOWER_BASE_URL = config.firetower_base_url
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 SECRET_KEY = config.django_secret_key
+
+# Used by django-fernet-encrypted-fields to encrypt sensitive DB fields (e.g. OAuth tokens).
+SALT_KEY = config.salt_key
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env_is_dev()
@@ -253,8 +257,6 @@ STATUSPAGE: StatuspageSettings | None = (
     else None
 )
 
-FIRETOWER_BASE_URL = config.firetower_base_url
-
 NOTION: dict | None = (
     {
         "INTEGRATION_TOKEN": config.notion.integration_token,
@@ -289,6 +291,23 @@ PAGERDUTY = (
     }
     if config.pagerduty
     else None
+)
+
+# Linear Integration Configuration
+LINEAR = (
+    {
+        "CLIENT_ID": config.linear.client_id,
+        "CLIENT_SECRET": config.linear.client_secret,
+        "TEAM_ID": config.linear.team_id,
+        "PROJECT_ID": config.linear.project_id,
+        "SYNC_IDENTIFIERS": config.linear.sync_identifiers,
+    }
+    if config.linear
+    else {}
+)
+
+ACTION_ITEM_SYNC_THROTTLE_SECONDS = (
+    int(config.linear.action_item_sync_throttle_seconds) if config.linear else 300
 )
 
 # Django REST Framework Configuration

--- a/src/firetower/settings.py
+++ b/src/firetower/settings.py
@@ -294,7 +294,7 @@ PAGERDUTY = (
 )
 
 # Linear Integration Configuration
-LINEAR = (
+LINEAR: dict | None = (
     {
         "CLIENT_ID": config.linear.client_id,
         "CLIENT_SECRET": config.linear.client_secret,
@@ -303,7 +303,7 @@ LINEAR = (
         "SYNC_IDENTIFIERS": config.linear.sync_identifiers,
     }
     if config.linear
-    else {}
+    else None
 )
 
 ACTION_ITEM_SYNC_THROTTLE_SECONDS = (

--- a/uv.lock
+++ b/uv.lock
@@ -468,6 +468,19 @@ wheels = [
 ]
 
 [[package]]
+name = "django-fernet-encrypted-fields"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/aa/529af3888215b8a660fc3897d6d63eaf1de9aa0699c633ca0ec483d4361c/django_fernet_encrypted_fields-0.3.1.tar.gz", hash = "sha256:5ed328c7f9cc7f2d452bb2e125f3ea2bea3563a259fa943e5a1c626175889a71", size = 5265, upload-time = "2025-11-10T08:39:57.398Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/7f/4e0b7ed8413fa58e7a77017342e8ab0e977d41cfc376ab9180ae75f216ec/django_fernet_encrypted_fields-0.3.1-py3-none-any.whl", hash = "sha256:3bd2abab02556dc6e15a58a61161ee6c5cdf45a50a8a52d9e035009eb54c6442", size = 5484, upload-time = "2025-11-10T08:39:55.866Z" },
+]
+
+[[package]]
 name = "django-kubernetes"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -548,6 +561,7 @@ dependencies = [
     { name = "ddtrace" },
     { name = "django" },
     { name = "django-cors-headers" },
+    { name = "django-fernet-encrypted-fields" },
     { name = "django-kubernetes" },
     { name = "djangorestframework" },
     { name = "google-auth" },
@@ -587,6 +601,7 @@ requires-dist = [
     { name = "ddtrace", specifier = "==3.18.1" },
     { name = "django", specifier = ">=5.2.14,<6" },
     { name = "django-cors-headers", specifier = ">=4.9.0" },
+    { name = "django-fernet-encrypted-fields", specifier = ">=0.3.1" },
     { name = "django-kubernetes", specifier = ">=1.1.0" },
     { name = "djangorestframework", specifier = ">=3.15.2" },
     { name = "google-auth", specifier = ">=2.37.0" },


### PR DESCRIPTION
Adds the Linear integration foundation: OAuth token model (encrypted), LinearService GraphQL client, and config/settings plumbing. No business logic yet — this is the infrastructure layer that action item sync, parent issue creation, and title/visibility hooks will build on in follow-up PRs.