### PR TITLE
ci: Parallelize Cloud Run service deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,8 +63,14 @@ jobs:
             cloud_run_job: firetower-prod-db-migration
     steps:
       - name: Checkout code
+        if: >-
+          (matrix.env_name == 'test' && inputs.environment == 'test') ||
+          (matrix.env_name == 'prod' && github.ref == 'refs/heads/main' && ((!inputs.environment) || inputs.environment == 'prod'))
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Authenticate with GCP
+        if: >-
+          (matrix.env_name == 'test' && inputs.environment == 'test') ||
+          (matrix.env_name == 'prod' && github.ref == 'refs/heads/main' && ((!inputs.environment) || inputs.environment == 'prod'))
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           project_id: ${{ secrets.GCP_PROJECT_SLUG }}
@@ -90,13 +96,11 @@ jobs:
       matrix:
         include:
           - service: firetower-test
-            flags: >-
-              --container nginx --image "${{ env.STATIC_IMAGE_REF }}" --port 80
-              --container firetower-backend --image "${{ env.BACKEND_IMAGE_REF }}"
+            multi_container: true
           - service: firetower-slack-app-test
-            flags: --image "${{ env.BACKEND_IMAGE_REF }}"
+            multi_container: false
           - service: firetower-async-test
-            flags: --image "${{ env.BACKEND_IMAGE_REF }}"
+            multi_container: false
     steps:
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -106,12 +110,23 @@ jobs:
           project_id: ${{ secrets.GCP_PROJECT_SLUG }}
           workload_identity_provider: projects/${{ secrets.GCP_PROJECT_NUM }}/locations/global/workloadIdentityPools/github/providers/github-prvdr
       - name: Deploy ${{ matrix.service }}
+        if: ${{ !matrix.multi_container }}
         uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3
         with:
           service: ${{ matrix.service }}
           project_id: ${{ secrets.GCP_PROJECT_SLUG }}
           region: us-west1
-          flags: ${{ matrix.flags }}
+          image: ${{ env.BACKEND_IMAGE_REF }}
+      - name: Deploy ${{ matrix.service }} (multi-container)
+        if: ${{ matrix.multi_container }}
+        uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3
+        with:
+          service: ${{ matrix.service }}
+          project_id: ${{ secrets.GCP_PROJECT_SLUG }}
+          region: us-west1
+          flags: >-
+            --container nginx --image "${{ env.STATIC_IMAGE_REF }}" --port 80
+            --container firetower-backend --image "${{ env.BACKEND_IMAGE_REF }}"
 
   deploy-prod:
     needs: [deploy-db-migration]
@@ -122,13 +137,11 @@ jobs:
       matrix:
         include:
           - service: firetower
-            flags: >-
-              --container nginx --image "${{ env.STATIC_IMAGE_REF }}" --port 80
-              --container firetower-backend --image "${{ env.BACKEND_IMAGE_REF }}"
+            multi_container: true
           - service: firetower-slack-app
-            flags: --image "${{ env.BACKEND_IMAGE_REF }}"
+            multi_container: false
           - service: firetower-async-prod
-            flags: --image "${{ env.BACKEND_IMAGE_REF }}"
+            multi_container: false
     steps:
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -138,9 +151,20 @@ jobs:
           project_id: ${{ secrets.GCP_PROJECT_SLUG }}
           workload_identity_provider: projects/${{ secrets.GCP_PROJECT_NUM }}/locations/global/workloadIdentityPools/github/providers/github-prvdr
       - name: Deploy ${{ matrix.service }}
+        if: ${{ !matrix.multi_container }}
         uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3
         with:
           service: ${{ matrix.service }}
           project_id: ${{ secrets.GCP_PROJECT_SLUG }}
           region: us-west1
-          flags: ${{ matrix.flags }}
+          image: ${{ env.BACKEND_IMAGE_REF }}
+      - name: Deploy ${{ matrix.service }} (multi-container)
+        if: ${{ matrix.multi_container }}
+        uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3
+        with:
+          service: ${{ matrix.service }}
+          project_id: ${{ secrets.GCP_PROJECT_SLUG }}
+          region: us-west1
+          flags: >-
+            --container nginx --image "${{ env.STATIC_IMAGE_REF }}" --port 80
+            --container firetower-backend --image "${{ env.BACKEND_IMAGE_REF }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,9 +50,17 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  deploy:
+  deploy-db-migration:
     needs: [build]
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - env_name: test
+            cloud_run_job: firetower-test-db-migration
+          - env_name: prod
+            cloud_run_job: firetower-prod-db-migration
     steps:
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -61,80 +69,78 @@ jobs:
         with:
           project_id: ${{ secrets.GCP_PROJECT_SLUG }}
           workload_identity_provider: projects/${{ secrets.GCP_PROJECT_NUM }}/locations/global/workloadIdentityPools/github/providers/github-prvdr
-      - name: deploy-test-db-migration
-        if: ${{ inputs.environment == 'test' }}
+      - name: Run migration (${{ matrix.env_name }})
+        if: >-
+          (matrix.env_name == 'test' && inputs.environment == 'test') ||
+          (matrix.env_name == 'prod' && github.ref == 'refs/heads/main' && ((!inputs.environment) || inputs.environment == 'prod'))
         uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3
         with:
-          job: firetower-test-db-migration
+          job: ${{ matrix.cloud_run_job }}
           project_id: ${{ secrets.GCP_PROJECT_SLUG }}
           region: us-west1
           image: ${{ env.BACKEND_IMAGE_REF }}
           wait: true
-      - name: deploy-test
-        if: ${{ inputs.environment == 'test' }}
-        uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3
-        with:
-          service: firetower-test
-          project_id: ${{ secrets.GCP_PROJECT_SLUG }}
-          region: us-west1
-          # NOTE: we use flags here because the action does not natively support updating multiple containers.
-          flags: >
-            --container nginx --image "${{ env.STATIC_IMAGE_REF }}" --port 80
-            --container firetower-backend --image "${{ env.BACKEND_IMAGE_REF }}"
 
-      - name: deploy-test-slack-bot
-        if: ${{ inputs.environment == 'test' }}
+  deploy-test:
+    needs: [deploy-db-migration]
+    if: ${{ inputs.environment == 'test' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service: firetower-test
+            flags: >-
+              --container nginx --image "${{ env.STATIC_IMAGE_REF }}" --port 80
+              --container firetower-backend --image "${{ env.BACKEND_IMAGE_REF }}"
+          - service: firetower-slack-app-test
+            flags: --image "${{ env.BACKEND_IMAGE_REF }}"
+          - service: firetower-async-test
+            flags: --image "${{ env.BACKEND_IMAGE_REF }}"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - name: Authenticate with GCP
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_SLUG }}
+          workload_identity_provider: projects/${{ secrets.GCP_PROJECT_NUM }}/locations/global/workloadIdentityPools/github/providers/github-prvdr
+      - name: Deploy ${{ matrix.service }}
         uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3
         with:
-          service: firetower-slack-app-test
+          service: ${{ matrix.service }}
           project_id: ${{ secrets.GCP_PROJECT_SLUG }}
           region: us-west1
-          image: ${{ env.BACKEND_IMAGE_REF }}
+          flags: ${{ matrix.flags }}
 
-      - name: deploy-test-async
-        if: ${{ inputs.environment == 'test' }}
+  deploy-prod:
+    needs: [deploy-db-migration]
+    if: ${{ github.ref == 'refs/heads/main' && ((!inputs.environment) || inputs.environment == 'prod') }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service: firetower
+            flags: >-
+              --container nginx --image "${{ env.STATIC_IMAGE_REF }}" --port 80
+              --container firetower-backend --image "${{ env.BACKEND_IMAGE_REF }}"
+          - service: firetower-slack-app
+            flags: --image "${{ env.BACKEND_IMAGE_REF }}"
+          - service: firetower-async-prod
+            flags: --image "${{ env.BACKEND_IMAGE_REF }}"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - name: Authenticate with GCP
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_SLUG }}
+          workload_identity_provider: projects/${{ secrets.GCP_PROJECT_NUM }}/locations/global/workloadIdentityPools/github/providers/github-prvdr
+      - name: Deploy ${{ matrix.service }}
         uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3
         with:
-          service: firetower-async-test
+          service: ${{ matrix.service }}
           project_id: ${{ secrets.GCP_PROJECT_SLUG }}
           region: us-west1
-          image: ${{ env.BACKEND_IMAGE_REF }}
-
-      - name: deploy-prod-db-migration
-        if: ${{ github.ref == 'refs/heads/main' && ((!inputs.environment) || inputs.environment == 'prod') }}
-        uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3
-        with:
-          job: firetower-prod-db-migration
-          project_id: ${{ secrets.GCP_PROJECT_SLUG }}
-          region: us-west1
-          image: ${{ env.BACKEND_IMAGE_REF }}
-          wait: true
-      - name: deploy-prod
-        if: ${{ github.ref == 'refs/heads/main' && ((!inputs.environment) || inputs.environment == 'prod') }}
-        uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3
-        with:
-          service: firetower
-          project_id: ${{ secrets.GCP_PROJECT_SLUG }}
-          region: us-west1
-          # NOTE: we use flags here because the action does not natively support updating multiple containers.
-          flags: >
-            --container nginx --image "${{ env.STATIC_IMAGE_REF }}" --port 80
-            --container firetower-backend --image "${{ env.BACKEND_IMAGE_REF }}"
-
-      - name: deploy-prod-slack-bot
-        if: ${{ github.ref == 'refs/heads/main' && ((!inputs.environment) || inputs.environment == 'prod') }}
-        uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3
-        with:
-          service: firetower-slack-app
-          project_id: ${{ secrets.GCP_PROJECT_SLUG }}
-          region: us-west1
-          image: ${{ env.BACKEND_IMAGE_REF }}
-
-      - name: deploy-prod-async
-        if: ${{ github.ref == 'refs/heads/main' && ((!inputs.environment) || inputs.environment == 'prod') }}
-        uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3
-        with:
-          service: firetower-async-prod
-          project_id: ${{ secrets.GCP_PROJECT_SLUG }}
-          region: us-west1
-          image: ${{ env.BACKEND_IMAGE_REF }}
+          flags: ${{ matrix.flags }}


### PR DESCRIPTION
Split the monolithic deploy job into matrix-based jobs so the three service deploys per environment (main, slack-bot, async) run in parallel after the db migration completes.

The deploy graph is now:

```
build --> deploy-db-migration (matrix: test + prod, step-level condition skips unused env)
            |
            +--> deploy-test  (matrix: 3 services in parallel)
            +--> deploy-prod  (matrix: 3 services in parallel)
```

DB migrations use a single matrix job with a step-level `if` to gate which environment actually runs. Service deploys use per-environment jobs with their own matrix of three independent Cloud Run services. `fail-fast: false` so a single service failure doesn't cancel the other two.

Single-container services now use `flags: --image "..."` instead of the `image:` parameter so all matrix entries share the same deploy step shape.


Agent transcript: https://claudescope.sentry.dev/share/zKxqyxJ4CMBvsoD_mOpXN4H9oqdO-xobMaObw0GNcPc