### PR TITLE
feat: Linear sync improvements — parent status, title prefix, captain assignee

### DIFF
--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import transaction
 
-from firetower.auth.models import ExternalProfileType
+from firetower.auth.models import ExternalProfile, ExternalProfileType
 from firetower.incidents.models import (
     ExternalLink,
     ExternalLinkType,
@@ -941,6 +941,14 @@ def create_linear_parent_issue(incident: Incident) -> None:
         sync_identifiers = linear_config.get("SYNC_IDENTIFIERS", False)
         title = _linear_issue_title(incident, sync_identifiers=sync_identifiers)
 
+        captain_linear_id = None
+        if incident.captain:
+            profile = ExternalProfile.objects.filter(
+                user=incident.captain, type=ExternalProfileType.LINEAR
+            ).first()
+            if profile:
+                captain_linear_id = profile.external_id
+
         if sync_identifiers:
             issue = _claim_linear_issue(linear_service, incident, team_id, project_id)
             if not issue:
@@ -957,6 +965,7 @@ def create_linear_parent_issue(incident: Incident) -> None:
                 title=title,
                 description=LINEAR_PARENT_DESCRIPTION,
                 state_id=started_state_id,
+                assignee_id=captain_linear_id,
             ):
                 linear_link.delete()
                 logger.warning(
@@ -965,7 +974,11 @@ def create_linear_parent_issue(incident: Incident) -> None:
                 return
         else:
             issue = linear_service.create_issue(
-                title, LINEAR_PARENT_DESCRIPTION, team_id, project_id
+                title,
+                LINEAR_PARENT_DESCRIPTION,
+                team_id,
+                project_id,
+                assignee_id=captain_linear_id,
             )
             if not issue:
                 linear_link.delete()

--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -859,20 +859,25 @@ def decorate_incident_channel(
             logger.exception(f"Failed to post to feed channel for {ctx.channel_name}")
 
 
-def _linear_issue_title(incident: Incident) -> str:
+def _linear_issue_title(incident: Incident, sync_identifiers: bool = False) -> str:
     if incident.is_private:
+        if sync_identifiers:
+            return "Private Incident"
         return f"[{incident.incident_number}] Private Incident"
+    if sync_identifiers:
+        return incident.title
     return f"[{incident.incident_number}] {incident.title}"
 
 
 def _sync_linear_title(incident: Incident) -> None:
     if not settings.LINEAR or not incident.linear_parent_issue_id:
         return
+    sync_identifiers = settings.LINEAR.get("SYNC_IDENTIFIERS", False)
     try:
         linear_service = LinearService()
         linear_service.update_issue(
             incident.linear_parent_issue_id,
-            title=_linear_issue_title(incident),
+            title=_linear_issue_title(incident, sync_identifiers=sync_identifiers),
         )
     except Exception:
         logger.exception(
@@ -934,7 +939,7 @@ def create_linear_parent_issue(incident: Incident) -> None:
         linear_service = LinearService()
         project_id = str(linear_config.get("PROJECT_ID", "")) or None
         sync_identifiers = linear_config.get("SYNC_IDENTIFIERS", False)
-        title = _linear_issue_title(incident)
+        title = _linear_issue_title(incident, sync_identifiers=sync_identifiers)
 
         if sync_identifiers:
             issue = _claim_linear_issue(linear_service, incident, team_id, project_id)

--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -859,6 +859,27 @@ def decorate_incident_channel(
             logger.exception(f"Failed to post to feed channel for {ctx.channel_name}")
 
 
+def _resolve_linear_user_id(
+    user: User | None, linear_service: LinearService
+) -> str | None:
+    if not user:
+        return None
+    profile = ExternalProfile.objects.filter(
+        user=user, type=ExternalProfileType.LINEAR
+    ).first()
+    if profile:
+        return profile.external_id
+    linear_user = linear_service.get_user_by_email(user.email)
+    if not linear_user:
+        return None
+    ExternalProfile.objects.get_or_create(
+        user=user,
+        type=ExternalProfileType.LINEAR,
+        defaults={"external_id": linear_user["id"]},
+    )
+    return linear_user["id"]
+
+
 def _linear_issue_title(incident: Incident, sync_identifiers: bool = False) -> str:
     if incident.is_private:
         if sync_identifiers:
@@ -941,13 +962,7 @@ def create_linear_parent_issue(incident: Incident) -> None:
         sync_identifiers = linear_config.get("SYNC_IDENTIFIERS", False)
         title = _linear_issue_title(incident, sync_identifiers=sync_identifiers)
 
-        captain_linear_id = None
-        if incident.captain:
-            profile = ExternalProfile.objects.filter(
-                user=incident.captain, type=ExternalProfileType.LINEAR
-            ).first()
-            if profile:
-                captain_linear_id = profile.external_id
+        captain_linear_id = _resolve_linear_user_id(incident.captain, linear_service)
 
         if sync_identifiers:
             issue = _claim_linear_issue(linear_service, incident, team_id, project_id)

--- a/src/firetower/incidents/services.py
+++ b/src/firetower/incidents/services.py
@@ -207,6 +207,17 @@ def _update_parent_issue_status(
         linear_service.update_issue(incident.linear_parent_issue_id, state_id=state_id)
 
 
+def _sync_parent_assignee(incident: Incident, linear_service: LinearService) -> None:
+    if not incident.linear_parent_issue_id:
+        return
+    from firetower.incidents.hooks import _resolve_linear_user_id  # noqa: PLC0415
+
+    captain_linear_id = _resolve_linear_user_id(incident.captain, linear_service)
+    linear_service.update_issue(
+        incident.linear_parent_issue_id, assignee_id=captain_linear_id
+    )
+
+
 def sync_action_items_from_linear(
     incident: Incident, force: bool = False
 ) -> ActionItemsSyncStats:
@@ -333,6 +344,13 @@ def sync_action_items_from_linear(
     except Exception:
         logger.exception(
             f"Failed to update Linear parent issue status for incident {incident.id}"
+        )
+
+    try:
+        _sync_parent_assignee(incident, linear_service)
+    except Exception:
+        logger.exception(
+            f"Failed to sync Linear parent assignee for incident {incident.id}"
         )
 
     logger.info(

--- a/src/firetower/incidents/services.py
+++ b/src/firetower/incidents/services.py
@@ -195,10 +195,7 @@ def _update_parent_issue_status(
         return
 
     statuses = list(incident.action_items.values_list("status", flat=True))
-    if not statuses:
-        return
-
-    all_complete = all(s in COMPLETED_STATUSES for s in statuses)
+    all_complete = not statuses or all(s in COMPLETED_STATUSES for s in statuses)
 
     states = linear_service.get_workflow_states(team_id)
     if not states:

--- a/src/firetower/incidents/tests/test_action_items.py
+++ b/src/firetower/incidents/tests/test_action_items.py
@@ -428,7 +428,7 @@ class TestSyncActionItemsFromLinear:
 
             sync_action_items_from_linear(incident, force=True)
 
-            mock_service.update_issue.assert_called_once_with(
+            mock_service.update_issue.assert_any_call(
                 "parent-issue-id", state_id="state-done"
             )
 
@@ -457,7 +457,7 @@ class TestSyncActionItemsFromLinear:
 
             sync_action_items_from_linear(incident, force=True)
 
-            mock_service.update_issue.assert_called_once_with(
+            mock_service.update_issue.assert_any_call(
                 "parent-issue-id", state_id="state-started"
             )
 
@@ -1089,7 +1089,7 @@ class TestCreateLinearParentIssuePrivacy:
         create_linear_parent_issue(incident)
 
         call_args = mock_service.update_issue.call_args
-        assert call_args[1]["title"] == f"[{incident.incident_number}] Private Incident"
+        assert call_args[1]["title"] == "Private Incident"
 
 
 @pytest.mark.django_db

--- a/src/firetower/incidents/tests/test_action_items.py
+++ b/src/firetower/incidents/tests/test_action_items.py
@@ -461,6 +461,69 @@ class TestSyncActionItemsFromLinear:
                 "parent-issue-id", state_id="state-started"
             )
 
+    def test_completes_parent_when_no_action_items(self, settings):
+        settings.LINEAR = {"TEAM_ID": "team-1"}
+        incident = self._make_incident()
+
+        with patch("firetower.incidents.services._get_linear_service") as mock_get:
+            mock_service = mock_get.return_value
+            mock_service.get_child_issues.return_value = []
+            mock_service.get_related_issues.return_value = []
+            mock_service.get_workflow_states.return_value = {
+                "completed": "state-done",
+                "backlog": "state-backlog",
+            }
+            mock_service.update_issue.return_value = True
+
+            sync_action_items_from_linear(incident, force=True)
+
+            mock_service.update_issue.assert_any_call(
+                "parent-issue-id", state_id="state-done"
+            )
+
+    def test_syncs_captain_as_parent_assignee(self, settings):
+        settings.LINEAR = {"TEAM_ID": "team-1"}
+        captain = User.objects.create_user(
+            username="captain@example.com",
+            email="captain@example.com",
+        )
+        ExternalProfile.objects.create(
+            user=captain,
+            type=ExternalProfileType.LINEAR,
+            external_id="linear-captain-id",
+        )
+        incident = self._make_incident(captain=captain)
+
+        with patch("firetower.incidents.services._get_linear_service") as mock_get:
+            mock_service = mock_get.return_value
+            mock_service.get_child_issues.return_value = []
+            mock_service.get_related_issues.return_value = []
+            mock_service.get_workflow_states.return_value = None
+            mock_service.update_issue.return_value = True
+
+            sync_action_items_from_linear(incident, force=True)
+
+            mock_service.update_issue.assert_any_call(
+                "parent-issue-id", assignee_id="linear-captain-id"
+            )
+
+    def test_unassigns_parent_when_no_captain(self, settings):
+        settings.LINEAR = {"TEAM_ID": "team-1"}
+        incident = self._make_incident(captain=None)
+
+        with patch("firetower.incidents.services._get_linear_service") as mock_get:
+            mock_service = mock_get.return_value
+            mock_service.get_child_issues.return_value = []
+            mock_service.get_related_issues.return_value = []
+            mock_service.get_workflow_states.return_value = None
+            mock_service.update_issue.return_value = True
+
+            sync_action_items_from_linear(incident, force=True)
+
+            mock_service.update_issue.assert_any_call(
+                "parent-issue-id", assignee_id=None
+            )
+
 
 @pytest.mark.django_db
 class TestLinearService:

--- a/src/firetower/incidents/tests/test_hooks.py
+++ b/src/firetower/incidents/tests/test_hooks.py
@@ -8,7 +8,9 @@ from firetower.incidents.hooks import (
     _create_status_channel,
     _create_troubleshooting_doc,
     _invite_oncall_users,
+    _linear_issue_title,
     _page_if_needed,
+    _resolve_linear_user_id,
     build_channel_name,
     build_channel_topic,
     on_captain_changed,
@@ -2587,3 +2589,113 @@ class TestOnIncidentCreatedTroubleshootingDoc:
         on_incident_created(incident)
 
         mock_create_ts.assert_called_once_with(incident, "C99999")
+
+
+@pytest.mark.django_db
+class TestLinearIssueTitle:
+    def test_public_incident_without_sync_identifiers(self):
+        incident = Incident.objects.create(
+            title="Database outage",
+            severity=IncidentSeverity.P1,
+        )
+
+        result = _linear_issue_title(incident, sync_identifiers=False)
+
+        assert result == f"[{incident.incident_number}] Database outage"
+
+    def test_public_incident_with_sync_identifiers(self):
+        incident = Incident.objects.create(
+            title="Database outage",
+            severity=IncidentSeverity.P1,
+        )
+
+        result = _linear_issue_title(incident, sync_identifiers=True)
+
+        assert result == "Database outage"
+
+    def test_private_incident_without_sync_identifiers(self):
+        incident = Incident.objects.create(
+            title="Secret outage",
+            severity=IncidentSeverity.P1,
+            is_private=True,
+        )
+
+        result = _linear_issue_title(incident, sync_identifiers=False)
+
+        assert result == f"[{incident.incident_number}] Private Incident"
+
+    def test_private_incident_with_sync_identifiers(self):
+        incident = Incident.objects.create(
+            title="Secret outage",
+            severity=IncidentSeverity.P1,
+            is_private=True,
+        )
+
+        result = _linear_issue_title(incident, sync_identifiers=True)
+
+        assert result == "Private Incident"
+
+
+@pytest.mark.django_db
+class TestResolveLinearUserId:
+    def test_returns_none_for_no_user(self):
+        mock_service = MagicMock()
+
+        result = _resolve_linear_user_id(None, mock_service)
+
+        assert result is None
+        mock_service.get_user_by_email.assert_not_called()
+
+    def test_returns_existing_external_profile(self):
+        user = User.objects.create_user(
+            username="dev@example.com",
+            email="dev@example.com",
+        )
+        ExternalProfile.objects.create(
+            user=user,
+            type=ExternalProfileType.LINEAR,
+            external_id="existing-linear-id",
+        )
+        mock_service = MagicMock()
+
+        result = _resolve_linear_user_id(user, mock_service)
+
+        assert result == "existing-linear-id"
+        mock_service.get_user_by_email.assert_not_called()
+
+    def test_falls_back_to_linear_api_and_creates_profile(self):
+        user = User.objects.create_user(
+            username="dev@example.com",
+            email="dev@example.com",
+        )
+        mock_service = MagicMock()
+        mock_service.get_user_by_email.return_value = {
+            "id": "api-linear-id",
+            "email": "dev@example.com",
+        }
+
+        result = _resolve_linear_user_id(user, mock_service)
+
+        assert result == "api-linear-id"
+        mock_service.get_user_by_email.assert_called_once_with("dev@example.com")
+        assert ExternalProfile.objects.filter(
+            user=user,
+            type=ExternalProfileType.LINEAR,
+            external_id="api-linear-id",
+        ).exists()
+
+    def test_returns_none_when_linear_api_returns_nothing(self):
+        user = User.objects.create_user(
+            username="dev@example.com",
+            email="dev@example.com",
+        )
+        mock_service = MagicMock()
+        mock_service.get_user_by_email.return_value = None
+
+        result = _resolve_linear_user_id(user, mock_service)
+
+        assert result is None
+        assert not ExternalProfile.objects.filter(
+            user=user,
+            type=ExternalProfileType.LINEAR,
+        ).exists()

--- a/src/firetower/integrations/services/linear.py
+++ b/src/firetower/integrations/services/linear.py
@@ -188,6 +188,25 @@ class LinearService:
             "url": issue["url"],
         }
 
+    def get_user_by_email(self, email: str) -> dict[str, str] | None:
+        query = """
+        query($email: String!) {
+            users(filter: { email: { eq: $email } }) {
+                nodes {
+                    id
+                    email
+                }
+            }
+        }
+        """
+        data = self._graphql(query, {"email": email})
+        if not data:
+            return None
+        nodes = data.get("users", {}).get("nodes", [])
+        if not nodes:
+            return None
+        return {"id": nodes[0]["id"], "email": nodes[0]["email"]}
+
     def create_issue(
         self,
         title: str,

--- a/src/firetower/integrations/services/linear.py
+++ b/src/firetower/integrations/services/linear.py
@@ -195,6 +195,7 @@ class LinearService:
         team_id: str,
         project_id: str | None = None,
         state_id: str | None = None,
+        assignee_id: str | None = None,
     ) -> dict[str, Any] | None:
         mutation = """
         mutation($input: IssueCreateInput!) {
@@ -217,6 +218,8 @@ class LinearService:
             input_data["projectId"] = project_id
         if state_id:
             input_data["stateId"] = state_id
+        if assignee_id:
+            input_data["assigneeId"] = assignee_id
 
         data = self._graphql(mutation, {"input": input_data})
         if not data:
@@ -261,6 +264,7 @@ class LinearService:
         title: str | None = None,
         description: str | None = None,
         state_id: str | None = None,
+        assignee_id: str | None = None,
     ) -> bool:
         mutation = """
         mutation($id: String!, $input: IssueUpdateInput!) {
@@ -276,6 +280,8 @@ class LinearService:
             input_data["description"] = description
         if state_id is not None:
             input_data["stateId"] = state_id
+        if assignee_id is not None:
+            input_data["assigneeId"] = assignee_id
 
         if not input_data:
             return True

--- a/src/firetower/integrations/tests/test_linear_service.py
+++ b/src/firetower/integrations/tests/test_linear_service.py
@@ -384,3 +384,33 @@ class TestGetRelatedIssues:
             result = linear_service.get_related_issues("issue-1")
 
         assert len(result) == 1
+
+
+class TestGetUserByEmail:
+    def test_returns_user_when_found(self, linear_service):
+        mock_response = {
+            "users": {
+                "nodes": [
+                    {"id": "user-123", "email": "alice@example.com"},
+                ]
+            }
+        }
+
+        with patch.object(linear_service, "_graphql", return_value=mock_response):
+            result = linear_service.get_user_by_email("alice@example.com")
+
+        assert result == {"id": "user-123", "email": "alice@example.com"}
+
+    def test_returns_none_when_no_user_found(self, linear_service):
+        mock_response = {"users": {"nodes": []}}
+
+        with patch.object(linear_service, "_graphql", return_value=mock_response):
+            result = linear_service.get_user_by_email("nobody@example.com")
+
+        assert result is None
+
+    def test_returns_none_on_api_failure(self, linear_service):
+        with patch.object(linear_service, "_graphql", return_value=None):
+            result = linear_service.get_user_by_email("alice@example.com")
+
+        assert result is None


### PR DESCRIPTION
A few follow-up fixes to the Linear action items integration:

- Set parent Linear issue to Done when there are no action items (previously left unchanged)
- Omit the [INC-2000] prefix from Linear issue titles when SYNC_IDENTIFIERS is enabled (redundant since the Linear issue already has a matching identifier)
- Assign the incident captain to the Linear parent issue on creation, and keep it in sync on every action item sync
- Look up Linear users by email and cache as ExternalProfile for future lookups