### PR TITLE
fix: Recover DB connections in slack bot after primary failover

### DIFF
--- a/src/firetower/settings.py
+++ b/src/firetower/settings.py
@@ -174,6 +174,7 @@ DATABASES = {
         "HOST": config.postgres.host,
         "USER": config.postgres.user,
         "PASSWORD": config.postgres.password,
+        "CONN_HEALTH_CHECKS": True,
     },
 }
 

--- a/src/firetower/slack_app/bolt.py
+++ b/src/firetower/slack_app/bolt.py
@@ -104,6 +104,7 @@ def get_bolt_app() -> App:
 def handle_command(
     ack: Any, body: dict, command: dict, respond: Any, client: Any = None
 ) -> None:
+    close_old_connections()
     raw_text = (body.get("text") or "").strip()
     parts = raw_text.split(None, 1)
     subcommand = parts[0].lower() if parts else ""
@@ -179,6 +180,7 @@ def _with_metrics(callback_id: str) -> Callable[..., Callable[..., Any]]:
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         @wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
+            close_old_connections()
             tags = [f"callback_id:{callback_id}"]
             statsd.increment("slack_app.views.submitted", tags=tags)
             try:

--- a/src/firetower/slack_app/handlers/new_incident.py
+++ b/src/firetower/slack_app/handlers/new_incident.py
@@ -3,7 +3,7 @@ import uuid
 from typing import Any
 
 from django.conf import settings
-from django.db import InterfaceError, OperationalError
+from django.db import InterfaceError, OperationalError, close_old_connections
 
 from firetower.auth.services import get_or_create_user_from_slack_id
 from firetower.incidents.hooks import (
@@ -181,6 +181,7 @@ ACTION_ID_TO_TAG_TYPE = {
 
 
 def handle_tag_options(ack: Any, payload: dict) -> None:
+    close_old_connections()
     action_id = payload.get("action_id", "")
     keyword = payload.get("value", "")
 

--- a/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
+++ b/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
@@ -45,8 +45,9 @@ class TestBackfillSubcommandRouting:
     @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
     @patch("firetower.slack_app.bolt.get_bolt_app")
     @patch("firetower.slack_app.bolt.statsd")
+    @patch("firetower.slack_app.bolt.close_old_connections")
     def test_backfill_routes_correctly(
-        self, mock_statsd, mock_get_bolt_app, mock_slack_svc
+        self, _mock_close, mock_statsd, mock_get_bolt_app, mock_slack_svc
     ):
         mock_slack_svc.get_channel_info.return_value = {
             "id": "C_TEST",

--- a/src/firetower/slack_app/tests/handlers/test_help.py
+++ b/src/firetower/slack_app/tests/handlers/test_help.py
@@ -5,6 +5,7 @@ import pytest
 from firetower.slack_app.bolt import handle_command
 
 
+@patch("firetower.slack_app.bolt.close_old_connections")
 class TestHandleCommand:
     def _make_body(self, text="", command="/ft"):
         return {"text": text, "command": command}
@@ -13,7 +14,7 @@ class TestHandleCommand:
         return {"command": command, "text": text}
 
     @patch("firetower.slack_app.bolt.statsd")
-    def test_help_returns_help_text(self, mock_statsd):
+    def test_help_returns_help_text(self, mock_statsd, _mock_close):
         ack = MagicMock()
         respond = MagicMock()
         body = self._make_body(text="help")
@@ -28,7 +29,7 @@ class TestHandleCommand:
         assert "/ft help" in response_text
 
     @patch("firetower.slack_app.bolt.statsd")
-    def test_empty_text_returns_help(self, mock_statsd):
+    def test_empty_text_returns_help(self, mock_statsd, _mock_close):
         ack = MagicMock()
         respond = MagicMock()
         body = self._make_body(text="")
@@ -42,7 +43,7 @@ class TestHandleCommand:
         assert "Firetower Slack App" in response_text
 
     @patch("firetower.slack_app.bolt.statsd")
-    def test_unknown_subcommand_returns_error(self, mock_statsd):
+    def test_unknown_subcommand_returns_error(self, mock_statsd, _mock_close):
         ack = MagicMock()
         respond = MagicMock()
         body = self._make_body(text="unknown")
@@ -57,7 +58,7 @@ class TestHandleCommand:
         assert "/ft unknown" in response_text
 
     @patch("firetower.slack_app.bolt.statsd")
-    def test_help_uses_ft_test_command(self, mock_statsd):
+    def test_help_uses_ft_test_command(self, mock_statsd, _mock_close):
         ack = MagicMock()
         respond = MagicMock()
         body = self._make_body(text="help", command="/ft-test")
@@ -70,7 +71,7 @@ class TestHandleCommand:
         assert "/ft-test help" in response_text
 
     @patch("firetower.slack_app.bolt.statsd")
-    def test_emits_submitted_and_completed_metrics(self, mock_statsd):
+    def test_emits_submitted_and_completed_metrics(self, mock_statsd, _mock_close):
         ack = MagicMock()
         respond = MagicMock()
         body = self._make_body(text="help")
@@ -86,7 +87,7 @@ class TestHandleCommand:
         )
 
     @patch("firetower.slack_app.bolt.statsd")
-    def test_emits_failed_metric_on_error(self, mock_statsd):
+    def test_emits_failed_metric_on_error(self, mock_statsd, _mock_close):
         ack = MagicMock()
         respond = MagicMock(side_effect=RuntimeError("boom"))
         body = self._make_body(text="help")

--- a/src/firetower/slack_app/tests/handlers/test_new_incident.py
+++ b/src/firetower/slack_app/tests/handlers/test_new_incident.py
@@ -365,8 +365,9 @@ class TestNewIncidentSubmission:
 
 
 @pytest.mark.django_db
+@patch("firetower.slack_app.handlers.new_incident.close_old_connections")
 class TestTagOptions:
-    def test_returns_matching_tags(self):
+    def test_returns_matching_tags(self, _mock_close):
         Tag.objects.create(name="us-east-1", type=TagType.AFFECTED_REGION)
         Tag.objects.create(name="us-west-2", type=TagType.AFFECTED_REGION)
         Tag.objects.create(name="eu-west-1", type=TagType.AFFECTED_REGION)
@@ -381,7 +382,7 @@ class TestTagOptions:
         names = {o["text"]["text"] for o in options}
         assert names == {"us-east-1", "us-west-2"}
 
-    def test_empty_query_returns_all(self):
+    def test_empty_query_returns_all(self, _mock_close):
         Tag.objects.create(name="us-east-1", type=TagType.AFFECTED_REGION)
         Tag.objects.create(name="eu-west-1", type=TagType.AFFECTED_REGION)
 
@@ -392,14 +393,14 @@ class TestTagOptions:
         options = ack.call_args[1]["options"]
         assert len(options) == 2
 
-    def test_unknown_action_id_returns_empty(self):
+    def test_unknown_action_id_returns_empty(self, _mock_close):
         ack = MagicMock()
         payload = {"action_id": "unknown_action", "value": ""}
         handle_tag_options(ack, payload)
 
         ack.assert_called_once_with(options=[])
 
-    def test_filters_by_tag_type(self):
+    def test_filters_by_tag_type(self, _mock_close):
         Tag.objects.create(name="us-east-1", type=TagType.AFFECTED_REGION)
         Tag.objects.create(name="api", type=TagType.AFFECTED_SERVICE)
 

--- a/src/firetower/slack_app/tests/test_bolt.py
+++ b/src/firetower/slack_app/tests/test_bolt.py
@@ -218,8 +218,9 @@ class TestRouting:
 
 
 class TestWithMetrics:
+    @patch("firetower.slack_app.bolt.close_old_connections")
     @patch("firetower.slack_app.bolt.statsd")
-    def test_emits_completed_on_success(self, mock_statsd):
+    def test_emits_completed_on_success(self, mock_statsd, _mock_close):
         handler = MagicMock(return_value="ok")
         wrapped = _with_metrics("test_modal")(handler)
 
@@ -240,8 +241,9 @@ class TestWithMetrics:
         ]
         assert failed_calls == []
 
+    @patch("firetower.slack_app.bolt.close_old_connections")
     @patch("firetower.slack_app.bolt.statsd")
-    def test_emits_failed_on_error(self, mock_statsd):
+    def test_emits_failed_on_error(self, mock_statsd, _mock_close):
         handler = MagicMock(side_effect=RuntimeError("db gone"))
         wrapped = _with_metrics("new_incident_modal")(handler)
 


### PR DESCRIPTION
The slack-bolt middleware calling close_old_connections() runs in the dispatch thread, but handlers run in slack-bolt's thread pool. Since Django DB connections are thread-local, the middleware was cleaning up connections in the wrong thread. After a DB primary failover, handler threads kept using dead connections indefinitely.

Moves close_old_connections() into handle_command() and the _with_metrics wrapper so it runs in the same thread as the DB queries.