### PR TITLE
fix: Block postmortem generation for private incidents

### DIFF
--- a/src/firetower/incidents/tasks.py
+++ b/src/firetower/incidents/tasks.py
@@ -55,6 +55,7 @@ def datadog_log(f: NamedFunction) -> NamedFunction:
 def schedule_demo() -> None:
     incident = Incident.objects.order_by("-created_at").first()
     if incident:
-        logger.info(f"Most recent incident: INC-{incident.id}: {incident.title}")
+        title = "Private Incident" if incident.is_private else incident.title
+        logger.info(f"Most recent incident: INC-{incident.id}: {title}")
     else:
         logger.info("No incidents found.")

--- a/src/firetower/incidents/tests/test_tasks.py
+++ b/src/firetower/incidents/tests/test_tasks.py
@@ -1,8 +1,8 @@
-from unittest.mock import call, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
-from firetower.incidents.tasks import datadog_log
+from firetower.incidents.tasks import datadog_log, schedule_demo
 
 
 class TestDatadogLogTaskName:
@@ -102,3 +102,40 @@ class TestDatadogLogStatsdIncrements:
 
         with pytest.raises(ValueError, match="should propagate"):
             wrapped()
+
+
+class TestScheduleDemoPrivateIncident:
+    @patch("firetower.incidents.tasks.statsd")
+    @patch("firetower.incidents.tasks.Incident")
+    def test_masks_title_for_private_incident(self, mock_incident_cls, mock_statsd):
+        mock_incident = MagicMock()
+        mock_incident.id = 42
+        mock_incident.title = "Secret outage details"
+        mock_incident.is_private = True
+        mock_incident_cls.objects.order_by.return_value.first.return_value = (
+            mock_incident
+        )
+
+        with patch("firetower.incidents.tasks.logger") as mock_logger:
+            schedule_demo.__wrapped__()
+
+        logged = mock_logger.info.call_args[0][0]
+        assert "Private Incident" in logged
+        assert "Secret outage details" not in logged
+
+    @patch("firetower.incidents.tasks.statsd")
+    @patch("firetower.incidents.tasks.Incident")
+    def test_shows_title_for_public_incident(self, mock_incident_cls, mock_statsd):
+        mock_incident = MagicMock()
+        mock_incident.id = 43
+        mock_incident.title = "Public outage"
+        mock_incident.is_private = False
+        mock_incident_cls.objects.order_by.return_value.first.return_value = (
+            mock_incident
+        )
+
+        with patch("firetower.incidents.tasks.logger") as mock_logger:
+            schedule_demo.__wrapped__()
+
+        logged = mock_logger.info.call_args[0][0]
+        assert "Public outage" in logged

--- a/src/firetower/slack_app/handlers/dumpslack.py
+++ b/src/firetower/slack_app/handlers/dumpslack.py
@@ -231,7 +231,12 @@ def handle_dumpslack_command(
         return
 
     if incident.is_private:
-        respond("Postmortem doc generation is disabled for private incidents.")
+        respond(
+            "Postmortem doc generation is disabled for private incidents. "
+            "We are working on a better flow for private incidents, but for now, "
+            "please create a private postmortem document, share it with the "
+            "appropriate people, and link it in the Firetower incident description."
+        )
         return
 
     respond(

--- a/src/firetower/slack_app/handlers/dumpslack.py
+++ b/src/firetower/slack_app/handlers/dumpslack.py
@@ -21,6 +21,9 @@ logger = logging.getLogger(__name__)
 
 
 def _trigger_slack_dump(client: Any, channel_id: str, incident: Any) -> None:
+    if incident.is_private:
+        return
+
     notion = NotionService.from_settings()
     if not notion:
         return
@@ -225,6 +228,10 @@ def handle_dumpslack_command(
     if not incident:
         cmd = command.get("command", "/ft")
         respond(f"No incident found for this channel. Use `{cmd} new` to create one.")
+        return
+
+    if incident.is_private:
+        respond("Postmortem doc generation is disabled for private incidents.")
         return
 
     respond(

--- a/src/firetower/slack_app/tests/handlers/test_dumpslack.py
+++ b/src/firetower/slack_app/tests/handlers/test_dumpslack.py
@@ -447,9 +447,21 @@ class TestDownloadImage:
 
 
 class TestTriggerSlackDump:
-    def test_skips_silently_when_notion_not_configured(self):
+    def test_skips_silently_for_private_incident(self):
         client = MagicMock()
         mock_incident = MagicMock()
+        mock_incident.is_private = True
+        with patch(
+            "firetower.slack_app.handlers.dumpslack.NotionService.from_settings",
+        ) as mock_notion:
+            _trigger_slack_dump(client, "C123", mock_incident)
+
+        mock_notion.assert_not_called()
+        client.chat_postMessage.assert_not_called()
+
+    def test_skips_silently_when_notion_not_configured(self):
+        client = MagicMock()
+        mock_incident = MagicMock(is_private=False)
         with patch(
             "firetower.slack_app.handlers.dumpslack.NotionService.from_settings",
             return_value=None,
@@ -460,7 +472,7 @@ class TestTriggerSlackDump:
 
     def test_posts_start_message_and_completion(self):
         client = MagicMock()
-        mock_incident = MagicMock()
+        mock_incident = MagicMock(is_private=False)
         mock_incident.captain = None
         mock_page = {"id": "page-id", "url": "https://notion.so/page-id"}
         mock_notion_link = MagicMock(url="")
@@ -498,7 +510,7 @@ class TestTriggerSlackDump:
         client.chat_postMessage.side_effect = SlackApiError(
             message="not_in_channel", response={"ok": False, "error": "not_in_channel"}
         )
-        mock_incident = MagicMock()
+        mock_incident = MagicMock(is_private=False)
         mock_incident.captain = None
         mock_page = {"id": "page-id", "url": "https://notion.so/page-id"}
         mock_notion_link = MagicMock(url="")
@@ -579,9 +591,32 @@ class TestHandleDumpslackCommand:
         ack.assert_called_once()
         assert "No incident" in respond.call_args[0][0]
 
-    def test_dispatches_async_dump(self):
+    def test_responds_when_private_incident(self):
         ack, body, command, client, respond, _ = self._make_args()
         mock_incident = MagicMock()
+        mock_incident.is_private = True
+        with (
+            patch(
+                "firetower.slack_app.handlers.dumpslack.NotionService.is_configured",
+                return_value=True,
+            ),
+            patch(
+                "firetower.slack_app.handlers.dumpslack.get_incident_from_channel",
+                return_value=mock_incident,
+            ),
+            patch(
+                "firetower.slack_app.handlers.dumpslack.trigger_slack_dump_async"
+            ) as mock_async,
+        ):
+            handle_dumpslack_command(ack, body, command, client, respond)
+
+        ack.assert_called_once()
+        assert "private" in respond.call_args[0][0].lower()
+        mock_async.assert_not_called()
+
+    def test_dispatches_async_dump(self):
+        ack, body, command, client, respond, _ = self._make_args()
+        mock_incident = MagicMock(is_private=False)
         with (
             patch(
                 "firetower.slack_app.handlers.dumpslack.NotionService.is_configured",


### PR DESCRIPTION
Prevents private incident details from leaking through the postmortem doc generation flow. Private incidents now skip Notion page creation, GenAI timeline generation, and mask titles in logs. Responders who run dumpslack on a private incident get a message with guidance on the manual flow.

Ideally we figure out how to do private docs through automation, but for now this will unblock our private incidents.