### PR TITLE
feat: Add Slack bookmark for Linear parent issue

### DIFF
--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -939,7 +939,9 @@ def _claim_linear_issue(
     return None
 
 
-def create_linear_parent_issue(incident: Incident) -> None:
+def create_linear_parent_issue(
+    incident: Incident, *, channel_id: str | None = None
+) -> None:
     linear_config = settings.LINEAR
     if not linear_config:
         return
@@ -1023,6 +1025,14 @@ def create_linear_parent_issue(incident: Incident) -> None:
         logger.exception(
             f"Failed to create Linear attachment for incident {incident.id}"
         )
+
+    if channel_id and linear_link.url:
+        try:
+            _slack_service.add_bookmark(channel_id, "Linear Issue", linear_link.url)
+        except Exception:
+            logger.exception(
+                f"Failed to add Linear bookmark for incident {incident.id}"
+            )
 
 
 def on_incident_created(incident: Incident) -> None:
@@ -1132,7 +1142,7 @@ def on_incident_created(incident: Incident) -> None:
         _create_troubleshooting_doc(incident, channel_id)
 
     try:
-        create_linear_parent_issue(incident)
+        create_linear_parent_issue(incident, channel_id=channel_id)
     except Exception:
         logger.exception(
             f"Failed to create Linear parent issue for incident {incident.id}"

--- a/src/firetower/incidents/tests/test_hooks.py
+++ b/src/firetower/incidents/tests/test_hooks.py
@@ -13,6 +13,7 @@ from firetower.incidents.hooks import (
     _resolve_linear_user_id,
     build_channel_name,
     build_channel_topic,
+    create_linear_parent_issue,
     on_captain_changed,
     on_incident_created,
     on_severity_changed,
@@ -2699,3 +2700,91 @@ class TestResolveLinearUserId:
             user=user,
             type=ExternalProfileType.LINEAR,
         ).exists()
+
+
+@pytest.mark.django_db
+class TestCreateLinearParentIssueBookmark:
+    @patch("firetower.incidents.hooks._slack_service")
+    @patch("firetower.incidents.hooks.LinearService")
+    def test_adds_bookmark_when_channel_id_provided(
+        self, mock_linear_cls, mock_slack, settings
+    ):
+        settings.LINEAR = {"TEAM_ID": "team-1"}
+        mock_linear = mock_linear_cls.return_value
+        mock_linear.create_issue.return_value = {
+            "id": "issue-1",
+            "url": "https://linear.app/team/issue/ENG-123",
+        }
+
+        incident = Incident.objects.create(
+            title="Test Incident",
+            severity=IncidentSeverity.P1,
+        )
+
+        create_linear_parent_issue(incident, channel_id="C99999")
+
+        mock_slack.add_bookmark.assert_called_once_with(
+            "C99999", "Linear Issue", "https://linear.app/team/issue/ENG-123"
+        )
+
+    @patch("firetower.incidents.hooks._slack_service")
+    @patch("firetower.incidents.hooks.LinearService")
+    def test_no_bookmark_when_no_channel_id(
+        self, mock_linear_cls, mock_slack, settings
+    ):
+        settings.LINEAR = {"TEAM_ID": "team-1"}
+        mock_linear = mock_linear_cls.return_value
+        mock_linear.create_issue.return_value = {
+            "id": "issue-1",
+            "url": "https://linear.app/team/issue/ENG-123",
+        }
+
+        incident = Incident.objects.create(
+            title="Test Incident",
+            severity=IncidentSeverity.P1,
+        )
+
+        create_linear_parent_issue(incident)
+
+        mock_slack.add_bookmark.assert_not_called()
+
+    @patch("firetower.incidents.hooks._slack_service")
+    @patch("firetower.incidents.hooks.LinearService")
+    def test_bookmark_failure_does_not_raise(
+        self, mock_linear_cls, mock_slack, settings
+    ):
+        settings.LINEAR = {"TEAM_ID": "team-1"}
+        mock_linear = mock_linear_cls.return_value
+        mock_linear.create_issue.return_value = {
+            "id": "issue-1",
+            "url": "https://linear.app/team/issue/ENG-123",
+        }
+        mock_slack.add_bookmark.side_effect = RuntimeError("bookmark boom")
+
+        incident = Incident.objects.create(
+            title="Test Incident",
+            severity=IncidentSeverity.P1,
+        )
+
+        create_linear_parent_issue(incident, channel_id="C99999")
+
+        link = ExternalLink.objects.get(incident=incident, type=ExternalLinkType.LINEAR)
+        assert link.url == "https://linear.app/team/issue/ENG-123"
+
+    @patch("firetower.incidents.hooks._slack_service")
+    @patch("firetower.incidents.hooks.LinearService")
+    def test_no_bookmark_when_linear_creation_fails(
+        self, mock_linear_cls, mock_slack, settings
+    ):
+        settings.LINEAR = {"TEAM_ID": "team-1"}
+        mock_linear = mock_linear_cls.return_value
+        mock_linear.create_issue.return_value = None
+
+        incident = Incident.objects.create(
+            title="Test Incident",
+            severity=IncidentSeverity.P1,
+        )
+
+        create_linear_parent_issue(incident, channel_id="C99999")
+
+        mock_slack.add_bookmark.assert_not_called()


### PR DESCRIPTION
Adds the Linear parent issue URL as a Slack channel bookmark when an incident is created, so responders can quickly find it from the channel.