### PR TITLE
attempt to fix datadog metrics in worker

### DIFF
--- a/src/firetower/incidents/tasks.py
+++ b/src/firetower/incidents/tasks.py
@@ -47,6 +47,9 @@ def datadog_log(f: NamedFunction) -> NamedFunction:
             raise e
         else:
             statsd.increment("django_q.task.success", 1, tags)
+        finally:
+            # TODO(taylor-osler-sentry): Figure out if/why this is necessary?
+            statsd.flush()
 
     return wrapper
 

--- a/src/firetower/incidents/tasks.py
+++ b/src/firetower/incidents/tasks.py
@@ -49,7 +49,13 @@ def datadog_log(f: NamedFunction) -> NamedFunction:
             statsd.increment("django_q.task.success", 1, tags)
         finally:
             # TODO(taylor-osler-sentry): Figure out if/why this is necessary?
-            statsd.flush()
+            try:
+                statsd.flush()
+            except Exception as e:
+                logger.error(
+                    f"Error while flushing datadog metrics: {e}", exc_info=True
+                )
+                # Don't re-raise; it's more important we raise the inner exception, if present
 
     return wrapper
 


### PR DESCRIPTION
For some reason metrics don't appear to be showing up right in Datadog. I can see the metrics, so they've been submitted *at least once*, but it's inconsistent. My current theory is that we aren't flushing the metrics buffer due to some quirk of how the worker is executing.

This PR makes the flush explicit.