### PR TITLE
feat: Add Linear hooks, action item endpoints, and backfill

### DIFF
--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -902,12 +902,17 @@ def _claim_linear_issue(
         issue = linear_service.get_issue(identifier)
         if issue:
             return issue
-        linear_service.create_issue("Placeholder", "", team_id, project_id)
+        result = linear_service.create_issue("Placeholder", "", team_id, project_id)
+        if not result:
+            logger.warning(
+                f"Failed to create placeholder Linear issue for {identifier}"
+            )
+            return None
 
     return None
 
 
-def _create_linear_parent_issue(incident: Incident) -> None:
+def create_linear_parent_issue(incident: Incident) -> None:
     linear_config = settings.LINEAR
     if not linear_config:
         return
@@ -1091,7 +1096,7 @@ def on_incident_created(incident: Incident) -> None:
         _create_troubleshooting_doc(incident, channel_id)
 
     try:
-        _create_linear_parent_issue(incident)
+        create_linear_parent_issue(incident)
     except Exception:
         logger.exception(
             f"Failed to create Linear parent issue for incident {incident.id}"

--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -1,5 +1,6 @@
 import logging
 from dataclasses import dataclass
+from typing import Any
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -15,6 +16,7 @@ from firetower.incidents.models import (
 )
 from firetower.integrations.services import (
     DatadogService,
+    LinearService,
     PagerDutyService,
     SlackService,
 )
@@ -857,6 +859,131 @@ def decorate_incident_channel(
             logger.exception(f"Failed to post to feed channel for {ctx.channel_name}")
 
 
+def _linear_issue_title(incident: Incident) -> str:
+    if incident.is_private:
+        return f"[{incident.incident_number}] Private Incident"
+    return f"[{incident.incident_number}] {incident.title}"
+
+
+def _sync_linear_title(incident: Incident) -> None:
+    if not incident.linear_parent_issue_id:
+        return
+    try:
+        linear_service = LinearService()
+        linear_service.update_issue(
+            incident.linear_parent_issue_id,
+            title=_linear_issue_title(incident),
+        )
+    except Exception:
+        logger.exception(
+            f"Failed to update Linear issue title for incident {incident.id}"
+        )
+
+
+LINEAR_PARENT_DESCRIPTION = (
+    "Relate action items to this ticket to have them tracked by Firetower. "
+    "Child issues or other relations (related, blocking, etc.) will all work. "
+    "Do not update title or captain here, use Firetower for that."
+)
+
+
+MAX_CLAIM_ATTEMPTS = 5
+
+
+def _claim_linear_issue(
+    linear_service: LinearService,
+    incident: Incident,
+    team_id: str,
+    project_id: str | None,
+) -> dict[str, Any] | None:
+    identifier = incident.incident_number
+
+    for _ in range(MAX_CLAIM_ATTEMPTS):
+        issue = linear_service.get_issue(identifier)
+        if issue:
+            return issue
+        linear_service.create_issue("Placeholder", "", team_id, project_id)
+
+    return None
+
+
+def _create_linear_parent_issue(incident: Incident) -> None:
+    linear_config = settings.LINEAR
+    if not linear_config:
+        return
+    team_id = str(linear_config.get("TEAM_ID", ""))
+    if not team_id:
+        return
+
+    linear_link, created = ExternalLink.objects.get_or_create(
+        incident=incident,
+        type=ExternalLinkType.LINEAR,
+        defaults={"url": ""},
+    )
+    if not created:
+        logger.info(f"Incident {incident.id} already has a Linear link, skipping")
+        return
+
+    try:
+        linear_service = LinearService()
+        project_id = str(linear_config.get("PROJECT_ID", "")) or None
+        sync_identifiers = linear_config.get("SYNC_IDENTIFIERS", False)
+        title = _linear_issue_title(incident)
+
+        if sync_identifiers:
+            issue = _claim_linear_issue(linear_service, incident, team_id, project_id)
+            if not issue:
+                linear_link.delete()
+                logger.warning(
+                    f"Failed to claim Linear issue for incident {incident.id}"
+                )
+                return
+
+            states = linear_service.get_workflow_states(team_id)
+            started_state_id = states.get("started") if states else None
+            if not linear_service.update_issue(
+                issue["id"],
+                title=title,
+                description=LINEAR_PARENT_DESCRIPTION,
+                state_id=started_state_id,
+            ):
+                logger.warning(
+                    f"Failed to update claimed Linear issue for incident {incident.id}"
+                )
+        else:
+            issue = linear_service.create_issue(
+                title, LINEAR_PARENT_DESCRIPTION, team_id, project_id
+            )
+            if not issue:
+                linear_link.delete()
+                logger.warning(
+                    f"Failed to create Linear issue for incident {incident.id}"
+                )
+                return
+
+        linear_link.url = issue["url"]
+        linear_link.save(update_fields=["url"])
+
+        incident.linear_parent_issue_id = issue["id"]
+        incident.save(update_fields=["linear_parent_issue_id"])
+    except Exception:
+        linear_link.delete()
+        logger.exception(
+            f"Failed to create Linear parent issue for incident {incident.id}"
+        )
+        return
+
+    try:
+        incident_url = _build_incident_url(incident)
+        linear_service.create_attachment(
+            issue["id"], incident_url, f"Firetower: {incident.incident_number}"
+        )
+    except Exception:
+        logger.exception(
+            f"Failed to create Linear attachment for incident {incident.id}"
+        )
+
+
 def on_incident_created(incident: Incident) -> None:
     # Use get_or_create to atomically claim the ExternalLink row before calling
     # the Slack API.  If two concurrent requests both reach this point, only one
@@ -963,6 +1090,13 @@ def on_incident_created(incident: Incident) -> None:
         _create_datadog_notebook(incident, channel_id)
         _create_troubleshooting_doc(incident, channel_id)
 
+    try:
+        _create_linear_parent_issue(incident)
+    except Exception:
+        logger.exception(
+            f"Failed to create Linear parent issue for incident {incident.id}"
+        )
+
 
 def on_status_changed(incident: Incident, old_status: str) -> None:
     channel_id: str | None = None
@@ -1046,30 +1180,30 @@ def on_severity_changed(incident: Incident, old_severity: str) -> None:
 def on_title_changed(incident: Incident) -> None:
     try:
         channel_id = _get_channel_id(incident)
-        if not channel_id:
-            return
-
-        _slack_service.set_channel_topic(channel_id, build_channel_topic(incident))
+        if channel_id:
+            _slack_service.set_channel_topic(channel_id, build_channel_topic(incident))
     except Exception:
         logger.exception(f"Error in on_title_changed for incident {incident.id}")
+
+    _sync_linear_title(incident)
 
 
 def on_visibility_changed(incident: Incident) -> None:
     try:
         channel_id = _get_channel_id(incident)
-        if not channel_id:
-            return
-
-        visibility = "private" if incident.is_private else "public"
-        incident_url = _build_incident_url(incident)
-        message = (
-            f"This incident has been marked as *{visibility}* in Firetower. "
-            f"If you want to make this channel {visibility}, you will need a Slack admin to make the change.\n"
-            f"<{incident_url}|View in Firetower>"
-        )
-        _slack_service.post_message(channel_id, message)
+        if channel_id:
+            visibility = "private" if incident.is_private else "public"
+            incident_url = _build_incident_url(incident)
+            message = (
+                f"This incident has been marked as *{visibility}* in Firetower. "
+                f"If you want to make this channel {visibility}, you will need a Slack admin to make the change.\n"
+                f"<{incident_url}|View in Firetower>"
+            )
+            _slack_service.post_message(channel_id, message)
     except Exception:
         logger.exception(f"Error in on_visibility_changed for incident {incident.id}")
+
+    _sync_linear_title(incident)
 
 
 def on_captain_changed(incident: Incident) -> None:

--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -902,6 +902,7 @@ def _claim_linear_issue(
         issue = linear_service.get_issue(identifier)
         if issue:
             return issue
+        # Created issue may get a different identifier; discard it and retry lookup
         result = linear_service.create_issue("Placeholder", "", team_id, project_id)
         if not result:
             logger.warning(

--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -953,9 +953,11 @@ def create_linear_parent_issue(incident: Incident) -> None:
                 description=LINEAR_PARENT_DESCRIPTION,
                 state_id=started_state_id,
             ):
+                linear_link.delete()
                 logger.warning(
                     f"Failed to update claimed Linear issue for incident {incident.id}"
                 )
+                return
         else:
             issue = linear_service.create_issue(
                 title, LINEAR_PARENT_DESCRIPTION, team_id, project_id

--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -866,7 +866,7 @@ def _linear_issue_title(incident: Incident) -> str:
 
 
 def _sync_linear_title(incident: Incident) -> None:
-    if not incident.linear_parent_issue_id:
+    if not settings.LINEAR or not incident.linear_parent_issue_id:
         return
     try:
         linear_service = LinearService()
@@ -926,7 +926,7 @@ def create_linear_parent_issue(incident: Incident) -> None:
         type=ExternalLinkType.LINEAR,
         defaults={"url": ""},
     )
-    if not created:
+    if not created and incident.linear_parent_issue_id:
         logger.info(f"Incident {incident.id} already has a Linear link, skipping")
         return
 

--- a/src/firetower/incidents/services.py
+++ b/src/firetower/incidents/services.py
@@ -217,10 +217,10 @@ def sync_action_items_from_linear(
 
     if not incident.linear_parent_issue_id:
         from firetower.incidents.hooks import (  # noqa: PLC0415
-            _create_linear_parent_issue,
+            create_linear_parent_issue,
         )
 
-        _create_linear_parent_issue(incident)
+        create_linear_parent_issue(incident)
         incident.refresh_from_db(fields=["linear_parent_issue_id"])
         if not incident.linear_parent_issue_id:
             stats.skipped = True

--- a/src/firetower/incidents/services.py
+++ b/src/firetower/incidents/services.py
@@ -216,7 +216,7 @@ def sync_action_items_from_linear(
     stats = ActionItemsSyncStats()
 
     if not incident.linear_parent_issue_id:
-        # One-time backfill for incidents created before Linear integration
+        # Backfill for incidents created before Linear integration
         from firetower.incidents.hooks import (  # noqa: PLC0415
             create_linear_parent_issue,
         )

--- a/src/firetower/incidents/services.py
+++ b/src/firetower/incidents/services.py
@@ -216,6 +216,7 @@ def sync_action_items_from_linear(
     stats = ActionItemsSyncStats()
 
     if not incident.linear_parent_issue_id:
+        # One-time backfill for incidents created before Linear integration
         from firetower.incidents.hooks import (  # noqa: PLC0415
             create_linear_parent_issue,
         )

--- a/src/firetower/incidents/services.py
+++ b/src/firetower/incidents/services.py
@@ -216,8 +216,15 @@ def sync_action_items_from_linear(
     stats = ActionItemsSyncStats()
 
     if not incident.linear_parent_issue_id:
-        stats.skipped = True
-        return stats
+        from firetower.incidents.hooks import (  # noqa: PLC0415
+            _create_linear_parent_issue,
+        )
+
+        _create_linear_parent_issue(incident)
+        incident.refresh_from_db(fields=["linear_parent_issue_id"])
+        if not incident.linear_parent_issue_id:
+            stats.skipped = True
+            return stats
 
     if not force and incident.action_items_last_synced_at:
         time_since_sync = timezone.now() - incident.action_items_last_synced_at

--- a/src/firetower/incidents/tests/test_action_items.py
+++ b/src/firetower/incidents/tests/test_action_items.py
@@ -387,7 +387,7 @@ class TestSyncActionItemsFromLinear:
 
         with (
             patch(
-                "firetower.incidents.services.create_linear_parent_issue",
+                "firetower.incidents.hooks.create_linear_parent_issue",
                 side_effect=fake_create_parent,
             ) as mock_create_parent,
             patch("firetower.incidents.services._get_linear_service") as mock_get,

--- a/src/firetower/incidents/tests/test_action_items.py
+++ b/src/firetower/incidents/tests/test_action_items.py
@@ -944,6 +944,7 @@ class TestCreateLinearParentIssueHook:
             title="Test Incident",
             status=IncidentStatus.ACTIVE,
             severity=IncidentSeverity.P1,
+            linear_parent_issue_id="existing-id",
         )
         ExternalLink.objects.create(
             incident=incident,

--- a/src/firetower/incidents/tests/test_action_items.py
+++ b/src/firetower/incidents/tests/test_action_items.py
@@ -8,7 +8,7 @@ from rest_framework.test import APIClient
 
 from firetower.auth.models import ExternalProfile, ExternalProfileType, UserProfile
 from firetower.incidents.hooks import (
-    _create_linear_parent_issue,
+    create_linear_parent_issue,
     on_title_changed,
     on_visibility_changed,
 )
@@ -368,6 +368,40 @@ class TestSyncActionItemsFromLinear:
                 user=item.assignee, type=ExternalProfileType.LINEAR
             )
             assert profile.external_id == "linear-user-456"
+
+    def test_backfill_creates_parent_and_syncs(self, settings):
+        settings.LINEAR = {"TEAM_ID": "team-1"}
+        incident = Incident.objects.create(
+            title="Test Incident",
+            status=IncidentStatus.ACTIVE,
+            severity=IncidentSeverity.P1,
+        )
+
+        children = [
+            _make_linear_issue(id="id-1", identifier="ENG-1", title="Task 1"),
+        ]
+
+        def fake_create_parent(inc):
+            inc.linear_parent_issue_id = "backfilled-parent-id"
+            inc.save(update_fields=["linear_parent_issue_id"])
+
+        with (
+            patch(
+                "firetower.incidents.services.create_linear_parent_issue",
+                side_effect=fake_create_parent,
+            ) as mock_create_parent,
+            patch("firetower.incidents.services._get_linear_service") as mock_get,
+        ):
+            mock_get.return_value.get_child_issues.return_value = children
+            mock_get.return_value.get_related_issues.return_value = []
+            mock_get.return_value.get_workflow_states.return_value = None
+
+            stats = sync_action_items_from_linear(incident, force=True)
+
+            mock_create_parent.assert_called_once_with(incident)
+            assert stats.skipped is False
+            assert stats.created == 1
+            assert incident.action_items.count() == 1
 
     def test_auto_completes_parent_when_all_done(self, settings):
         settings.LINEAR = {"TEAM_ID": "team-1"}
@@ -797,7 +831,7 @@ class TestCreateLinearParentIssueHook:
             severity=IncidentSeverity.P1,
         )
 
-        _create_linear_parent_issue(incident)
+        create_linear_parent_issue(incident)
 
         incident.refresh_from_db()
         assert incident.linear_parent_issue_id == "linear-issue-id"
@@ -850,7 +884,7 @@ class TestCreateLinearParentIssueHook:
             severity=IncidentSeverity.P1,
         )
 
-        _create_linear_parent_issue(incident)
+        create_linear_parent_issue(incident)
 
         incident.refresh_from_db()
         assert incident.linear_parent_issue_id == "linear-issue-id"
@@ -868,7 +902,7 @@ class TestCreateLinearParentIssueHook:
             severity=IncidentSeverity.P1,
         )
 
-        _create_linear_parent_issue(incident)
+        create_linear_parent_issue(incident)
 
         assert not ExternalLink.objects.filter(
             incident=incident, type=ExternalLinkType.LINEAR
@@ -894,7 +928,7 @@ class TestCreateLinearParentIssueHook:
             severity=IncidentSeverity.P1,
         )
 
-        _create_linear_parent_issue(incident)
+        create_linear_parent_issue(incident)
 
         assert not ExternalLink.objects.filter(
             incident=incident, type=ExternalLinkType.LINEAR
@@ -917,7 +951,7 @@ class TestCreateLinearParentIssueHook:
             url="https://linear.app/existing",
         )
 
-        _create_linear_parent_issue(incident)
+        create_linear_parent_issue(incident)
 
         MockLinearService.return_value.get_issue.assert_not_called()
 
@@ -947,7 +981,7 @@ class TestCreateLinearParentIssueHook:
             severity=IncidentSeverity.P1,
         )
 
-        _create_linear_parent_issue(incident)
+        create_linear_parent_issue(incident)
 
         incident.refresh_from_db()
         assert incident.linear_parent_issue_id == "new-issue-id"
@@ -1050,7 +1084,7 @@ class TestCreateLinearParentIssuePrivacy:
             is_private=True,
         )
 
-        _create_linear_parent_issue(incident)
+        create_linear_parent_issue(incident)
 
         call_args = mock_service.update_issue.call_args
         assert call_args[1]["title"] == f"[{incident.incident_number}] Private Incident"

--- a/src/firetower/incidents/tests/test_action_items.py
+++ b/src/firetower/incidents/tests/test_action_items.py
@@ -4,17 +4,26 @@ from unittest.mock import patch
 import pytest
 from django.contrib.auth.models import User
 from django.utils import timezone
+from rest_framework.test import APIClient
 
-from firetower.auth.models import ExternalProfile, ExternalProfileType
+from firetower.auth.models import ExternalProfile, ExternalProfileType, UserProfile
+from firetower.incidents.hooks import (
+    _create_linear_parent_issue,
+    on_title_changed,
+    on_visibility_changed,
+)
 from firetower.incidents.models import (
     ActionItem,
     ActionItemRelationType,
     ActionItemStatus,
+    ExternalLink,
+    ExternalLinkType,
     Incident,
     IncidentSeverity,
     IncidentStatus,
 )
 from firetower.incidents.services import (
+    ActionItemsSyncStats,
     sync_action_items_from_linear,
 )
 from firetower.integrations.services.linear import LinearService
@@ -757,3 +766,465 @@ class TestLinearService:
             states2 = service.get_workflow_states("team-1")
             assert states2 is states
             assert mock_gql.call_count == 1
+
+
+@pytest.mark.django_db
+class TestCreateLinearParentIssueHook:
+    @patch("firetower.incidents.hooks.LinearService")
+    @patch("firetower.incidents.hooks.settings")
+    def test_claims_precreated_issue(self, mock_settings, MockLinearService):
+        mock_settings.LINEAR = {
+            "TEAM_ID": "team-1",
+            "PROJECT_ID": "",
+            "SYNC_IDENTIFIERS": True,
+        }
+        mock_settings.FIRETOWER_BASE_URL = "https://firetower.example.com"
+
+        mock_service = MockLinearService.return_value
+        mock_service.get_issue.return_value = {
+            "id": "linear-issue-id",
+            "identifier": "INC-100",
+            "title": "Placeholder",
+            "url": "https://linear.app/t/INC-100",
+        }
+        mock_service.get_workflow_states.return_value = {"started": "started-id"}
+        mock_service.update_issue.return_value = True
+        mock_service.create_attachment.return_value = True
+
+        incident = Incident.objects.create(
+            title="Test Incident",
+            status=IncidentStatus.ACTIVE,
+            severity=IncidentSeverity.P1,
+        )
+
+        _create_linear_parent_issue(incident)
+
+        incident.refresh_from_db()
+        assert incident.linear_parent_issue_id == "linear-issue-id"
+
+        linear_link = ExternalLink.objects.get(
+            incident=incident, type=ExternalLinkType.LINEAR
+        )
+        assert linear_link.url == "https://linear.app/t/INC-100"
+
+        mock_service.create_issue.assert_not_called()
+        mock_service.update_issue.assert_called_once()
+        mock_service.create_attachment.assert_called_once_with(
+            "linear-issue-id",
+            f"https://firetower.example.com/{incident.incident_number}",
+            f"Firetower: {incident.incident_number}",
+        )
+
+    @patch("firetower.incidents.hooks.LinearService")
+    @patch("firetower.incidents.hooks.settings")
+    def test_creates_placeholder_when_not_precreated(
+        self, mock_settings, MockLinearService
+    ):
+        mock_settings.LINEAR = {
+            "TEAM_ID": "team-1",
+            "PROJECT_ID": "",
+            "SYNC_IDENTIFIERS": True,
+        }
+        mock_settings.FIRETOWER_BASE_URL = "https://firetower.example.com"
+
+        mock_service = MockLinearService.return_value
+        issue_data = {
+            "id": "linear-issue-id",
+            "identifier": "INC-100",
+            "title": "Placeholder",
+            "url": "https://linear.app/t/INC-100",
+        }
+        mock_service.get_issue.side_effect = [None, issue_data]
+        mock_service.create_issue.return_value = {
+            "id": "placeholder-id",
+            "identifier": "INC-99",
+            "url": "https://linear.app/t/INC-99",
+        }
+        mock_service.get_workflow_states.return_value = {"started": "started-id"}
+        mock_service.update_issue.return_value = True
+        mock_service.create_attachment.return_value = True
+
+        incident = Incident.objects.create(
+            title="Test Incident",
+            status=IncidentStatus.ACTIVE,
+            severity=IncidentSeverity.P1,
+        )
+
+        _create_linear_parent_issue(incident)
+
+        incident.refresh_from_db()
+        assert incident.linear_parent_issue_id == "linear-issue-id"
+        mock_service.create_issue.assert_called_once_with(
+            "Placeholder", "", "team-1", None
+        )
+
+    @patch("firetower.incidents.hooks.settings")
+    def test_skips_when_no_team_id(self, mock_settings):
+        mock_settings.LINEAR = {"TEAM_ID": ""}
+
+        incident = Incident.objects.create(
+            title="Test Incident",
+            status=IncidentStatus.ACTIVE,
+            severity=IncidentSeverity.P1,
+        )
+
+        _create_linear_parent_issue(incident)
+
+        assert not ExternalLink.objects.filter(
+            incident=incident, type=ExternalLinkType.LINEAR
+        ).exists()
+
+    @patch("firetower.incidents.hooks.LinearService")
+    @patch("firetower.incidents.hooks.settings")
+    def test_cleans_up_on_claim_failure(self, mock_settings, MockLinearService):
+        mock_settings.LINEAR = {
+            "TEAM_ID": "team-1",
+            "PROJECT_ID": "",
+            "SYNC_IDENTIFIERS": True,
+        }
+        mock_settings.FIRETOWER_BASE_URL = "https://firetower.example.com"
+
+        mock_service = MockLinearService.return_value
+        mock_service.get_issue.return_value = None
+        mock_service.create_issue.return_value = None
+
+        incident = Incident.objects.create(
+            title="Test Incident",
+            status=IncidentStatus.ACTIVE,
+            severity=IncidentSeverity.P1,
+        )
+
+        _create_linear_parent_issue(incident)
+
+        assert not ExternalLink.objects.filter(
+            incident=incident, type=ExternalLinkType.LINEAR
+        ).exists()
+        assert incident.linear_parent_issue_id is None
+
+    @patch("firetower.incidents.hooks.LinearService")
+    @patch("firetower.incidents.hooks.settings")
+    def test_skips_when_link_already_exists(self, mock_settings, MockLinearService):
+        mock_settings.LINEAR = {"TEAM_ID": "team-1", "PROJECT_ID": ""}
+
+        incident = Incident.objects.create(
+            title="Test Incident",
+            status=IncidentStatus.ACTIVE,
+            severity=IncidentSeverity.P1,
+        )
+        ExternalLink.objects.create(
+            incident=incident,
+            type=ExternalLinkType.LINEAR,
+            url="https://linear.app/existing",
+        )
+
+        _create_linear_parent_issue(incident)
+
+        MockLinearService.return_value.get_issue.assert_not_called()
+
+    @patch("firetower.incidents.hooks.LinearService")
+    @patch("firetower.incidents.hooks.settings")
+    def test_creates_new_issue_when_sync_identifiers_disabled(
+        self, mock_settings, MockLinearService
+    ):
+        mock_settings.LINEAR = {
+            "TEAM_ID": "team-1",
+            "PROJECT_ID": "proj-1",
+            "SYNC_IDENTIFIERS": False,
+        }
+        mock_settings.FIRETOWER_BASE_URL = "https://firetower.example.com"
+
+        mock_service = MockLinearService.return_value
+        mock_service.create_issue.return_value = {
+            "id": "new-issue-id",
+            "identifier": "ENG-200",
+            "url": "https://linear.app/t/ENG-200",
+        }
+        mock_service.create_attachment.return_value = True
+
+        incident = Incident.objects.create(
+            title="Test Incident",
+            status=IncidentStatus.ACTIVE,
+            severity=IncidentSeverity.P1,
+        )
+
+        _create_linear_parent_issue(incident)
+
+        incident.refresh_from_db()
+        assert incident.linear_parent_issue_id == "new-issue-id"
+
+        linear_link = ExternalLink.objects.get(
+            incident=incident, type=ExternalLinkType.LINEAR
+        )
+        assert linear_link.url == "https://linear.app/t/ENG-200"
+
+        mock_service.get_issue.assert_not_called()
+        mock_service.create_issue.assert_called_once()
+
+
+@pytest.mark.django_db
+class TestTitleChangeLinearSync:
+    @patch("firetower.incidents.hooks.LinearService")
+    def test_updates_linear_title(self, MockLinearService):
+        mock_service = MockLinearService.return_value
+        mock_service.update_issue.return_value = True
+
+        incident = Incident.objects.create(
+            title="Updated Title",
+            status=IncidentStatus.ACTIVE,
+            severity=IncidentSeverity.P1,
+            linear_parent_issue_id="linear-issue-id",
+        )
+
+        with patch("firetower.incidents.hooks._get_channel_id", return_value=None):
+            on_title_changed(incident)
+
+        mock_service.update_issue.assert_called_once_with(
+            "linear-issue-id",
+            title=f"[{incident.incident_number}] Updated Title",
+        )
+
+    @patch("firetower.incidents.hooks.LinearService")
+    def test_skips_when_no_parent_issue(self, MockLinearService):
+        incident = Incident.objects.create(
+            title="Test",
+            status=IncidentStatus.ACTIVE,
+            severity=IncidentSeverity.P1,
+        )
+
+        with patch("firetower.incidents.hooks._get_channel_id", return_value=None):
+            on_title_changed(incident)
+
+        MockLinearService.return_value.update_issue.assert_not_called()
+
+    @patch("firetower.incidents.hooks.LinearService")
+    def test_redacts_title_for_private_incident(self, MockLinearService):
+        mock_service = MockLinearService.return_value
+        mock_service.update_issue.return_value = True
+
+        incident = Incident.objects.create(
+            title="Secret Outage",
+            status=IncidentStatus.ACTIVE,
+            severity=IncidentSeverity.P1,
+            linear_parent_issue_id="linear-issue-id",
+            is_private=True,
+        )
+
+        with patch("firetower.incidents.hooks._get_channel_id", return_value=None):
+            on_title_changed(incident)
+
+        mock_service.update_issue.assert_called_once_with(
+            "linear-issue-id",
+            title=f"[{incident.incident_number}] Private Incident",
+        )
+
+
+@pytest.mark.django_db
+class TestCreateLinearParentIssuePrivacy:
+    @patch("firetower.incidents.hooks.LinearService")
+    @patch("firetower.incidents.hooks.settings")
+    def test_creates_with_redacted_title_for_private_incident(
+        self, mock_settings, MockLinearService
+    ):
+        mock_settings.LINEAR = {
+            "TEAM_ID": "team-1",
+            "PROJECT_ID": "",
+            "SYNC_IDENTIFIERS": True,
+        }
+        mock_settings.FIRETOWER_BASE_URL = "https://firetower.example.com"
+
+        mock_service = MockLinearService.return_value
+        mock_service.get_issue.return_value = {
+            "id": "linear-issue-id",
+            "identifier": "INC-100",
+            "title": "Placeholder",
+            "url": "https://linear.app/t/INC-100",
+        }
+        mock_service.get_workflow_states.return_value = {"started": "started-id"}
+        mock_service.update_issue.return_value = True
+        mock_service.create_attachment.return_value = True
+
+        incident = Incident.objects.create(
+            title="Secret Outage",
+            status=IncidentStatus.ACTIVE,
+            severity=IncidentSeverity.P1,
+            is_private=True,
+        )
+
+        _create_linear_parent_issue(incident)
+
+        call_args = mock_service.update_issue.call_args
+        assert call_args[1]["title"] == f"[{incident.incident_number}] Private Incident"
+
+
+@pytest.mark.django_db
+class TestVisibilityChangeLinearSync:
+    @patch("firetower.incidents.hooks.LinearService")
+    def test_redacts_title_when_made_private(self, MockLinearService):
+        mock_service = MockLinearService.return_value
+        mock_service.update_issue.return_value = True
+
+        incident = Incident.objects.create(
+            title="Visible Outage",
+            status=IncidentStatus.ACTIVE,
+            severity=IncidentSeverity.P1,
+            linear_parent_issue_id="linear-issue-id",
+            is_private=True,
+        )
+
+        with patch("firetower.incidents.hooks._get_channel_id", return_value=None):
+            on_visibility_changed(incident)
+
+        mock_service.update_issue.assert_called_once_with(
+            "linear-issue-id",
+            title=f"[{incident.incident_number}] Private Incident",
+        )
+
+    @patch("firetower.incidents.hooks.LinearService")
+    def test_restores_title_when_made_public(self, MockLinearService):
+        mock_service = MockLinearService.return_value
+        mock_service.update_issue.return_value = True
+
+        incident = Incident.objects.create(
+            title="Now Public Outage",
+            status=IncidentStatus.ACTIVE,
+            severity=IncidentSeverity.P1,
+            linear_parent_issue_id="linear-issue-id",
+            is_private=False,
+        )
+
+        with patch("firetower.incidents.hooks._get_channel_id", return_value=None):
+            on_visibility_changed(incident)
+
+        mock_service.update_issue.assert_called_once_with(
+            "linear-issue-id",
+            title=f"[{incident.incident_number}] Now Public Outage",
+        )
+
+    @patch("firetower.incidents.hooks.LinearService")
+    def test_skips_when_no_parent_issue(self, MockLinearService):
+        incident = Incident.objects.create(
+            title="Test",
+            status=IncidentStatus.ACTIVE,
+            severity=IncidentSeverity.P1,
+            is_private=True,
+        )
+
+        with patch("firetower.incidents.hooks._get_channel_id", return_value=None):
+            on_visibility_changed(incident)
+
+        MockLinearService.return_value.update_issue.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestActionItemViews:
+    def setup_method(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username="test@example.com",
+            email="test@example.com",
+            password="testpass123",
+        )
+        self.client.force_authenticate(user=self.user)
+
+    def test_list_action_items(self):
+        incident = Incident.objects.create(
+            title="Test Incident",
+            status=IncidentStatus.ACTIVE,
+            severity=IncidentSeverity.P1,
+        )
+        ActionItem.objects.create(
+            incident=incident,
+            linear_issue_id="id-1",
+            linear_identifier="ENG-1",
+            title="Task 1",
+            status=ActionItemStatus.TODO,
+            url="https://linear.app/t/ENG-1",
+        )
+
+        with patch("firetower.incidents.views.sync_action_items_from_linear"):
+            response = self.client.get(
+                f"/api/ui/incidents/{incident.incident_number}/action-items/"
+            )
+
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["linear_identifier"] == "ENG-1"
+        assert response.data[0]["title"] == "Task 1"
+        assert response.data[0]["relation_type"] == "child"
+
+    def test_list_action_items_includes_assignee_info(self):
+        user = User.objects.create_user(
+            username="dev@example.com",
+            email="dev@example.com",
+            first_name="Jane",
+            last_name="Dev",
+        )
+        UserProfile.objects.filter(user=user).update(
+            avatar_url="https://example.com/avatar.jpg"
+        )
+
+        incident = Incident.objects.create(
+            title="Test Incident",
+            status=IncidentStatus.ACTIVE,
+            severity=IncidentSeverity.P1,
+        )
+        ActionItem.objects.create(
+            incident=incident,
+            linear_issue_id="id-1",
+            linear_identifier="ENG-1",
+            title="Task 1",
+            status=ActionItemStatus.TODO,
+            assignee=user,
+            url="https://linear.app/t/ENG-1",
+        )
+
+        with patch("firetower.incidents.views.sync_action_items_from_linear"):
+            response = self.client.get(
+                f"/api/ui/incidents/{incident.incident_number}/action-items/"
+            )
+
+        assert response.status_code == 200
+        assert response.data[0]["assignee_name"] == "Jane Dev"
+        assert (
+            response.data[0]["assignee_avatar_url"] == "https://example.com/avatar.jpg"
+        )
+
+    def test_force_sync_action_items(self):
+        incident = Incident.objects.create(
+            title="Test Incident",
+            status=IncidentStatus.ACTIVE,
+            severity=IncidentSeverity.P1,
+        )
+
+        with patch(
+            "firetower.incidents.views.sync_action_items_from_linear"
+        ) as mock_sync:
+            mock_sync.return_value = ActionItemsSyncStats(created=1)
+
+            response = self.client.post(
+                f"/api/incidents/{incident.incident_number}/sync-action-items/"
+            )
+
+        assert response.status_code == 200
+        assert response.data["success"] is True
+        assert response.data["stats"]["created"] == 1
+        mock_sync.assert_called_once_with(incident, force=True)
+
+    def test_action_items_respects_privacy(self):
+        other_user = User.objects.create_user(
+            username="other@example.com",
+            email="other@example.com",
+        )
+        incident = Incident.objects.create(
+            title="Private Incident",
+            status=IncidentStatus.ACTIVE,
+            severity=IncidentSeverity.P1,
+            is_private=True,
+            captain=other_user,
+        )
+
+        response = self.client.get(
+            f"/api/ui/incidents/{incident.incident_number}/action-items/"
+        )
+
+        assert response.status_code == 404

--- a/src/firetower/incidents/tests/test_action_items.py
+++ b/src/firetower/incidents/tests/test_action_items.py
@@ -955,6 +955,7 @@ class TestCreateLinearParentIssueHook:
         create_linear_parent_issue(incident)
 
         MockLinearService.return_value.get_issue.assert_not_called()
+        MockLinearService.return_value.create_issue.assert_not_called()
 
     @patch("firetower.incidents.hooks.LinearService")
     @patch("firetower.incidents.hooks.settings")

--- a/src/firetower/incidents/urls.py
+++ b/src/firetower/incidents/urls.py
@@ -9,6 +9,7 @@ from .views import (
     action_item_list,
     incident_detail_ui,
     incident_list_ui,
+    sync_action_items,
     sync_incident_participants,
 )
 
@@ -41,6 +42,11 @@ urlpatterns = [
         "incidents/<str:incident_id>/status/",
         IncidentStatusRetrieveAPIView.as_view(),
         name="incident-status-retrieve",
+    ),
+    path(
+        "incidents/<str:incident_id>/sync-action-items/",
+        sync_action_items,
+        name="sync-action-items",
     ),
     path(
         "incidents/<str:incident_id>/sync-participants/",

--- a/src/firetower/incidents/views.py
+++ b/src/firetower/incidents/views.py
@@ -292,17 +292,7 @@ class IncidentStatusRetrieveAPIView(generics.RetrieveAPIView):
 
     def get_object(self) -> Incident:
         incident_id = self.kwargs["incident_id"]
-        project_key = settings.PROJECT_KEY
-
-        incident_pattern = rf"^{re.escape(project_key)}-(\d+)$"
-        match = re.match(incident_pattern, incident_id, re.IGNORECASE)
-
-        if not match:
-            raise ValidationError(
-                f"Invalid incident ID format. Expected format: {project_key}-<number> (e.g., {project_key}-123)"
-            )
-
-        numeric_id = int(match.group(1))
+        numeric_id = parse_incident_id(incident_id)
         return get_object_or_404(self.get_queryset(), id=numeric_id)
 
 

--- a/src/firetower/incidents/views.py
+++ b/src/firetower/incidents/views.py
@@ -49,7 +49,12 @@ from .serializers import (
     TagCreateSerializer,
     TagSerializer,
 )
-from .services import ParticipantsSyncStats, sync_incident_participants_from_slack
+from .services import (
+    ActionItemsSyncStats,
+    ParticipantsSyncStats,
+    sync_action_items_from_linear,
+    sync_incident_participants_from_slack,
+)
 from .utils import (
     region_names_in_grouping,
     sort_tags_with_overrides,
@@ -57,6 +62,19 @@ from .utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def parse_incident_id(incident_id: str) -> int:
+    project_key = settings.PROJECT_KEY
+    incident_pattern = rf"^{re.escape(project_key)}-(\d+)$"
+    match = re.match(incident_pattern, incident_id, re.IGNORECASE)
+
+    if not match:
+        raise ValidationError(
+            f"Invalid incident ID format. Expected format: {project_key}-<number> (e.g., {project_key}-123)"
+        )
+
+    return int(match.group(1))
 
 
 class IncidentListUIView(generics.ListAPIView):
@@ -124,18 +142,7 @@ class IncidentDetailUIView(generics.RetrieveAPIView):
         Returns incident if found and user has access, otherwise 404.
         """
         incident_id = self.kwargs["incident_id"]
-        project_key = settings.PROJECT_KEY
-
-        # Extract numeric ID from incident number (INC-2000 -> 2000), case-insensitive
-        incident_pattern = rf"^{re.escape(project_key)}-(\d+)$"
-        match = re.match(incident_pattern, incident_id, re.IGNORECASE)
-
-        if not match:
-            raise ValidationError(
-                f"Invalid incident ID format. Expected format: {project_key}-<number> (e.g., {project_key}-123)"
-            )
-
-        numeric_id = int(match.group(1))
+        numeric_id = parse_incident_id(incident_id)
 
         # Get incident by numeric ID
         queryset = self.get_queryset()
@@ -233,19 +240,7 @@ class IncidentRetrieveUpdateAPIView(generics.RetrieveUpdateAPIView):
         Filters by visibility before lookup to avoid leaking incident existence.
         """
         incident_id = self.kwargs["incident_id"]
-        project_key = settings.PROJECT_KEY
-
-        # Extract numeric ID from incident number (INC-2000 -> 2000), case-insensitive
-        incident_pattern = rf"^{re.escape(project_key)}-(\d+)$"
-        match = re.match(incident_pattern, incident_id, re.IGNORECASE)
-
-        if not match:
-            raise ValidationError(
-                f"Invalid incident ID format. Expected format: {project_key}-<number> (e.g., {project_key}-123)"
-            )
-
-        # Get incident by numeric ID, filtered by visibility
-        numeric_id = int(match.group(1))
+        numeric_id = parse_incident_id(incident_id)
         queryset = self.get_queryset()
 
         # Filter by visibility before lookup (404 if not visible)
@@ -336,24 +331,10 @@ class SyncIncidentParticipantsView(generics.GenericAPIView):
         Returns incident if found and user has access, otherwise 404.
         """
         incident_id = self.kwargs["incident_id"]
-        project_key = settings.PROJECT_KEY
-
-        # Case-insensitive match for incident ID format
-        incident_pattern = rf"^{re.escape(project_key)}-(\d+)$"
-        match = re.match(incident_pattern, incident_id, re.IGNORECASE)
-
-        if not match:
-            raise ValidationError(
-                f"Invalid incident ID format. Expected format: {project_key}-<number> (e.g., {project_key}-123)"
-            )
-
-        numeric_id = int(match.group(1))
-        queryset = self.get_queryset()
-        queryset = filter_visible_to_user(queryset, self.request.user)
+        numeric_id = parse_incident_id(incident_id)
+        queryset = filter_visible_to_user(self.get_queryset(), self.request.user)
 
         obj = get_object_or_404(queryset, id=numeric_id)
-
-        # Check object permissions
         self.check_object_permissions(self.request, obj)
 
         return obj
@@ -387,31 +368,74 @@ sync_incident_participants = SyncIncidentParticipantsView.as_view()
 
 
 class ActionItemListView(generics.ListAPIView):
+    permission_classes = [IncidentPermission]
     serializer_class = ActionItemSerializer
     pagination_class = None
 
     def get_queryset(self) -> QuerySet[ActionItem]:
-        incident_id = self.kwargs["incident_id"]
-        project_key = settings.PROJECT_KEY
+        return self._get_incident().action_items.select_related("assignee__userprofile")
 
-        incident_pattern = rf"^{re.escape(project_key)}-(\d+)$"
-        match = re.match(incident_pattern, incident_id, re.IGNORECASE)
+    def _get_incident(self) -> Incident:
+        if not hasattr(self, "_incident"):
+            numeric_id = parse_incident_id(self.kwargs["incident_id"])
+            queryset = filter_visible_to_user(Incident.objects.all(), self.request.user)
+            self._incident = get_object_or_404(queryset, id=numeric_id)
+            self.check_object_permissions(self.request, self._incident)
+        return self._incident
 
-        if not match:
-            raise ValidationError(
-                f"Invalid incident ID format. Expected format: {project_key}-<number> (e.g., {project_key}-123)"
+    def list(self, request: Request, *args: object, **kwargs: object) -> Response:
+        incident = self._get_incident()
+
+        try:
+            sync_action_items_from_linear(incident)
+        except Exception as e:
+            logger.error(
+                f"Failed to sync action items for incident {incident.id}: {e}",
+                exc_info=True,
             )
 
-        numeric_id = int(match.group(1))
-        incident_qs = filter_visible_to_user(Incident.objects.all(), self.request.user)
-        get_object_or_404(incident_qs, id=numeric_id)
+        return super().list(request, *args, **kwargs)
 
-        return ActionItem.objects.filter(incident_id=numeric_id).select_related(
-            "assignee__userprofile"
-        )
+
+class SyncActionItemsView(generics.GenericAPIView):
+    permission_classes = [IncidentPermission]
+
+    def get_queryset(self) -> QuerySet[Incident]:
+        return Incident.objects.all()
+
+    def get_object(self) -> Incident:
+        numeric_id = parse_incident_id(self.kwargs["incident_id"])
+        queryset = filter_visible_to_user(self.get_queryset(), self.request.user)
+        obj = get_object_or_404(queryset, id=numeric_id)
+        self.check_object_permissions(self.request, obj)
+        return obj
+
+    def post(self, request: Request, incident_id: str) -> Response:
+        incident = self.get_object()
+
+        try:
+            stats = sync_action_items_from_linear(incident, force=True)
+            return Response({"success": True, "stats": asdict(stats)})
+        except Exception as e:
+            logger.error(
+                f"Failed to force sync action items for incident {incident.id}: {e}",
+                exc_info=True,
+            )
+            error_stats = ActionItemsSyncStats(
+                errors=["Failed to sync action items from Linear"]
+            )
+            return Response(
+                {
+                    "success": False,
+                    "error": "Failed to sync action items from Linear",
+                    "stats": asdict(error_stats),
+                },
+                status=500,
+            )
 
 
 action_item_list = ActionItemListView.as_view()
+sync_action_items = SyncActionItemsView.as_view()
 
 
 class TagListCreateAPIView(generics.ListCreateAPIView):


### PR DESCRIPTION
PR 3 of 4 in the Linear action items series. Adds:

- Linear hooks: create parent issue on incident creation, sync title on title/visibility changes, redact private incident titles
- Action items list endpoint with sync-on-read
- Force sync endpoint (POST /incidents/<id>/sync-action-items/)
- Backfill: if an incident is missing a Linear connection when synced, creates one automatically
- DRYs up incident ID parsing across all views with parse_incident_id() helper
- Tests for hooks, views, backfill path