### PR TITLE
ref: Remove superuser bypass for private incident visibility

### DIFF
--- a/src/firetower/incidents/models.py
+++ b/src/firetower/incidents/models.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from django.conf import settings
-from django.contrib.auth.models import AbstractUser, User
+from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.db import models, transaction
 from django.db.models import Q, QuerySet
@@ -296,12 +296,9 @@ class Incident(models.Model):
             links[link.type.lower()] = link.url
         return links
 
-    def is_visible_to_user(self, user: User | AbstractUser) -> bool:
+    def is_visible_to_user(self, user: User) -> bool:
         if not self.is_private:
             return True
-
-        if not isinstance(user, User):
-            return False
 
         if user in [self.captain, self.reporter]:
             return True
@@ -403,7 +400,7 @@ class ExternalLink(models.Model):
 
 
 def filter_visible_to_user(
-    queryset: QuerySet[Incident], user: User | AbstractUser
+    queryset: QuerySet[Incident], user: User
 ) -> QuerySet[Incident]:
     """
     Filter incidents queryset to only those visible to user.

--- a/src/firetower/incidents/models.py
+++ b/src/firetower/incidents/models.py
@@ -297,15 +297,12 @@ class Incident(models.Model):
         return links
 
     def is_visible_to_user(self, user: User | AbstractUser) -> bool:
-        """Check if incident is visible to the given user"""
         if not self.is_private:
             return True
 
-        # Superusers can see all incidents
-        if user.is_superuser:
-            return True
+        if not isinstance(user, User):
+            return False
 
-        # Check if user is involved
         if user in [self.captain, self.reporter]:
             return True
 
@@ -421,10 +418,6 @@ def filter_visible_to_user(
     # Anonymous users see no incidents. IAP should prevent this, but just in case.
     if not user.is_authenticated:
         return queryset.none()
-
-    # Superusers see everything
-    if user.is_superuser:
-        return queryset
 
     return queryset.filter(
         Q(is_private=False) | Q(captain=user) | Q(reporter=user) | Q(participants=user)

--- a/src/firetower/incidents/tests/test_models.py
+++ b/src/firetower/incidents/tests/test_models.py
@@ -234,6 +234,44 @@ class TestIncident:
 
         assert incident.is_visible_to_user(superuser) is False
 
+    def test_private_incident_visible_to_involved_superuser(self):
+        """Test private incident is visible to superusers who are captain, reporter, or participant"""
+        superuser = User.objects.create_superuser(
+            username="superuser@example.com",
+            email="superuser@example.com",
+            password="test123",
+        )
+
+        # Visible as captain
+        incident_captain = Incident.objects.create(
+            title="Private Captain",
+            status=IncidentStatus.ACTIVE,
+            severity=IncidentSeverity.P1,
+            is_private=True,
+            captain=superuser,
+        )
+        assert incident_captain.is_visible_to_user(superuser) is True
+
+        # Visible as reporter
+        incident_reporter = Incident.objects.create(
+            title="Private Reporter",
+            status=IncidentStatus.ACTIVE,
+            severity=IncidentSeverity.P1,
+            is_private=True,
+            reporter=superuser,
+        )
+        assert incident_reporter.is_visible_to_user(superuser) is True
+
+        # Visible as participant
+        incident_participant = Incident.objects.create(
+            title="Private Participant",
+            status=IncidentStatus.ACTIVE,
+            severity=IncidentSeverity.P1,
+            is_private=True,
+        )
+        incident_participant.participants.add(superuser)
+        assert incident_participant.is_visible_to_user(superuser) is True
+
     def test_affected_service_tag_names_property(self):
         """Test affected_service_tag_names property returns list of tag names"""
         incident = Incident.objects.create(

--- a/src/firetower/incidents/tests/test_models.py
+++ b/src/firetower/incidents/tests/test_models.py
@@ -217,8 +217,8 @@ class TestIncident:
         assert incident.is_visible_to_user(participant) is True
         assert incident.is_visible_to_user(other_user) is False
 
-    def test_private_incident_visible_to_superuser(self):
-        """Test private incident is visible to superusers"""
+    def test_private_incident_not_visible_to_superuser(self):
+        """Test private incident is not visible to uninvolved superusers"""
         superuser = User.objects.create_superuser(
             username="superuser@example.com",
             email="superuser@example.com",
@@ -232,7 +232,7 @@ class TestIncident:
             is_private=True,
         )
 
-        assert incident.is_visible_to_user(superuser) is True
+        assert incident.is_visible_to_user(superuser) is False
 
     def test_affected_service_tag_names_property(self):
         """Test affected_service_tag_names property returns list of tag names"""
@@ -417,8 +417,8 @@ class TestExternalLink:
 
 @pytest.mark.django_db
 class TestFilterVisibleToUser:
-    def test_superuser_sees_all_incidents(self):
-        """Test superusers see all incidents"""
+    def test_superuser_cannot_see_private_incidents(self):
+        """Test superusers cannot see private incidents they are not involved in"""
         superuser = User.objects.create_superuser(
             username="superuser@example.com",
             email="superuser@example.com",
@@ -432,7 +432,7 @@ class TestFilterVisibleToUser:
             is_private=False,
         )
 
-        private = Incident.objects.create(
+        Incident.objects.create(
             title="Private",
             status=IncidentStatus.ACTIVE,
             severity=IncidentSeverity.P1,
@@ -442,9 +442,8 @@ class TestFilterVisibleToUser:
         queryset = Incident.objects.all()
         filtered = filter_visible_to_user(queryset, superuser)
 
-        assert filtered.count() == 2
+        assert filtered.count() == 1
         assert public in filtered
-        assert private in filtered
 
     def test_regular_user_sees_public_and_own_private(self):
         """Test regular users see public incidents and their own private ones"""

--- a/src/firetower/incidents/tests/test_views.py
+++ b/src/firetower/incidents/tests/test_views.py
@@ -237,7 +237,7 @@ class TestIncidentViews:
 
         assert response.status_code == 200
         assert response.data["count"] == 1
-        assert len(response.data["results"]) == 2
+        assert len(response.data["results"]) == 1
 
     def test_retrieve_incident_syncs_participants(self):
         """Test that retrieving incident details syncs participants from Slack"""

--- a/src/firetower/incidents/tests/test_views.py
+++ b/src/firetower/incidents/tests/test_views.py
@@ -211,8 +211,8 @@ class TestIncidentViews:
 
         assert response.status_code == 404
 
-    def test_superuser_sees_all_private_incidents(self):
-        """Test superuser can see all incidents including private ones"""
+    def test_superuser_cannot_see_private_incidents(self):
+        """Test superuser cannot see private incidents they are not involved in"""
         superuser = User.objects.create_superuser(
             username="admin@example.com",
             email="admin@example.com",
@@ -236,7 +236,7 @@ class TestIncidentViews:
         response = self.client.get("/api/ui/incidents/")
 
         assert response.status_code == 200
-        assert response.data["count"] == 2
+        assert response.data["count"] == 1
         assert len(response.data["results"]) == 2
 
     def test_retrieve_incident_syncs_participants(self):


### PR DESCRIPTION
Superusers can no longer see private incidents they aren't involved in through the app. They must use Django admin for that. Private incidents are only visible to captains, reporters, and participants — same rules as regular users.