### PR TITLE
ci(deploy): Upgrade Docker actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,9 +32,9 @@ jobs:
       - name: Login to Artifact Registry
         run: gcloud auth configure-docker us-west1-docker.pkg.dev
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
       - name: Build and push (backend)
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           push: true
           tags: ${{ env.BACKEND_IMAGE_REF }}
@@ -42,7 +42,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Build and push (static assets)
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           push: true
           tags: ${{ env.STATIC_IMAGE_REF }}


### PR DESCRIPTION
Bump docker/setup-buildx-action from v3 to v4 and docker/build-push-action from v6 to v7 to resolve the Node.js 20 deprecation warning on GitHub Actions runners.

Node.js 20 actions will be forced to Node.js 24 starting June 2nd, 2026 and removed entirely September 16th, 2026. Both v4 and v7 of these actions ship with Node.js 24 as the default runtime with no breaking changes to the inputs we use (push, tags, file, cache-from, cache-to).


Agent transcript: https://claudescope.sentry.dev/share/Vsdpg5CzKgwefFsEYe-nA-YwFgX8nXWBKxCSqDhWioo