### PR TITLE
feat: Show full metadata modal on /inc fixed|resolved

### DIFF
--- a/src/firetower/slack_app/handlers/resolved.py
+++ b/src/firetower/slack_app/handlers/resolved.py
@@ -3,19 +3,17 @@ from typing import Any
 
 from firetower.auth.models import ExternalProfileType
 from firetower.auth.services import get_or_create_user_from_slack_id
-from firetower.incidents.models import IncidentSeverity, IncidentStatus
+from firetower.incidents.models import Incident, IncidentSeverity, IncidentStatus
 from firetower.incidents.serializers import IncidentWriteSerializer
-from firetower.slack_app.handlers.utils import get_incident_from_channel
+from firetower.slack_app.handlers.utils import (
+    get_incident_from_channel,
+    parse_incident_form_values,
+)
 
 logger = logging.getLogger(__name__)
 
 
-def _build_resolved_modal(
-    incident_number: str,
-    channel_id: str,
-    current_severity: str,
-    captain_slack_id: str | None,
-) -> dict:
+def _build_resolved_modal(incident: Incident, channel_id: str) -> dict:
     severity_options = [
         {
             "text": {"type": "plain_text", "text": sev.label},
@@ -23,26 +21,96 @@ def _build_resolved_modal(
         }
         for sev in IncidentSeverity
     ]
-    initial_severity = next(
-        (opt for opt in severity_options if opt["value"] == current_severity),
-        next(
-            opt for opt in severity_options if opt["value"] == IncidentSeverity.P2.value
-        ),
-    )
+    current_severity = IncidentSeverity(incident.severity)
+    current_severity_option = {
+        "text": {"type": "plain_text", "text": current_severity.label},
+        "value": current_severity.value,
+    }
 
-    captain_element: dict = {
+    captain_element: dict[str, Any] = {
         "type": "users_select",
         "action_id": "captain_select",
         "placeholder": {"type": "plain_text", "text": "Select incident captain"},
     }
-    if captain_slack_id:
-        captain_element["initial_user"] = captain_slack_id
+    if incident.captain:
+        slack_profile = incident.captain.external_profiles.filter(
+            type=ExternalProfileType.SLACK
+        ).first()
+        if slack_profile:
+            captain_element["initial_user"] = slack_profile.external_id
+
+    title_element: dict[str, Any] = {
+        "type": "plain_text_input",
+        "action_id": "title",
+        "placeholder": {"type": "plain_text", "text": "Brief incident title"},
+        "initial_value": incident.title or "",
+    }
+
+    description_element: dict[str, Any] = {
+        "type": "plain_text_input",
+        "action_id": "description",
+        "multiline": True,
+        "placeholder": {"type": "plain_text", "text": "What's happening?"},
+    }
+    if incident.description:
+        description_element["initial_value"] = incident.description
+
+    impact_summary_element: dict[str, Any] = {
+        "type": "plain_text_input",
+        "action_id": "impact_summary",
+        "multiline": True,
+        "placeholder": {
+            "type": "plain_text",
+            "text": "What is the user/business impact?",
+        },
+    }
+    if incident.impact_summary:
+        impact_summary_element["initial_value"] = incident.impact_summary
+
+    impact_type_initial = [
+        {"text": {"type": "plain_text", "text": name}, "value": name}
+        for name in incident.impact_type_tag_names
+    ]
+    impact_type_element: dict[str, Any] = {
+        "type": "multi_external_select",
+        "action_id": "impact_type_tags",
+        "min_query_length": 0,
+        "placeholder": {"type": "plain_text", "text": "Select impact types"},
+    }
+    if impact_type_initial:
+        impact_type_element["initial_options"] = impact_type_initial
+
+    affected_service_initial = [
+        {"text": {"type": "plain_text", "text": name}, "value": name}
+        for name in incident.affected_service_tag_names
+    ]
+    affected_service_element: dict[str, Any] = {
+        "type": "multi_external_select",
+        "action_id": "affected_service_tags",
+        "min_query_length": 0,
+        "placeholder": {"type": "plain_text", "text": "Select affected services"},
+    }
+    if affected_service_initial:
+        affected_service_element["initial_options"] = affected_service_initial
+
+    affected_region_initial = [
+        {"text": {"type": "plain_text", "text": name}, "value": name}
+        for name in incident.affected_region_tag_names
+    ]
+    affected_region_element: dict[str, Any] = {
+        "type": "multi_external_select",
+        "action_id": "affected_region_tags",
+        "min_query_length": 0,
+        "placeholder": {"type": "plain_text", "text": "Select affected regions"},
+    }
+    if affected_region_initial:
+        affected_region_element["initial_options"] = affected_region_initial
 
     return {
         "type": "modal",
         "callback_id": "resolved_incident_modal",
         "private_metadata": channel_id,
-        "title": {"type": "plain_text", "text": incident_number},
+        "title": {"type": "plain_text", "text": incident.incident_number},
         "submit": {"type": "plain_text", "text": "Submit"},
         "close": {"type": "plain_text", "text": "Cancel"},
         "blocks": [
@@ -50,19 +118,8 @@ def _build_resolved_modal(
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "This incident has been contained! Please confirm the final severity and incident captain.",
+                    "text": "This incident has been contained! Please confirm the details below.",
                 },
-            },
-            {
-                "type": "input",
-                "block_id": "severity_block",
-                "element": {
-                    "type": "static_select",
-                    "action_id": "severity_select",
-                    "options": severity_options,
-                    "initial_option": initial_severity,
-                },
-                "label": {"type": "plain_text", "text": "Severity"},
             },
             {
                 "type": "input",
@@ -78,6 +135,58 @@ def _build_resolved_modal(
                         "text": "The incident captain is responsible for driving the postmortem.",
                     }
                 ],
+            },
+            {
+                "type": "input",
+                "block_id": "severity_block",
+                "element": {
+                    "type": "static_select",
+                    "action_id": "severity_select",
+                    "options": severity_options,
+                    "initial_option": current_severity_option,
+                },
+                "label": {"type": "plain_text", "text": "Severity"},
+            },
+            {
+                "type": "input",
+                "block_id": "title_block",
+                "element": title_element,
+                "label": {"type": "plain_text", "text": "Title"},
+            },
+            {
+                "type": "input",
+                "block_id": "description_block",
+                "optional": True,
+                "element": description_element,
+                "label": {"type": "plain_text", "text": "Description"},
+            },
+            {
+                "type": "input",
+                "block_id": "impact_summary_block",
+                "optional": True,
+                "element": impact_summary_element,
+                "label": {"type": "plain_text", "text": "Impact Summary"},
+            },
+            {
+                "type": "input",
+                "block_id": "impact_type_block",
+                "optional": True,
+                "element": impact_type_element,
+                "label": {"type": "plain_text", "text": "Impact Type"},
+            },
+            {
+                "type": "input",
+                "block_id": "affected_service_block",
+                "optional": True,
+                "element": affected_service_element,
+                "label": {"type": "plain_text", "text": "Affected Service"},
+            },
+            {
+                "type": "input",
+                "block_id": "affected_region_block",
+                "optional": True,
+                "element": affected_region_element,
+                "label": {"type": "plain_text", "text": "Affected Region"},
             },
         ],
     }
@@ -96,40 +205,29 @@ def handle_resolved_command(ack: Any, body: dict, command: dict, respond: Any) -
         respond("Could not open modal — missing trigger_id.")
         return
 
-    captain_slack_id = None
-    if incident.captain:
-        slack_profile = incident.captain.external_profiles.filter(
-            type=ExternalProfileType.SLACK
-        ).first()
-        if slack_profile:
-            captain_slack_id = slack_profile.external_id
-
     from firetower.slack_app.bolt import get_bolt_app  # noqa: PLC0415
 
     get_bolt_app().client.views_open(
         trigger_id=trigger_id,
-        view=_build_resolved_modal(
-            incident.incident_number,
-            channel_id,
-            incident.severity,
-            captain_slack_id,
-        ),
+        view=_build_resolved_modal(incident, channel_id),
     )
 
 
 def handle_resolved_submission(ack: Any, body: dict, view: dict, client: Any) -> None:
-    values = view.get("state", {}).get("values", {})
+    form = parse_incident_form_values(view)
     channel_id = view.get("private_metadata", "")
 
+    values = view.get("state", {}).get("values", {})
+
+    # The resolved modal uses "severity_select" as action_id (not "severity")
     severity = (
         values.get("severity_block", {})
         .get("severity_select", {})
         .get("selected_option", {})
         .get("value", "")
-    )
-    captain_slack_id = (
-        values.get("captain_block", {}).get("captain_select", {}).get("selected_user")
-    )
+    ) or form["severity"]
+
+    captain_slack_id = form["captain_slack_id"]
 
     if not captain_slack_id:
         ack(
@@ -165,6 +263,12 @@ def handle_resolved_submission(ack: Any, body: dict, view: dict, client: Any) ->
         "status": target_status,
         "severity": severity,
         "captain": captain_user.email,
+        "title": form["title"],
+        "description": form["description"],
+        "impact_summary": form["impact_summary"],
+        "impact_type_tags": form["impact_type_tags"],
+        "affected_service_tags": form["affected_service_tags"],
+        "affected_region_tags": form["affected_region_tags"],
     }
 
     serializer = IncidentWriteSerializer(instance=incident, data=data, partial=True)

--- a/src/firetower/slack_app/handlers/resolved.py
+++ b/src/firetower/slack_app/handlers/resolved.py
@@ -236,6 +236,13 @@ def handle_resolved_submission(ack: Any, body: dict, view: dict, client: Any) ->
         )
         return
 
+    if not form["title"]:
+        ack(
+            response_action="errors",
+            errors={"title_block": "This field is required."},
+        )
+        return
+
     ack()
 
     incident = get_incident_from_channel(channel_id)

--- a/src/firetower/slack_app/tests/handlers/test_resolved.py
+++ b/src/firetower/slack_app/tests/handlers/test_resolved.py
@@ -2,13 +2,38 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from firetower.incidents.models import IncidentSeverity, IncidentStatus
+from firetower.incidents.models import IncidentSeverity, IncidentStatus, Tag, TagType
 from firetower.slack_app.handlers.resolved import (
+    _build_resolved_modal,
     handle_resolved_command,
     handle_resolved_submission,
 )
 
 from .conftest import CHANNEL_ID
+
+
+def _make_resolved_view(severity="P1", captain="U_CAPTAIN", title="Test Incident"):
+    return {
+        "private_metadata": CHANNEL_ID,
+        "state": {
+            "values": {
+                "severity_block": {
+                    "severity_select": {"selected_option": {"value": severity}}
+                },
+                "captain_block": {"captain_select": {"selected_user": captain}},
+                "title_block": {"title": {"value": title}},
+                "description_block": {"description": {"value": "Updated desc"}},
+                "impact_summary_block": {"impact_summary": {"value": "Updated impact"}},
+                "impact_type_block": {"impact_type_tags": {"selected_options": []}},
+                "affected_service_block": {
+                    "affected_service_tags": {"selected_options": []}
+                },
+                "affected_region_block": {
+                    "affected_region_tags": {"selected_options": []}
+                },
+            }
+        },
+    }
 
 
 @pytest.mark.django_db
@@ -40,6 +65,66 @@ class TestResolvedCommand:
 
 
 @pytest.mark.django_db
+class TestResolvedModal:
+    def test_contains_metadata_fields(self, incident):
+        modal = _build_resolved_modal(incident, CHANNEL_ID)
+        block_ids = [b["block_id"] for b in modal["blocks"] if "block_id" in b]
+        assert "severity_block" in block_ids
+        assert "captain_block" in block_ids
+        assert "title_block" in block_ids
+        assert "description_block" in block_ids
+        assert "impact_summary_block" in block_ids
+        assert "impact_type_block" in block_ids
+        assert "affected_service_block" in block_ids
+        assert "affected_region_block" in block_ids
+
+    def test_contains_context_message(self, incident):
+        modal = _build_resolved_modal(incident, CHANNEL_ID)
+        section = modal["blocks"][0]
+        assert "contained" in section["text"]["text"]
+
+    def test_prefills_title(self, incident):
+        modal = _build_resolved_modal(incident, CHANNEL_ID)
+        block = next(b for b in modal["blocks"] if b.get("block_id") == "title_block")
+        assert block["element"]["initial_value"] == "Test Incident"
+
+    def test_prefills_severity(self, incident):
+        modal = _build_resolved_modal(incident, CHANNEL_ID)
+        block = next(
+            b for b in modal["blocks"] if b.get("block_id") == "severity_block"
+        )
+        assert block["element"]["initial_option"]["value"] == "P2"
+
+    def test_prefills_description(self, incident):
+        incident.description = "Some description"
+        incident.save()
+        modal = _build_resolved_modal(incident, CHANNEL_ID)
+        block = next(
+            b for b in modal["blocks"] if b.get("block_id") == "description_block"
+        )
+        assert block["element"]["initial_value"] == "Some description"
+
+    def test_prefills_impact_summary(self, incident):
+        incident.impact_summary = "Some impact"
+        incident.save()
+        modal = _build_resolved_modal(incident, CHANNEL_ID)
+        block = next(
+            b for b in modal["blocks"] if b.get("block_id") == "impact_summary_block"
+        )
+        assert block["element"]["initial_value"] == "Some impact"
+
+    def test_prefills_tags(self, incident):
+        tag = Tag.objects.create(name="api-server", type=TagType.AFFECTED_SERVICE)
+        incident.affected_service_tags.add(tag)
+        modal = _build_resolved_modal(incident, CHANNEL_ID)
+        block = next(
+            b for b in modal["blocks"] if b.get("block_id") == "affected_service_block"
+        )
+        assert "initial_options" in block["element"]
+        assert block["element"]["initial_options"][0]["value"] == "api-server"
+
+
+@pytest.mark.django_db
 class TestResolvedSubmission:
     @patch("firetower.incidents.serializers.on_status_changed")
     @patch("firetower.incidents.serializers.on_severity_changed")
@@ -60,17 +145,7 @@ class TestResolvedSubmission:
         ack = MagicMock()
         client = MagicMock()
         body = {"user": {"id": "U_CAPTAIN"}}
-        view = {
-            "private_metadata": CHANNEL_ID,
-            "state": {
-                "values": {
-                    "severity_block": {
-                        "severity_select": {"selected_option": {"value": "P1"}}
-                    },
-                    "captain_block": {"captain_select": {"selected_user": "U_CAPTAIN"}},
-                }
-            },
-        }
+        view = _make_resolved_view(severity="P1")
 
         handle_resolved_submission(ack, body, view, client)
 
@@ -91,17 +166,7 @@ class TestResolvedSubmission:
         ack = MagicMock()
         client = MagicMock()
         body = {"user": {"id": "U_CAPTAIN"}}
-        view = {
-            "private_metadata": CHANNEL_ID,
-            "state": {
-                "values": {
-                    "severity_block": {
-                        "severity_select": {"selected_option": {"value": "P4"}}
-                    },
-                    "captain_block": {"captain_select": {"selected_user": "U_CAPTAIN"}},
-                }
-            },
-        }
+        view = _make_resolved_view(severity="P4")
 
         handle_resolved_submission(ack, body, view, client)
 
@@ -109,21 +174,31 @@ class TestResolvedSubmission:
         incident.refresh_from_db()
         assert incident.status == IncidentStatus.DONE
 
+    @patch("firetower.incidents.serializers.on_status_changed")
+    @patch("firetower.incidents.serializers.on_title_changed")
+    @patch("firetower.slack_app.handlers.resolved.get_or_create_user_from_slack_id")
+    def test_saves_metadata_fields(
+        self, mock_get_user, mock_title_hook, mock_status_hook, user, incident
+    ):
+        mock_get_user.return_value = user
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_CAPTAIN"}}
+        view = _make_resolved_view(severity="P3", title="Updated Title")
+
+        handle_resolved_submission(ack, body, view, client)
+
+        ack.assert_called_once_with()
+        incident.refresh_from_db()
+        assert incident.title == "Updated Title"
+        assert incident.description == "Updated desc"
+        assert incident.impact_summary == "Updated impact"
+
     def test_missing_captain_returns_error(self, incident):
         ack = MagicMock()
         client = MagicMock()
         body = {"user": {"id": "U_CAPTAIN"}}
-        view = {
-            "private_metadata": CHANNEL_ID,
-            "state": {
-                "values": {
-                    "severity_block": {
-                        "severity_select": {"selected_option": {"value": "P2"}}
-                    },
-                    "captain_block": {"captain_select": {"selected_user": None}},
-                }
-            },
-        }
+        view = _make_resolved_view(captain=None)
 
         handle_resolved_submission(ack, body, view, client)
 


### PR DESCRIPTION
Expands the resolved/fixed modal to include all metadata fields (title, description, impact summary, impact type, affected service, affected region) alongside severity and captain. Encourages filling in more metadata when closing incidents.