### PR TITLE
async: use ddtrace-run for child process

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ dependencies = [
     "cryptography>=48.0.0",
     "datadog==0.52.1",
     "datadog-api-client==2.54.0",
-    "ddtrace==3.18.1",
     "django>=5.2.14,<6",
     "django-cors-headers>=4.9.0",
     "django-fernet-encrypted-fields>=0.3.1",
@@ -45,6 +44,7 @@ dev = [
     "blessed>=1.39.0",
 ]
 prod = [
+    "ddtrace>=3.18.1",
     "granian>=2.6.0",
     "sentry-sdk[django]>=2.47.0",
 ]

--- a/src/firetower/incidents/management/commands/wrapped_worker.py
+++ b/src/firetower/incidents/management/commands/wrapped_worker.py
@@ -75,6 +75,10 @@ def _handle_shutdown(signum: int, frame: Any) -> None:
     _shutdown.set()
 
 
+def _check_binary(fpath: str) -> bool:
+    return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+
 class Command(BaseCommand):
     help = "Run a Q cluster subprocess wrapped with an HTTP health check server."
 
@@ -86,18 +90,39 @@ class Command(BaseCommand):
 
         server = _start_health_server()
 
+        env = os.environ.copy()
+        command: list[str] = []
+
+        ddtrace = shutil.which("ddtrace-run")
+        if ddtrace is None or ddtrace == "":
+            hardcoded_ddtrace = "/app/.venv/bin/ddtrace-run"
+            if not _check_binary(hardcoded_ddtrace):
+                logger.warning(
+                    "ddtrace-run could not be found. Datadog metrics may not work!"
+                )
+            else:
+                ddtrace = hardcoded_ddtrace
+        if ddtrace is not None and ddtrace != "":
+            command.append(ddtrace)
+
         django_admin = shutil.which("django-admin")
         if django_admin is None or django_admin == "":
             django_admin = "/app/.venv/bin/django-admin"
+            if not _check_binary(django_admin):
+                raise RuntimeError(
+                    f"Tried to load django-admin from {django_admin}, but it doesn't exist!"
+                )
+        command.append(django_admin)
 
         proc = None
         try:
             proc = subprocess.Popen(
-                [django_admin, "qcluster", "--settings", "firetower.settings"],
+                [*command, "qcluster", "--settings", "firetower.settings"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=True,
                 bufsize=1,
+                env=env,
             )
 
             def _pump_output() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -605,7 +605,6 @@ dependencies = [
     { name = "cryptography" },
     { name = "datadog" },
     { name = "datadog-api-client" },
-    { name = "ddtrace" },
     { name = "django" },
     { name = "django-cors-headers" },
     { name = "django-fernet-encrypted-fields" },
@@ -638,6 +637,7 @@ dev = [
     { name = "ty" },
 ]
 prod = [
+    { name = "ddtrace" },
     { name = "granian" },
     { name = "sentry-sdk", extra = ["django"] },
 ]
@@ -647,7 +647,6 @@ requires-dist = [
     { name = "cryptography", specifier = ">=48.0.0" },
     { name = "datadog", specifier = "==0.52.1" },
     { name = "datadog-api-client", specifier = "==2.54.0" },
-    { name = "ddtrace", specifier = "==3.18.1" },
     { name = "django", specifier = ">=5.2.14,<6" },
     { name = "django-cors-headers", specifier = ">=4.9.0" },
     { name = "django-fernet-encrypted-fields", specifier = ">=0.3.1" },
@@ -680,6 +679,7 @@ dev = [
     { name = "ty", specifier = ">=0.0.1a19" },
 ]
 prod = [
+    { name = "ddtrace", specifier = ">=3.18.1" },
     { name = "granian", specifier = ">=2.6.0" },
     { name = "sentry-sdk", extras = ["django"], specifier = ">=2.47.0" },
 ]


### PR DESCRIPTION
Attempt to fix the following logs in prod, as well as custom metrics not showing up:

```
DEBUG 2026-05-14 21:42:17,672 ddtrace.internal.remoteconfig.worker Agent is down or Remote Config is not enabled in the Agent
```