### PR TITLE
fix: Make PM info message public

### DIFF
--- a/src/firetower/slack_app/handlers/dumpslack.py
+++ b/src/firetower/slack_app/handlers/dumpslack.py
@@ -20,8 +20,25 @@ from firetower.slack_app.handlers.utils import get_incident_from_channel
 logger = logging.getLogger(__name__)
 
 
+_PRIVATE_INCIDENT_PM_MESSAGE = (
+    "Postmortem doc generation is disabled for private incidents. "
+    "We are working on a better flow for private incidents, but for now, "
+    "please create a private postmortem document, share it with the "
+    "appropriate people, and link it in the Firetower incident description."
+)
+
+
 def _trigger_slack_dump(client: Any, channel_id: str, incident: Any) -> None:
     if incident.is_private:
+        try:
+            client.chat_postMessage(
+                channel=channel_id, text=_PRIVATE_INCIDENT_PM_MESSAGE
+            )
+        except Exception:
+            logger.exception(
+                "Failed to post private incident PM message to channel %s",
+                channel_id,
+            )
         return
 
     notion = NotionService.from_settings()
@@ -231,12 +248,7 @@ def handle_dumpslack_command(
         return
 
     if incident.is_private:
-        respond(
-            "Postmortem doc generation is disabled for private incidents. "
-            "We are working on a better flow for private incidents, but for now, "
-            "please create a private postmortem document, share it with the "
-            "appropriate people, and link it in the Firetower incident description."
-        )
+        respond(_PRIVATE_INCIDENT_PM_MESSAGE)
         return
 
     respond(

--- a/src/firetower/slack_app/handlers/help.py
+++ b/src/firetower/slack_app/handlers/help.py
@@ -18,6 +18,6 @@ def handle_help_command(ack: Any, command: dict, respond: Any) -> None:
         f"  `{cmd} mitigated` - Mark incident as mitigated (alias: `{cmd} mit`)\n"
         f"  `{cmd} resolved` - Mark incident as resolved (alias: `{cmd} fixed`)\n"
         f"  `{cmd} statuspage` - Create or update a statuspage post\n"
-        f"  `{cmd} dumpslack` - Dump slack channel history (not yet implemented)\n"
+        f"  `{cmd} dumpslack` - Update slack transcript in postmortem doc\n"
         f"  `{cmd} reopen` - Reopen an incident\n"
     )

--- a/src/firetower/slack_app/tests/handlers/test_dumpslack.py
+++ b/src/firetower/slack_app/tests/handlers/test_dumpslack.py
@@ -447,7 +447,7 @@ class TestDownloadImage:
 
 
 class TestTriggerSlackDump:
-    def test_skips_silently_for_private_incident(self):
+    def test_posts_guidance_and_skips_notion_for_private_incident(self):
         client = MagicMock()
         mock_incident = MagicMock()
         mock_incident.is_private = True
@@ -457,7 +457,10 @@ class TestTriggerSlackDump:
             _trigger_slack_dump(client, "C123", mock_incident)
 
         mock_notion.assert_not_called()
-        client.chat_postMessage.assert_not_called()
+        client.chat_postMessage.assert_called_once()
+        posted = client.chat_postMessage.call_args[1]["text"]
+        assert "private" in posted.lower()
+        assert "C123" == client.chat_postMessage.call_args[1]["channel"]
 
     def test_skips_silently_when_notion_not_configured(self):
         client = MagicMock()


### PR DESCRIPTION
Should have tested this. Makes the PM info message for private incidents public, not ephemeral.
