### PR TITLE
feat: Reduce required fields in /inc new and capture them at /inc mitigated and /inc resolved

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -5,6 +5,8 @@ django_secret_key = "django-insecure-gmj)qc*_dk&^i1=z7oy(ew7%5*fz^yowp8=4=0882_d
 salt_key = ""
 sentry_dsn = "https://your-sentry-dsn@o1.ingest.us.sentry.io/project-id"
 firetower_base_url = "http://localhost:5173"
+# Optional: link rendered in /inc mitigated and /inc resolved modals to help users pick service_tier/affected_service.
+service_registry_url = "https://your-service-registry.example.com"
 region_grouping = [["region-a", "region-b"], ["region-c", "region-d"]]
 
 [postgres]

--- a/src/firetower/config.py
+++ b/src/firetower/config.py
@@ -103,6 +103,7 @@ class ConfigFile:
     django_secret_key: str
     salt_key: str
     sentry_dsn: str
+    service_registry_url: str | None = None
     notion: NotionConfig | None = None
     genai: GenAIConfig | None = None
     log_level: str = "INFO"
@@ -175,6 +176,7 @@ class DummyConfigFile(ConfigFile):
         self.django_secret_key = "dummy_value_DO_NOT_USE"
         self.salt_key = ""
         self.sentry_dsn = ""
+        self.service_registry_url = None
         self.region_grouping: list[list[str]] = []
         self.log_level = "INFO"
         self.hooks_enabled = False

--- a/src/firetower/settings.py
+++ b/src/firetower/settings.py
@@ -70,6 +70,7 @@ def _coerce_region_grouping(raw: list[Any]) -> list[list[str]]:
 PROJECT_KEY = config.project_key
 REGION_GROUPING = _coerce_region_grouping(config.region_grouping)
 FIRETOWER_BASE_URL = config.firetower_base_url
+SERVICE_REGISTRY_URL = config.service_registry_url
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/

--- a/src/firetower/slack_app/handlers/backfill_incident.py
+++ b/src/firetower/slack_app/handlers/backfill_incident.py
@@ -250,12 +250,6 @@ def handle_backfill_submission(ack: Any, body: dict, view: dict, client: Any) ->
         "is_private": is_private,
         "external_links": {"slack": channel_url},
     }
-    if form["impact_type_tags"]:
-        data["impact_type_tags"] = form["impact_type_tags"]
-    if form["affected_service_tags"]:
-        data["affected_service_tags"] = form["affected_service_tags"]
-    if form["affected_region_tags"]:
-        data["affected_region_tags"] = form["affected_region_tags"]
 
     serializer = IncidentWriteSerializer(data=data, context={"skip_hooks": True})
     if not serializer.is_valid():

--- a/src/firetower/slack_app/handlers/mitigated.py
+++ b/src/firetower/slack_app/handlers/mitigated.py
@@ -3,62 +3,26 @@ from typing import Any
 
 from django.conf import settings
 
-from firetower.incidents.models import IncidentStatus
+from firetower.auth.services import get_or_create_user_from_slack_id
+from firetower.incidents.models import Incident, IncidentStatus
 from firetower.incidents.serializers import IncidentWriteSerializer
-from firetower.slack_app.handlers.utils import get_incident_from_channel
+from firetower.slack_app.handlers.utils import (
+    build_incident_lifecycle_modal,
+    get_incident_from_channel,
+    parse_incident_form_values,
+)
 
 logger = logging.getLogger(__name__)
 
 
-def _build_mitigated_modal(incident_number: str, channel_id: str) -> dict:
-    return {
-        "type": "modal",
-        "callback_id": "mitigated_incident_modal",
-        "private_metadata": channel_id,
-        "title": {"type": "plain_text", "text": incident_number},
-        "submit": {"type": "plain_text", "text": "Submit"},
-        "close": {"type": "plain_text", "text": "Cancel"},
-        "blocks": [
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "Mark this incident as mitigated. Please provide the current impact and any remaining action items.",
-                },
-            },
-            {
-                "type": "input",
-                "block_id": "impact_block",
-                "element": {
-                    "type": "plain_text_input",
-                    "action_id": "impact_update",
-                    "multiline": True,
-                    "placeholder": {
-                        "type": "plain_text",
-                        "text": "What is the current impact after mitigation?",
-                    },
-                },
-                "label": {
-                    "type": "plain_text",
-                    "text": "Current impact post-mitigation",
-                },
-            },
-            {
-                "type": "input",
-                "block_id": "todo_block",
-                "element": {
-                    "type": "plain_text_input",
-                    "action_id": "todo_update",
-                    "multiline": True,
-                    "placeholder": {
-                        "type": "plain_text",
-                        "text": "What still needs to be done?",
-                    },
-                },
-                "label": {"type": "plain_text", "text": "Remaining action items"},
-            },
-        ],
-    }
+def _build_mitigated_modal(incident: Incident, channel_id: str) -> dict:
+    return build_incident_lifecycle_modal(
+        incident=incident,
+        channel_id=channel_id,
+        title_text=f"Mitigated: {incident.incident_number}",
+        callback_id="mitigated_incident_modal",
+        intro_text="This incident is mitigated. Please confirm details below.",
+    )
 
 
 def handle_mitigated_command(ack: Any, body: dict, command: dict, respond: Any) -> None:
@@ -78,31 +42,75 @@ def handle_mitigated_command(ack: Any, body: dict, command: dict, respond: Any) 
 
     get_bolt_app().client.views_open(
         trigger_id=trigger_id,
-        view=_build_mitigated_modal(incident.incident_number, channel_id),
+        view=_build_mitigated_modal(incident, channel_id),
     )
 
 
 def handle_mitigated_submission(ack: Any, body: dict, view: dict, client: Any) -> None:
-    ack()
-    values = view.get("state", {}).get("values", {})
+    form = parse_incident_form_values(view)
     channel_id = view.get("private_metadata", "")
 
-    impact = values.get("impact_block", {}).get("impact_update", {}).get("value", "")
-    todo = values.get("todo_block", {}).get("todo_update", {}).get("value", "")
+    captain_slack_id = form["captain_slack_id"]
+    severity = form["severity"]
+    service_tier = form["service_tier"]
+
+    errors: dict[str, str] = {}
+    if not captain_slack_id:
+        errors["captain_block"] = "An incident captain is required."
+    if not severity:
+        errors["severity_block"] = "Severity is required."
+    if not form["title"]:
+        errors["title_block"] = "This field is required."
+    if not form["description"]:
+        errors["description_block"] = "Description is required."
+    if not form["impact_summary"]:
+        errors["impact_summary_block"] = "Impact summary is required."
+    if not form["impact_type_tags"]:
+        errors["impact_type_block"] = "Select at least one impact type."
+    if not service_tier:
+        errors["service_tier_block"] = "Service tier is required."
+
+    if errors:
+        ack(response_action="errors", errors=errors)
+        return
+
+    ack()
 
     incident = get_incident_from_channel(channel_id)
     if not incident:
         logger.error("Mitigated submission: no incident for channel %s", channel_id)
         return
 
-    serializer = IncidentWriteSerializer(
-        instance=incident, data={"status": IncidentStatus.MITIGATED}, partial=True
-    )
-    if not serializer.is_valid():
-        logger.error("Mitigated status update failed: %s", serializer.errors)
+    captain_user = get_or_create_user_from_slack_id(captain_slack_id)
+    if not captain_user:
+        logger.error(
+            "Could not resolve Slack user %s to a Firetower user", captain_slack_id
+        )
         client.chat_postMessage(
             channel=channel_id,
-            text=f"Failed to update incident status: {serializer.errors}",
+            text="Failed to resolve the selected captain to a Firetower user.",
+        )
+        return
+
+    data: dict[str, Any] = {
+        "status": IncidentStatus.MITIGATED,
+        "severity": severity,
+        "service_tier": service_tier,
+        "captain": captain_user.email,
+        "title": form["title"],
+        "description": form["description"],
+        "impact_summary": form["impact_summary"],
+        "impact_type_tags": form["impact_type_tags"],
+        "affected_service_tags": form["affected_service_tags"],
+        "affected_region_tags": form["affected_region_tags"],
+    }
+
+    serializer = IncidentWriteSerializer(instance=incident, data=data, partial=True)
+    if not serializer.is_valid():
+        logger.error("Mitigated update failed: %s", serializer.errors)
+        client.chat_postMessage(
+            channel=channel_id,
+            text=f"Failed to update incident: {serializer.errors}",
         )
         return
     serializer.save()
@@ -112,9 +120,6 @@ def handle_mitigated_submission(ack: Any, body: dict, view: dict, client: Any) -
         channel=channel_id,
         text=(
             f"<{incident_url}|{incident.incident_number}> has been marked Mitigated.\n"
-            f"*Current Impact*:\n"
-            f"```{impact}```\n"
-            f"*Remaining Action Items*:\n"
-            f"```{todo}```"
+            f"Track follow-ups via the Action Items section on the incident page."
         ),
     )

--- a/src/firetower/slack_app/handlers/mitigated.py
+++ b/src/firetower/slack_app/handlers/mitigated.py
@@ -93,8 +93,5 @@ def handle_mitigated_submission(ack: Any, body: dict, view: dict, client: Any) -
     incident_url = f"{settings.FIRETOWER_BASE_URL}/{incident.incident_number}"
     client.chat_postMessage(
         channel=channel_id,
-        text=(
-            f"<{incident_url}|{incident.incident_number}> has been marked Mitigated.\n"
-            f"Track follow-ups via the Action Items section on the incident page."
-        ),
+        text=f"<{incident_url}|{incident.incident_number}> has been marked Mitigated.",
     )

--- a/src/firetower/slack_app/handlers/mitigated.py
+++ b/src/firetower/slack_app/handlers/mitigated.py
@@ -8,8 +8,10 @@ from firetower.incidents.models import Incident, IncidentStatus
 from firetower.incidents.serializers import IncidentWriteSerializer
 from firetower.slack_app.handlers.utils import (
     build_incident_lifecycle_modal,
+    build_incident_update_data,
     get_incident_from_channel,
     parse_incident_form_values,
+    validate_lifecycle_form,
 )
 
 logger = logging.getLogger(__name__)
@@ -19,7 +21,7 @@ def _build_mitigated_modal(incident: Incident, channel_id: str) -> dict:
     return build_incident_lifecycle_modal(
         incident=incident,
         channel_id=channel_id,
-        title_text=f"Mitigated: {incident.incident_number}",
+        title_text=incident.incident_number,
         callback_id="mitigated_incident_modal",
         intro_text="This incident is mitigated. Please confirm details below.",
     )
@@ -50,26 +52,7 @@ def handle_mitigated_submission(ack: Any, body: dict, view: dict, client: Any) -
     form = parse_incident_form_values(view)
     channel_id = view.get("private_metadata", "")
 
-    captain_slack_id = form["captain_slack_id"]
-    severity = form["severity"]
-    service_tier = form["service_tier"]
-
-    errors: dict[str, str] = {}
-    if not captain_slack_id:
-        errors["captain_block"] = "An incident captain is required."
-    if not severity:
-        errors["severity_block"] = "Severity is required."
-    if not form["title"]:
-        errors["title_block"] = "This field is required."
-    if not form["description"]:
-        errors["description_block"] = "Description is required."
-    if not form["impact_summary"]:
-        errors["impact_summary_block"] = "Impact summary is required."
-    if not form["impact_type_tags"]:
-        errors["impact_type_block"] = "Select at least one impact type."
-    if not service_tier:
-        errors["service_tier_block"] = "Service tier is required."
-
+    errors = validate_lifecycle_form(form)
     if errors:
         ack(response_action="errors", errors=errors)
         return
@@ -81,10 +64,11 @@ def handle_mitigated_submission(ack: Any, body: dict, view: dict, client: Any) -
         logger.error("Mitigated submission: no incident for channel %s", channel_id)
         return
 
-    captain_user = get_or_create_user_from_slack_id(captain_slack_id)
+    captain_user = get_or_create_user_from_slack_id(form["captain_slack_id"])
     if not captain_user:
         logger.error(
-            "Could not resolve Slack user %s to a Firetower user", captain_slack_id
+            "Could not resolve Slack user %s to a Firetower user",
+            form["captain_slack_id"],
         )
         client.chat_postMessage(
             channel=channel_id,
@@ -92,18 +76,9 @@ def handle_mitigated_submission(ack: Any, body: dict, view: dict, client: Any) -
         )
         return
 
-    data: dict[str, Any] = {
-        "status": IncidentStatus.MITIGATED,
-        "severity": severity,
-        "service_tier": service_tier,
-        "captain": captain_user.email,
-        "title": form["title"],
-        "description": form["description"],
-        "impact_summary": form["impact_summary"],
-        "impact_type_tags": form["impact_type_tags"],
-        "affected_service_tags": form["affected_service_tags"],
-        "affected_region_tags": form["affected_region_tags"],
-    }
+    data = build_incident_update_data(
+        form, IncidentStatus.MITIGATED, captain_user.email
+    )
 
     serializer = IncidentWriteSerializer(instance=incident, data=data, partial=True)
     if not serializer.is_valid():

--- a/src/firetower/slack_app/handlers/new_incident.py
+++ b/src/firetower/slack_app/handlers/new_incident.py
@@ -337,10 +337,6 @@ def handle_new_incident_submission(
         dm_message += f"Incident: {incident_url}\n"
         if channel_id:
             dm_message += f"Slack channel: <#{channel_id}>"
-        dm_message += (
-            "\n\nYou'll be asked to fill in impact details and affected systems at "
-            "`/inc mitigated` and `/inc resolved`. You can also edit any field with `/inc update`."
-        )
 
         client.chat_postMessage(channel=slack_user_id, text=dm_message)
 

--- a/src/firetower/slack_app/handlers/new_incident.py
+++ b/src/firetower/slack_app/handlers/new_incident.py
@@ -32,9 +32,6 @@ def _create_fallback_channel(client: Any, slack_user_id: str, form_data: dict) -
     impact_summary = form_data.get("impact_summary", "")
     captain_slack_id = form_data.get("captain_slack_id")
     is_private = form_data.get("is_private", False)
-    impact_type_tags = form_data.get("impact_type_tags", [])
-    affected_service_tags = form_data.get("affected_service_tags", [])
-    affected_region_tags = form_data.get("affected_region_tags", [])
 
     channel_name = f"{settings.PROJECT_KEY.lower()}-{uuid.uuid4().hex[:8]}"
 
@@ -65,12 +62,6 @@ def _create_fallback_channel(client: Any, slack_user_id: str, form_data: dict) -
         metadata_lines.append(f"Captain: <@{captain_slack_id}>")
     metadata_lines.append(f"Reporter: <@{slack_user_id}>")
     metadata_lines.append(f"Private: {'yes' if is_private else 'no'}")
-    if impact_type_tags:
-        metadata_lines.append(f"Impact Types: {', '.join(impact_type_tags)}")
-    if affected_service_tags:
-        metadata_lines.append(f"Affected Services: {', '.join(affected_service_tags)}")
-    if affected_region_tags:
-        metadata_lines.append(f"Affected Regions: {', '.join(affected_region_tags)}")
 
     metadata_text = "\n".join(metadata_lines)
     try:
@@ -252,12 +243,6 @@ def _create_incident_via_db(
         "reporter": user.email,
         "is_private": is_private,
     }
-    if form["impact_type_tags"]:
-        data["impact_type_tags"] = form["impact_type_tags"]
-    if form["affected_service_tags"]:
-        data["affected_service_tags"] = form["affected_service_tags"]
-    if form["affected_region_tags"]:
-        data["affected_region_tags"] = form["affected_region_tags"]
 
     serializer = IncidentWriteSerializer(data=data)
     if not serializer.is_valid():
@@ -307,9 +292,6 @@ def handle_new_incident_submission(
             "impact_summary": form["impact_summary"],
             "captain_slack_id": form["captain_slack_id"],
             "is_private": is_private,
-            "impact_type_tags": form.get("impact_type_tags", []),
-            "affected_service_tags": form.get("affected_service_tags", []),
-            "affected_region_tags": form.get("affected_region_tags", []),
         }
         _create_fallback_channel(client, slack_user_id, form_data)
         return

--- a/src/firetower/slack_app/handlers/new_incident.py
+++ b/src/firetower/slack_app/handlers/new_incident.py
@@ -337,6 +337,10 @@ def handle_new_incident_submission(
         dm_message += f"Incident: {incident_url}\n"
         if channel_id:
             dm_message += f"Slack channel: <#{channel_id}>"
+        dm_message += (
+            "\n\nYou'll be asked to fill in impact details and affected systems at "
+            "`/inc mitigated` and `/inc resolved`. You can also edit any field with `/inc update`."
+        )
 
         client.chat_postMessage(channel=slack_user_id, text=dm_message)
 

--- a/src/firetower/slack_app/handlers/resolved.py
+++ b/src/firetower/slack_app/handlers/resolved.py
@@ -6,8 +6,10 @@ from firetower.incidents.models import Incident, IncidentStatus
 from firetower.incidents.serializers import IncidentWriteSerializer
 from firetower.slack_app.handlers.utils import (
     build_incident_lifecycle_modal,
+    build_incident_update_data,
     get_incident_from_channel,
     parse_incident_form_values,
+    validate_lifecycle_form,
 )
 
 logger = logging.getLogger(__name__)
@@ -48,26 +50,7 @@ def handle_resolved_submission(ack: Any, body: dict, view: dict, client: Any) ->
     form = parse_incident_form_values(view)
     channel_id = view.get("private_metadata", "")
 
-    captain_slack_id = form["captain_slack_id"]
-    severity = form["severity"]
-    service_tier = form["service_tier"]
-
-    errors: dict[str, str] = {}
-    if not captain_slack_id:
-        errors["captain_block"] = "An incident captain is required."
-    if not severity:
-        errors["severity_block"] = "Severity is required."
-    if not form["title"]:
-        errors["title_block"] = "This field is required."
-    if not form["description"]:
-        errors["description_block"] = "Description is required."
-    if not form["impact_summary"]:
-        errors["impact_summary_block"] = "Impact summary is required."
-    if not form["impact_type_tags"]:
-        errors["impact_type_block"] = "Select at least one impact type."
-    if not service_tier:
-        errors["service_tier_block"] = "Service tier is required."
-
+    errors = validate_lifecycle_form(form)
     if errors:
         ack(response_action="errors", errors=errors)
         return
@@ -79,10 +62,11 @@ def handle_resolved_submission(ack: Any, body: dict, view: dict, client: Any) ->
         logger.error("Resolved submission: no incident for channel %s", channel_id)
         return
 
-    captain_user = get_or_create_user_from_slack_id(captain_slack_id)
+    captain_user = get_or_create_user_from_slack_id(form["captain_slack_id"])
     if not captain_user:
         logger.error(
-            "Could not resolve Slack user %s to a Firetower user", captain_slack_id
+            "Could not resolve Slack user %s to a Firetower user",
+            form["captain_slack_id"],
         )
         client.chat_postMessage(
             channel=channel_id,
@@ -90,23 +74,13 @@ def handle_resolved_submission(ack: Any, body: dict, view: dict, client: Any) ->
         )
         return
 
+    severity = form["severity"]
     if severity in ("P0", "P1", "P2"):
         target_status = IncidentStatus.POSTMORTEM
     else:
         target_status = IncidentStatus.DONE
 
-    data: dict[str, Any] = {
-        "status": target_status,
-        "severity": severity,
-        "service_tier": service_tier,
-        "captain": captain_user.email,
-        "title": form["title"],
-        "description": form["description"],
-        "impact_summary": form["impact_summary"],
-        "impact_type_tags": form["impact_type_tags"],
-        "affected_service_tags": form["affected_service_tags"],
-        "affected_region_tags": form["affected_region_tags"],
-    }
+    data = build_incident_update_data(form, target_status, captain_user.email)
 
     serializer = IncidentWriteSerializer(instance=incident, data=data, partial=True)
     if not serializer.is_valid():

--- a/src/firetower/slack_app/handlers/resolved.py
+++ b/src/firetower/slack_app/handlers/resolved.py
@@ -1,11 +1,11 @@
 import logging
 from typing import Any
 
-from firetower.auth.models import ExternalProfileType
 from firetower.auth.services import get_or_create_user_from_slack_id
-from firetower.incidents.models import Incident, IncidentSeverity, IncidentStatus
+from firetower.incidents.models import Incident, IncidentStatus
 from firetower.incidents.serializers import IncidentWriteSerializer
 from firetower.slack_app.handlers.utils import (
+    build_incident_lifecycle_modal,
     get_incident_from_channel,
     parse_incident_form_values,
 )
@@ -14,182 +14,13 @@ logger = logging.getLogger(__name__)
 
 
 def _build_resolved_modal(incident: Incident, channel_id: str) -> dict:
-    severity_options = [
-        {
-            "text": {"type": "plain_text", "text": sev.label},
-            "value": sev.value,
-        }
-        for sev in IncidentSeverity
-    ]
-    current_severity = IncidentSeverity(incident.severity)
-    current_severity_option = {
-        "text": {"type": "plain_text", "text": current_severity.label},
-        "value": current_severity.value,
-    }
-
-    captain_element: dict[str, Any] = {
-        "type": "users_select",
-        "action_id": "captain_select",
-        "placeholder": {"type": "plain_text", "text": "Select incident captain"},
-    }
-    if incident.captain:
-        slack_profile = incident.captain.external_profiles.filter(
-            type=ExternalProfileType.SLACK
-        ).first()
-        if slack_profile:
-            captain_element["initial_user"] = slack_profile.external_id
-
-    title_element: dict[str, Any] = {
-        "type": "plain_text_input",
-        "action_id": "title",
-        "placeholder": {"type": "plain_text", "text": "Brief incident title"},
-        "initial_value": incident.title or "",
-    }
-
-    description_element: dict[str, Any] = {
-        "type": "plain_text_input",
-        "action_id": "description",
-        "multiline": True,
-        "placeholder": {"type": "plain_text", "text": "What's happening?"},
-    }
-    if incident.description:
-        description_element["initial_value"] = incident.description
-
-    impact_summary_element: dict[str, Any] = {
-        "type": "plain_text_input",
-        "action_id": "impact_summary",
-        "multiline": True,
-        "placeholder": {
-            "type": "plain_text",
-            "text": "What is the user/business impact?",
-        },
-    }
-    if incident.impact_summary:
-        impact_summary_element["initial_value"] = incident.impact_summary
-
-    impact_type_initial = [
-        {"text": {"type": "plain_text", "text": name}, "value": name}
-        for name in incident.impact_type_tag_names
-    ]
-    impact_type_element: dict[str, Any] = {
-        "type": "multi_external_select",
-        "action_id": "impact_type_tags",
-        "min_query_length": 0,
-        "placeholder": {"type": "plain_text", "text": "Select impact types"},
-    }
-    if impact_type_initial:
-        impact_type_element["initial_options"] = impact_type_initial
-
-    affected_service_initial = [
-        {"text": {"type": "plain_text", "text": name}, "value": name}
-        for name in incident.affected_service_tag_names
-    ]
-    affected_service_element: dict[str, Any] = {
-        "type": "multi_external_select",
-        "action_id": "affected_service_tags",
-        "min_query_length": 0,
-        "placeholder": {"type": "plain_text", "text": "Select affected services"},
-    }
-    if affected_service_initial:
-        affected_service_element["initial_options"] = affected_service_initial
-
-    affected_region_initial = [
-        {"text": {"type": "plain_text", "text": name}, "value": name}
-        for name in incident.affected_region_tag_names
-    ]
-    affected_region_element: dict[str, Any] = {
-        "type": "multi_external_select",
-        "action_id": "affected_region_tags",
-        "min_query_length": 0,
-        "placeholder": {"type": "plain_text", "text": "Select affected regions"},
-    }
-    if affected_region_initial:
-        affected_region_element["initial_options"] = affected_region_initial
-
-    return {
-        "type": "modal",
-        "callback_id": "resolved_incident_modal",
-        "private_metadata": channel_id,
-        "title": {"type": "plain_text", "text": incident.incident_number},
-        "submit": {"type": "plain_text", "text": "Submit"},
-        "close": {"type": "plain_text", "text": "Cancel"},
-        "blocks": [
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "This incident has been contained! Please confirm the details below.",
-                },
-            },
-            {
-                "type": "input",
-                "block_id": "captain_block",
-                "element": captain_element,
-                "label": {"type": "plain_text", "text": "Incident Captain"},
-            },
-            {
-                "type": "context",
-                "elements": [
-                    {
-                        "type": "mrkdwn",
-                        "text": "The incident captain is responsible for driving the postmortem.",
-                    }
-                ],
-            },
-            {
-                "type": "input",
-                "block_id": "severity_block",
-                "element": {
-                    "type": "static_select",
-                    "action_id": "severity_select",
-                    "options": severity_options,
-                    "initial_option": current_severity_option,
-                },
-                "label": {"type": "plain_text", "text": "Severity"},
-            },
-            {
-                "type": "input",
-                "block_id": "title_block",
-                "element": title_element,
-                "label": {"type": "plain_text", "text": "Title"},
-            },
-            {
-                "type": "input",
-                "block_id": "description_block",
-                "optional": True,
-                "element": description_element,
-                "label": {"type": "plain_text", "text": "Description"},
-            },
-            {
-                "type": "input",
-                "block_id": "impact_summary_block",
-                "optional": True,
-                "element": impact_summary_element,
-                "label": {"type": "plain_text", "text": "Impact Summary"},
-            },
-            {
-                "type": "input",
-                "block_id": "impact_type_block",
-                "optional": True,
-                "element": impact_type_element,
-                "label": {"type": "plain_text", "text": "Impact Type"},
-            },
-            {
-                "type": "input",
-                "block_id": "affected_service_block",
-                "optional": True,
-                "element": affected_service_element,
-                "label": {"type": "plain_text", "text": "Affected Service"},
-            },
-            {
-                "type": "input",
-                "block_id": "affected_region_block",
-                "optional": True,
-                "element": affected_region_element,
-                "label": {"type": "plain_text", "text": "Affected Region"},
-            },
-        ],
-    }
+    return build_incident_lifecycle_modal(
+        incident=incident,
+        channel_id=channel_id,
+        title_text=incident.incident_number,
+        callback_id="resolved_incident_modal",
+        intro_text="This incident has been contained! Please confirm the details below.",
+    )
 
 
 def handle_resolved_command(ack: Any, body: dict, command: dict, respond: Any) -> None:
@@ -217,30 +48,28 @@ def handle_resolved_submission(ack: Any, body: dict, view: dict, client: Any) ->
     form = parse_incident_form_values(view)
     channel_id = view.get("private_metadata", "")
 
-    values = view.get("state", {}).get("values", {})
-
-    # The resolved modal uses "severity_select" as action_id (not "severity")
-    severity = (
-        values.get("severity_block", {})
-        .get("severity_select", {})
-        .get("selected_option", {})
-        .get("value", "")
-    ) or form["severity"]
-
     captain_slack_id = form["captain_slack_id"]
+    severity = form["severity"]
+    service_tier = form["service_tier"]
 
+    errors: dict[str, str] = {}
     if not captain_slack_id:
-        ack(
-            response_action="errors",
-            errors={"captain_block": "An incident captain is required."},
-        )
-        return
-
+        errors["captain_block"] = "An incident captain is required."
+    if not severity:
+        errors["severity_block"] = "Severity is required."
     if not form["title"]:
-        ack(
-            response_action="errors",
-            errors={"title_block": "This field is required."},
-        )
+        errors["title_block"] = "This field is required."
+    if not form["description"]:
+        errors["description_block"] = "Description is required."
+    if not form["impact_summary"]:
+        errors["impact_summary_block"] = "Impact summary is required."
+    if not form["impact_type_tags"]:
+        errors["impact_type_block"] = "Select at least one impact type."
+    if not service_tier:
+        errors["service_tier_block"] = "Service tier is required."
+
+    if errors:
+        ack(response_action="errors", errors=errors)
         return
 
     ack()
@@ -269,6 +98,7 @@ def handle_resolved_submission(ack: Any, body: dict, view: dict, client: Any) ->
     data: dict[str, Any] = {
         "status": target_status,
         "severity": severity,
+        "service_tier": service_tier,
         "captain": captain_user.email,
         "title": form["title"],
         "description": form["description"],

--- a/src/firetower/slack_app/handlers/utils.py
+++ b/src/firetower/slack_app/handlers/utils.py
@@ -380,6 +380,8 @@ def build_incident_lifecycle_modal(
                 "element": affected_region_element,
                 "label": {"type": "plain_text", "text": "Affected Regions"},
             },
+            # TODO(RELENG-768): drop this hint once inline tag creation
+            # ("+ Create 'X'" synthetic option) lands for service/region.
             {
                 "type": "context",
                 "elements": [

--- a/src/firetower/slack_app/handlers/utils.py
+++ b/src/firetower/slack_app/handlers/utils.py
@@ -8,6 +8,7 @@ from firetower.incidents.models import (
     ExternalLinkType,
     Incident,
     IncidentSeverity,
+    IncidentStatus,
     ServiceTier,
 )
 
@@ -388,8 +389,44 @@ def build_incident_lifecycle_modal(
         "type": "modal",
         "callback_id": callback_id,
         "private_metadata": channel_id,
-        "title": {"type": "plain_text", "text": title_text},
+        "title": {"type": "plain_text", "text": title_text[:24]},
         "submit": {"type": "plain_text", "text": "Submit"},
         "close": {"type": "plain_text", "text": "Cancel"},
         "blocks": blocks,
+    }
+
+
+def validate_lifecycle_form(form: dict[str, Any]) -> dict[str, str]:
+    errors: dict[str, str] = {}
+    if not form["captain_slack_id"]:
+        errors["captain_block"] = "An incident captain is required."
+    if not form["severity"]:
+        errors["severity_block"] = "Severity is required."
+    if not form["title"]:
+        errors["title_block"] = "This field is required."
+    if not form["description"]:
+        errors["description_block"] = "Description is required."
+    if not form["impact_summary"]:
+        errors["impact_summary_block"] = "Impact summary is required."
+    if not form["impact_type_tags"]:
+        errors["impact_type_block"] = "Select at least one impact type."
+    if not form["service_tier"]:
+        errors["service_tier_block"] = "Service tier is required."
+    return errors
+
+
+def build_incident_update_data(
+    form: dict[str, Any], status: IncidentStatus, captain_email: str
+) -> dict[str, Any]:
+    return {
+        "status": status,
+        "severity": form["severity"],
+        "service_tier": form["service_tier"],
+        "captain": captain_email,
+        "title": form["title"],
+        "description": form["description"],
+        "impact_summary": form["impact_summary"],
+        "impact_type_tags": form["impact_type_tags"],
+        "affected_service_tags": form["affected_service_tags"],
+        "affected_region_tags": form["affected_region_tags"],
     }

--- a/src/firetower/slack_app/handlers/utils.py
+++ b/src/firetower/slack_app/handlers/utils.py
@@ -130,11 +130,11 @@ def parse_incident_form_values(view: dict) -> dict[str, Any]:
     service_tier = service_tier_option.get("value") if service_tier_option else None
     description = (
         values.get("description_block", {}).get("description", {}).get("value") or ""
-    )
+    ).strip()
     impact_summary = (
         values.get("impact_summary_block", {}).get("impact_summary", {}).get("value")
         or ""
-    )
+    ).strip()
 
     impact_type_selections = (
         values.get("impact_type_block", {})
@@ -186,10 +186,9 @@ def build_incident_lifecycle_modal(
 ) -> dict[str, Any]:
     """Build the shared 9-field modal used by /inc mitigated and /inc resolved.
 
-    Fields are pre-filled from `incident`. Required fields (captain, severity,
-    title, description, impact_summary, impact_type, service_tier) are marked
-    required by Slack defaults. Optional fields (affected_service,
-    affected_region) set "optional": True.
+    Fields are pre-filled from `incident`. All nine fields (captain, severity,
+    title, impact_summary, description, impact_type, service_tier,
+    affected_service, affected_region) are required by Slack defaults.
     """
     severity_options = [
         {"text": {"type": "plain_text", "text": sev.label}, "value": sev.value}

--- a/src/firetower/slack_app/handlers/utils.py
+++ b/src/firetower/slack_app/handlers/utils.py
@@ -105,7 +105,7 @@ def build_incident_form_blocks(user_id: str = "") -> list[dict[str, Any]]:
                 "multiline": True,
                 "placeholder": {
                     "type": "plain_text",
-                    "text": "What is the user/business impact?",
+                    "text": "How is this affecting users?",
                 },
             },
             "label": {"type": "plain_text", "text": "Impact Summary"},
@@ -229,7 +229,10 @@ def build_incident_lifecycle_modal(
         "type": "plain_text_input",
         "action_id": "description",
         "multiline": True,
-        "placeholder": {"type": "plain_text", "text": "What's happening?"},
+        "placeholder": {
+            "type": "plain_text",
+            "text": "Additional relevant information",
+        },
     }
     if incident.description:
         description_element["initial_value"] = incident.description
@@ -238,10 +241,7 @@ def build_incident_lifecycle_modal(
         "type": "plain_text_input",
         "action_id": "impact_summary",
         "multiline": True,
-        "placeholder": {
-            "type": "plain_text",
-            "text": "What is the user/business impact?",
-        },
+        "placeholder": {"type": "plain_text", "text": "How is this affecting users?"},
     }
     if incident.impact_summary:
         impact_summary_element["initial_value"] = incident.impact_summary
@@ -254,7 +254,7 @@ def build_incident_lifecycle_modal(
         "type": "multi_external_select",
         "action_id": "impact_type_tags",
         "min_query_length": 0,
-        "placeholder": {"type": "plain_text", "text": "Select impact types"},
+        "placeholder": {"type": "plain_text", "text": "Type"},
     }
     if impact_type_initial:
         impact_type_element["initial_options"] = impact_type_initial
@@ -328,21 +328,21 @@ def build_incident_lifecycle_modal(
         },
         {
             "type": "input",
-            "block_id": "description_block",
-            "element": description_element,
-            "label": {"type": "plain_text", "text": "Description"},
-        },
-        {
-            "type": "input",
             "block_id": "impact_summary_block",
             "element": impact_summary_element,
             "label": {"type": "plain_text", "text": "Impact Summary"},
         },
         {
             "type": "input",
+            "block_id": "description_block",
+            "element": description_element,
+            "label": {"type": "plain_text", "text": "Description"},
+        },
+        {
+            "type": "input",
             "block_id": "impact_type_block",
             "element": impact_type_element,
-            "label": {"type": "plain_text", "text": "Impact Type"},
+            "label": {"type": "plain_text", "text": "Type of impact"},
         },
         {
             "type": "input",
@@ -366,21 +366,29 @@ def build_incident_lifecycle_modal(
             }
         )
 
+    incident_url = f"{settings.FIRETOWER_BASE_URL}/{incident.incident_number}"
     blocks.extend(
         [
             {
                 "type": "input",
                 "block_id": "affected_service_block",
-                "optional": True,
                 "element": affected_service_element,
                 "label": {"type": "plain_text", "text": "Affected Service"},
             },
             {
                 "type": "input",
                 "block_id": "affected_region_block",
-                "optional": True,
                 "element": affected_region_element,
                 "label": {"type": "plain_text", "text": "Affected Region"},
+            },
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f"Missing a service or region? Add it from the <{incident_url}|incident page>.",
+                    }
+                ],
             },
         ]
     )
@@ -412,6 +420,10 @@ def validate_lifecycle_form(form: dict[str, Any]) -> dict[str, str]:
         errors["impact_type_block"] = "Select at least one impact type."
     if not form["service_tier"]:
         errors["service_tier_block"] = "Service tier is required."
+    if not form["affected_service_tags"]:
+        errors["affected_service_block"] = "Select at least one affected service."
+    if not form["affected_region_tags"]:
+        errors["affected_region_block"] = "Select at least one affected region."
     return errors
 
 

--- a/src/firetower/slack_app/handlers/utils.py
+++ b/src/firetower/slack_app/handlers/utils.py
@@ -360,7 +360,7 @@ def build_incident_lifecycle_modal(
                 "elements": [
                     {
                         "type": "mrkdwn",
-                        "text": f"<{service_registry_url}|See service registry>",
+                        "text": f"<{service_registry_url}|Service Registry>",
                     }
                 ],
             }

--- a/src/firetower/slack_app/handlers/utils.py
+++ b/src/firetower/slack_app/handlers/utils.py
@@ -82,21 +82,6 @@ def build_incident_form_blocks(user_id: str = "") -> list[dict[str, Any]]:
         },
         {
             "type": "input",
-            "block_id": "description_block",
-            "optional": True,
-            "element": {
-                "type": "plain_text_input",
-                "action_id": "description",
-                "multiline": True,
-                "placeholder": {
-                    "type": "plain_text",
-                    "text": "What's happening?",
-                },
-            },
-            "label": {"type": "plain_text", "text": "Description"},
-        },
-        {
-            "type": "input",
             "block_id": "impact_summary_block",
             "optional": True,
             "element": {
@@ -109,6 +94,21 @@ def build_incident_form_blocks(user_id: str = "") -> list[dict[str, Any]]:
                 },
             },
             "label": {"type": "plain_text", "text": "Impact Summary"},
+        },
+        {
+            "type": "input",
+            "block_id": "description_block",
+            "optional": True,
+            "element": {
+                "type": "plain_text_input",
+                "action_id": "description",
+                "multiline": True,
+                "placeholder": {
+                    "type": "plain_text",
+                    "text": "What's happening?",
+                },
+            },
+            "label": {"type": "plain_text", "text": "Description"},
         },
     ]
 

--- a/src/firetower/slack_app/handlers/utils.py
+++ b/src/firetower/slack_app/handlers/utils.py
@@ -373,13 +373,13 @@ def build_incident_lifecycle_modal(
                 "type": "input",
                 "block_id": "affected_service_block",
                 "element": affected_service_element,
-                "label": {"type": "plain_text", "text": "Affected Service"},
+                "label": {"type": "plain_text", "text": "Affected Services"},
             },
             {
                 "type": "input",
                 "block_id": "affected_region_block",
                 "element": affected_region_element,
-                "label": {"type": "plain_text", "text": "Affected Region"},
+                "label": {"type": "plain_text", "text": "Affected Regions"},
             },
             {
                 "type": "context",

--- a/src/firetower/slack_app/handlers/utils.py
+++ b/src/firetower/slack_app/handlers/utils.py
@@ -109,51 +109,6 @@ def build_incident_form_blocks(user_id: str = "") -> list[dict[str, Any]]:
             },
             "label": {"type": "plain_text", "text": "Impact Summary"},
         },
-        {
-            "type": "input",
-            "block_id": "impact_type_block",
-            "optional": True,
-            "element": {
-                "type": "multi_external_select",
-                "action_id": "impact_type_tags",
-                "min_query_length": 0,
-                "placeholder": {
-                    "type": "plain_text",
-                    "text": "Select impact types",
-                },
-            },
-            "label": {"type": "plain_text", "text": "Impact Type"},
-        },
-        {
-            "type": "input",
-            "block_id": "affected_service_block",
-            "optional": True,
-            "element": {
-                "type": "multi_external_select",
-                "action_id": "affected_service_tags",
-                "min_query_length": 0,
-                "placeholder": {
-                    "type": "plain_text",
-                    "text": "Select affected services",
-                },
-            },
-            "label": {"type": "plain_text", "text": "Affected Service"},
-        },
-        {
-            "type": "input",
-            "block_id": "affected_region_block",
-            "optional": True,
-            "element": {
-                "type": "multi_external_select",
-                "action_id": "affected_region_tags",
-                "min_query_length": 0,
-                "placeholder": {
-                    "type": "plain_text",
-                    "text": "Select affected regions",
-                },
-            },
-            "label": {"type": "plain_text", "text": "Affected Region"},
-        },
     ]
 
 

--- a/src/firetower/slack_app/handlers/utils.py
+++ b/src/firetower/slack_app/handlers/utils.py
@@ -1,10 +1,14 @@
 from typing import Any
 
+from django.conf import settings
+
+from firetower.auth.models import ExternalProfileType
 from firetower.incidents.models import (
     ExternalLink,
     ExternalLinkType,
     Incident,
     IncidentSeverity,
+    ServiceTier,
 )
 
 _DEFAULT_SEVERITY = IncidentSeverity.P3
@@ -157,10 +161,17 @@ def parse_incident_form_values(view: dict) -> dict[str, Any]:
     values = view.get("state", {}).get("values", {})
 
     title = values.get("title_block", {}).get("title", {}).get("value", "").strip()
-    selected_option = (
-        values.get("severity_block", {}).get("severity", {}).get("selected_option")
-    )
+    severity_block = values.get("severity_block", {})
+    selected_option = severity_block.get("severity", {}).get(
+        "selected_option"
+    ) or severity_block.get("severity_select", {}).get("selected_option")
     severity = selected_option.get("value") if selected_option else None
+    service_tier_option = (
+        values.get("service_tier_block", {})
+        .get("service_tier_select", {})
+        .get("selected_option")
+    )
+    service_tier = service_tier_option.get("value") if service_tier_option else None
     description = (
         values.get("description_block", {}).get("description", {}).get("value") or ""
     )
@@ -200,10 +211,230 @@ def parse_incident_form_values(view: dict) -> dict[str, Any]:
     return {
         "title": title,
         "severity": severity,
+        "service_tier": service_tier,
         "description": description,
         "impact_summary": impact_summary,
         "impact_type_tags": impact_type_tags,
         "affected_service_tags": affected_service_tags,
         "affected_region_tags": affected_region_tags,
         "captain_slack_id": captain_slack_id,
+    }
+
+
+def build_incident_lifecycle_modal(
+    incident: Incident,
+    channel_id: str,
+    title_text: str,
+    callback_id: str,
+    intro_text: str,
+) -> dict[str, Any]:
+    """Build the shared 9-field modal used by /inc mitigated and /inc resolved.
+
+    Fields are pre-filled from `incident`. Required fields (captain, severity,
+    title, description, impact_summary, impact_type, service_tier) are marked
+    required by Slack defaults. Optional fields (affected_service,
+    affected_region) set "optional": True.
+    """
+    severity_options = [
+        {"text": {"type": "plain_text", "text": sev.label}, "value": sev.value}
+        for sev in IncidentSeverity
+    ]
+    current_severity = IncidentSeverity(incident.severity)
+    current_severity_option = {
+        "text": {"type": "plain_text", "text": current_severity.label},
+        "value": current_severity.value,
+    }
+
+    service_tier_options = [
+        {"text": {"type": "plain_text", "text": tier.label}, "value": tier.value}
+        for tier in ServiceTier
+    ]
+
+    captain_element: dict[str, Any] = {
+        "type": "users_select",
+        "action_id": "captain_select",
+        "placeholder": {"type": "plain_text", "text": "Select incident captain"},
+    }
+    if incident.captain:
+        slack_profile = incident.captain.external_profiles.filter(
+            type=ExternalProfileType.SLACK
+        ).first()
+        if slack_profile:
+            captain_element["initial_user"] = slack_profile.external_id
+
+    title_element: dict[str, Any] = {
+        "type": "plain_text_input",
+        "action_id": "title",
+        "placeholder": {"type": "plain_text", "text": "Brief incident title"},
+        "initial_value": incident.title or "",
+    }
+
+    description_element: dict[str, Any] = {
+        "type": "plain_text_input",
+        "action_id": "description",
+        "multiline": True,
+        "placeholder": {"type": "plain_text", "text": "What's happening?"},
+    }
+    if incident.description:
+        description_element["initial_value"] = incident.description
+
+    impact_summary_element: dict[str, Any] = {
+        "type": "plain_text_input",
+        "action_id": "impact_summary",
+        "multiline": True,
+        "placeholder": {
+            "type": "plain_text",
+            "text": "What is the user/business impact?",
+        },
+    }
+    if incident.impact_summary:
+        impact_summary_element["initial_value"] = incident.impact_summary
+
+    impact_type_initial = [
+        {"text": {"type": "plain_text", "text": name}, "value": name}
+        for name in incident.impact_type_tag_names
+    ]
+    impact_type_element: dict[str, Any] = {
+        "type": "multi_external_select",
+        "action_id": "impact_type_tags",
+        "min_query_length": 0,
+        "placeholder": {"type": "plain_text", "text": "Select impact types"},
+    }
+    if impact_type_initial:
+        impact_type_element["initial_options"] = impact_type_initial
+
+    service_tier_element: dict[str, Any] = {
+        "type": "static_select",
+        "action_id": "service_tier_select",
+        "placeholder": {"type": "plain_text", "text": "Select service tier"},
+        "options": service_tier_options,
+    }
+    if incident.service_tier:
+        current_tier = ServiceTier(incident.service_tier)
+        service_tier_element["initial_option"] = {
+            "text": {"type": "plain_text", "text": current_tier.label},
+            "value": current_tier.value,
+        }
+
+    affected_service_initial = [
+        {"text": {"type": "plain_text", "text": name}, "value": name}
+        for name in incident.affected_service_tag_names
+    ]
+    affected_service_element: dict[str, Any] = {
+        "type": "multi_external_select",
+        "action_id": "affected_service_tags",
+        "min_query_length": 0,
+        "placeholder": {"type": "plain_text", "text": "Select affected services"},
+    }
+    if affected_service_initial:
+        affected_service_element["initial_options"] = affected_service_initial
+
+    affected_region_initial = [
+        {"text": {"type": "plain_text", "text": name}, "value": name}
+        for name in incident.affected_region_tag_names
+    ]
+    affected_region_element: dict[str, Any] = {
+        "type": "multi_external_select",
+        "action_id": "affected_region_tags",
+        "min_query_length": 0,
+        "placeholder": {"type": "plain_text", "text": "Select affected regions"},
+    }
+    if affected_region_initial:
+        affected_region_element["initial_options"] = affected_region_initial
+
+    blocks: list[dict[str, Any]] = [
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": intro_text},
+        },
+        {
+            "type": "input",
+            "block_id": "captain_block",
+            "element": captain_element,
+            "label": {"type": "plain_text", "text": "Incident Captain"},
+        },
+        {
+            "type": "input",
+            "block_id": "severity_block",
+            "element": {
+                "type": "static_select",
+                "action_id": "severity_select",
+                "options": severity_options,
+                "initial_option": current_severity_option,
+            },
+            "label": {"type": "plain_text", "text": "Severity"},
+        },
+        {
+            "type": "input",
+            "block_id": "title_block",
+            "element": title_element,
+            "label": {"type": "plain_text", "text": "Title"},
+        },
+        {
+            "type": "input",
+            "block_id": "description_block",
+            "element": description_element,
+            "label": {"type": "plain_text", "text": "Description"},
+        },
+        {
+            "type": "input",
+            "block_id": "impact_summary_block",
+            "element": impact_summary_element,
+            "label": {"type": "plain_text", "text": "Impact Summary"},
+        },
+        {
+            "type": "input",
+            "block_id": "impact_type_block",
+            "element": impact_type_element,
+            "label": {"type": "plain_text", "text": "Impact Type"},
+        },
+        {
+            "type": "input",
+            "block_id": "service_tier_block",
+            "element": service_tier_element,
+            "label": {"type": "plain_text", "text": "Service Tier"},
+        },
+    ]
+
+    service_registry_url = getattr(settings, "SERVICE_REGISTRY_URL", None)
+    if service_registry_url:
+        blocks.append(
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f"<{service_registry_url}|See service registry>",
+                    }
+                ],
+            }
+        )
+
+    blocks.extend(
+        [
+            {
+                "type": "input",
+                "block_id": "affected_service_block",
+                "optional": True,
+                "element": affected_service_element,
+                "label": {"type": "plain_text", "text": "Affected Service"},
+            },
+            {
+                "type": "input",
+                "block_id": "affected_region_block",
+                "optional": True,
+                "element": affected_region_element,
+                "label": {"type": "plain_text", "text": "Affected Region"},
+            },
+        ]
+    )
+
+    return {
+        "type": "modal",
+        "callback_id": callback_id,
+        "private_metadata": channel_id,
+        "title": {"type": "plain_text", "text": title_text},
+        "submit": {"type": "plain_text", "text": "Submit"},
+        "close": {"type": "plain_text", "text": "Cancel"},
+        "blocks": blocks,
     }

--- a/src/firetower/slack_app/tests/handlers/test_mitigated.py
+++ b/src/firetower/slack_app/tests/handlers/test_mitigated.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.conf import settings
 
 from firetower.incidents.models import IncidentStatus, Tag, TagType
 from firetower.slack_app.handlers.mitigated import (
@@ -257,3 +258,45 @@ class TestMitigatedSubmission:
         call_kwargs = ack.call_args[1]
         assert call_kwargs["response_action"] == "errors"
         assert "impact_summary_block" in call_kwargs["errors"]
+
+    @patch("firetower.slack_app.handlers.mitigated.get_or_create_user_from_slack_id")
+    def test_captain_resolution_failure(self, mock_get_user, incident):
+        mock_get_user.return_value = None
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_CAPTAIN"}}
+        view = _make_mitigated_view()
+
+        handle_mitigated_submission(ack, body, view, client)
+
+        ack.assert_called_once_with()
+        client.chat_postMessage.assert_called_once()
+        msg = client.chat_postMessage.call_args[1]["text"]
+        assert "Failed to resolve the selected captain" in msg
+
+
+@pytest.mark.django_db
+class TestServiceRegistryBlock:
+    @patch.object(settings, "SERVICE_REGISTRY_URL", "https://example.com/registry")
+    def test_context_block_present_when_url_set(self, incident):
+        modal = _build_mitigated_modal(incident, CHANNEL_ID)
+        blocks = modal["blocks"]
+        service_tier_idx = next(
+            i for i, b in enumerate(blocks) if b.get("block_id") == "service_tier_block"
+        )
+        affected_service_idx = next(
+            i
+            for i, b in enumerate(blocks)
+            if b.get("block_id") == "affected_service_block"
+        )
+        context_block = blocks[service_tier_idx + 1]
+        assert context_block["type"] == "context"
+        assert "https://example.com/registry" in context_block["elements"][0]["text"]
+        assert affected_service_idx == service_tier_idx + 2
+
+    @patch.object(settings, "SERVICE_REGISTRY_URL", None)
+    def test_no_context_block_when_url_not_set(self, incident):
+        modal = _build_mitigated_modal(incident, CHANNEL_ID)
+        blocks = modal["blocks"]
+        context_blocks = [b for b in blocks if b.get("type") == "context"]
+        assert len(context_blocks) == 0

--- a/src/firetower/slack_app/tests/handlers/test_mitigated.py
+++ b/src/firetower/slack_app/tests/handlers/test_mitigated.py
@@ -313,7 +313,7 @@ class TestServiceRegistryBlock:
             b
             for b in modal["blocks"]
             if b.get("type") == "context"
-            and "service registry" in b["elements"][0]["text"]
+            and "Service Registry" in b["elements"][0]["text"]
         ]
         assert len(registry_blocks) == 0
 

--- a/src/firetower/slack_app/tests/handlers/test_mitigated.py
+++ b/src/firetower/slack_app/tests/handlers/test_mitigated.py
@@ -271,6 +271,32 @@ class TestMitigatedSubmission:
         assert call_kwargs["response_action"] == "errors"
         assert "impact_summary_block" in call_kwargs["errors"]
 
+    def test_whitespace_only_description_returns_error(self, incident):
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_CAPTAIN"}}
+        view = _make_mitigated_view(description="   \n\t  ")
+
+        handle_mitigated_submission(ack, body, view, client)
+
+        ack.assert_called_once()
+        call_kwargs = ack.call_args[1]
+        assert call_kwargs["response_action"] == "errors"
+        assert "description_block" in call_kwargs["errors"]
+
+    def test_whitespace_only_impact_summary_returns_error(self, incident):
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_CAPTAIN"}}
+        view = _make_mitigated_view(impact_summary="   ")
+
+        handle_mitigated_submission(ack, body, view, client)
+
+        ack.assert_called_once()
+        call_kwargs = ack.call_args[1]
+        assert call_kwargs["response_action"] == "errors"
+        assert "impact_summary_block" in call_kwargs["errors"]
+
     @patch("firetower.slack_app.handlers.mitigated.get_or_create_user_from_slack_id")
     def test_captain_resolution_failure(self, mock_get_user, incident):
         mock_get_user.return_value = None

--- a/src/firetower/slack_app/tests/handlers/test_mitigated.py
+++ b/src/firetower/slack_app/tests/handlers/test_mitigated.py
@@ -21,8 +21,8 @@ def _make_mitigated_view(
     impact_summary="Users affected",
     impact_type_tags=("Degraded Service",),
     service_tier="T1",
-    affected_service_tags=(),
-    affected_region_tags=(),
+    affected_service_tags=("api-server",),
+    affected_region_tags=("us-east-1",),
 ):
     def _options(values):
         return [{"value": v} for v in values]
@@ -62,6 +62,16 @@ def _make_mitigated_view(
 @pytest.fixture
 def impact_type_tag(db):
     return Tag.objects.create(name="Degraded Service", type=TagType.IMPACT_TYPE)
+
+
+@pytest.fixture
+def affected_service_tag(db):
+    return Tag.objects.create(name="api-server", type=TagType.AFFECTED_SERVICE)
+
+
+@pytest.fixture
+def affected_region_tag(db):
+    return Tag.objects.create(name="us-east-1", type=TagType.AFFECTED_REGION)
 
 
 @pytest.mark.django_db
@@ -113,7 +123,7 @@ class TestMitigatedModal:
         ):
             assert required in block_ids
 
-    def test_required_vs_optional_blocks(self, incident):
+    def test_all_blocks_required(self, incident):
         modal = _build_mitigated_modal(incident, CHANNEL_ID)
         by_id = {b["block_id"]: b for b in modal["blocks"] if "block_id" in b}
         for required in (
@@ -124,10 +134,10 @@ class TestMitigatedModal:
             "impact_summary_block",
             "impact_type_block",
             "service_tier_block",
+            "affected_service_block",
+            "affected_region_block",
         ):
             assert by_id[required].get("optional", False) is False
-        assert by_id["affected_service_block"]["optional"] is True
-        assert by_id["affected_region_block"]["optional"] is True
 
     def test_prefills_title_and_severity(self, incident):
         modal = _build_mitigated_modal(incident, CHANNEL_ID)
@@ -149,6 +159,8 @@ class TestMitigatedSubmission:
         user,
         incident,
         impact_type_tag,
+        affected_service_tag,
+        affected_region_tag,
     ):
         mock_get_user.return_value = user
         ack = MagicMock()
@@ -168,30 +180,31 @@ class TestMitigatedSubmission:
         msg = client.chat_postMessage.call_args[1]["text"]
         assert "Mitigated" in msg
 
-    @patch("firetower.incidents.serializers.on_status_changed")
-    @patch("firetower.incidents.serializers.on_title_changed")
-    @patch("firetower.slack_app.handlers.mitigated.get_or_create_user_from_slack_id")
-    def test_optional_affected_fields(
-        self,
-        mock_get_user,
-        mock_title_hook,
-        mock_status_hook,
-        user,
-        incident,
-        impact_type_tag,
-    ):
-        mock_get_user.return_value = user
+    def test_missing_affected_service_returns_error(self, incident):
         ack = MagicMock()
         client = MagicMock()
         body = {"user": {"id": "U_CAPTAIN"}}
-        # Omit affected_service and affected_region — submission should still succeed.
-        view = _make_mitigated_view(affected_service_tags=(), affected_region_tags=())
+        view = _make_mitigated_view(affected_service_tags=())
 
         handle_mitigated_submission(ack, body, view, client)
 
-        ack.assert_called_once_with()
-        incident.refresh_from_db()
-        assert incident.status == IncidentStatus.MITIGATED
+        ack.assert_called_once()
+        call_kwargs = ack.call_args[1]
+        assert call_kwargs["response_action"] == "errors"
+        assert "affected_service_block" in call_kwargs["errors"]
+
+    def test_missing_affected_region_returns_error(self, incident):
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_CAPTAIN"}}
+        view = _make_mitigated_view(affected_region_tags=())
+
+        handle_mitigated_submission(ack, body, view, client)
+
+        ack.assert_called_once()
+        call_kwargs = ack.call_args[1]
+        assert call_kwargs["response_action"] == "errors"
+        assert "affected_region_block" in call_kwargs["errors"]
 
     def test_missing_captain_returns_error(self, incident):
         ack = MagicMock()
@@ -277,7 +290,7 @@ class TestMitigatedSubmission:
 @pytest.mark.django_db
 class TestServiceRegistryBlock:
     @patch.object(settings, "SERVICE_REGISTRY_URL", "https://example.com/registry")
-    def test_context_block_present_when_url_set(self, incident):
+    def test_service_registry_block_present_when_url_set(self, incident):
         modal = _build_mitigated_modal(incident, CHANNEL_ID)
         blocks = modal["blocks"]
         service_tier_idx = next(
@@ -294,8 +307,23 @@ class TestServiceRegistryBlock:
         assert affected_service_idx == service_tier_idx + 2
 
     @patch.object(settings, "SERVICE_REGISTRY_URL", None)
-    def test_no_context_block_when_url_not_set(self, incident):
+    def test_no_service_registry_block_when_url_not_set(self, incident):
         modal = _build_mitigated_modal(incident, CHANNEL_ID)
-        blocks = modal["blocks"]
-        context_blocks = [b for b in blocks if b.get("type") == "context"]
-        assert len(context_blocks) == 0
+        registry_blocks = [
+            b
+            for b in modal["blocks"]
+            if b.get("type") == "context"
+            and "service registry" in b["elements"][0]["text"]
+        ]
+        assert len(registry_blocks) == 0
+
+    def test_incident_page_hint_block_always_present(self, incident):
+        modal = _build_mitigated_modal(incident, CHANNEL_ID)
+        hint_blocks = [
+            b
+            for b in modal["blocks"]
+            if b.get("type") == "context"
+            and "incident page" in b["elements"][0]["text"]
+            and incident.incident_number in b["elements"][0]["text"]
+        ]
+        assert len(hint_blocks) == 1

--- a/src/firetower/slack_app/tests/handlers/test_mitigated.py
+++ b/src/firetower/slack_app/tests/handlers/test_mitigated.py
@@ -167,7 +167,6 @@ class TestMitigatedSubmission:
         client.chat_postMessage.assert_called_once()
         msg = client.chat_postMessage.call_args[1]["text"]
         assert "Mitigated" in msg
-        assert "Action Items" in msg
 
     @patch("firetower.incidents.serializers.on_status_changed")
     @patch("firetower.incidents.serializers.on_title_changed")

--- a/src/firetower/slack_app/tests/handlers/test_mitigated.py
+++ b/src/firetower/slack_app/tests/handlers/test_mitigated.py
@@ -2,13 +2,65 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from firetower.incidents.models import IncidentStatus
+from firetower.incidents.models import IncidentStatus, Tag, TagType
 from firetower.slack_app.handlers.mitigated import (
+    _build_mitigated_modal,
     handle_mitigated_command,
     handle_mitigated_submission,
 )
 
 from .conftest import CHANNEL_ID
+
+
+def _make_mitigated_view(
+    severity="P2",
+    captain="U_CAPTAIN",
+    title="Test Incident",
+    description="Things broke",
+    impact_summary="Users affected",
+    impact_type_tags=("Degraded Service",),
+    service_tier="T1",
+    affected_service_tags=(),
+    affected_region_tags=(),
+):
+    def _options(values):
+        return [{"value": v} for v in values]
+
+    state_values: dict = {
+        "captain_block": {"captain_select": {"selected_user": captain}},
+        "title_block": {"title": {"value": title}},
+        "description_block": {"description": {"value": description}},
+        "impact_summary_block": {"impact_summary": {"value": impact_summary}},
+        "impact_type_block": {
+            "impact_type_tags": {"selected_options": _options(impact_type_tags)}
+        },
+        "affected_service_block": {
+            "affected_service_tags": {
+                "selected_options": _options(affected_service_tags)
+            }
+        },
+        "affected_region_block": {
+            "affected_region_tags": {"selected_options": _options(affected_region_tags)}
+        },
+    }
+    if severity is not None:
+        state_values["severity_block"] = {
+            "severity_select": {"selected_option": {"value": severity}}
+        }
+    else:
+        state_values["severity_block"] = {"severity_select": {}}
+    if service_tier is not None:
+        state_values["service_tier_block"] = {
+            "service_tier_select": {"selected_option": {"value": service_tier}}
+        }
+    else:
+        state_values["service_tier_block"] = {"service_tier_select": {}}
+    return {"private_metadata": CHANNEL_ID, "state": {"values": state_values}}
+
+
+@pytest.fixture
+def impact_type_tag(db):
+    return Tag.objects.create(name="Degraded Service", type=TagType.IMPACT_TYPE)
 
 
 @pytest.mark.django_db
@@ -43,51 +95,165 @@ class TestMitigatedCommand:
 
 
 @pytest.mark.django_db
+class TestMitigatedModal:
+    def test_contains_all_lifecycle_fields(self, incident):
+        modal = _build_mitigated_modal(incident, CHANNEL_ID)
+        block_ids = [b["block_id"] for b in modal["blocks"] if "block_id" in b]
+        for required in (
+            "captain_block",
+            "severity_block",
+            "title_block",
+            "description_block",
+            "impact_summary_block",
+            "impact_type_block",
+            "service_tier_block",
+            "affected_service_block",
+            "affected_region_block",
+        ):
+            assert required in block_ids
+
+    def test_required_vs_optional_blocks(self, incident):
+        modal = _build_mitigated_modal(incident, CHANNEL_ID)
+        by_id = {b["block_id"]: b for b in modal["blocks"] if "block_id" in b}
+        for required in (
+            "captain_block",
+            "severity_block",
+            "title_block",
+            "description_block",
+            "impact_summary_block",
+            "impact_type_block",
+            "service_tier_block",
+        ):
+            assert by_id[required].get("optional", False) is False
+        assert by_id["affected_service_block"]["optional"] is True
+        assert by_id["affected_region_block"]["optional"] is True
+
+    def test_prefills_title_and_severity(self, incident):
+        modal = _build_mitigated_modal(incident, CHANNEL_ID)
+        by_id = {b["block_id"]: b for b in modal["blocks"] if "block_id" in b}
+        assert by_id["title_block"]["element"]["initial_value"] == "Test Incident"
+        assert by_id["severity_block"]["element"]["initial_option"]["value"] == "P2"
+
+
+@pytest.mark.django_db
 class TestMitigatedSubmission:
     @patch("firetower.incidents.serializers.on_status_changed")
     @patch("firetower.incidents.serializers.on_title_changed")
+    @patch("firetower.slack_app.handlers.mitigated.get_or_create_user_from_slack_id")
     def test_transitions_to_mitigated(
-        self, mock_title_hook, mock_status_hook, incident
+        self,
+        mock_get_user,
+        mock_title_hook,
+        mock_status_hook,
+        user,
+        incident,
+        impact_type_tag,
     ):
+        mock_get_user.return_value = user
         ack = MagicMock()
         client = MagicMock()
         body = {"user": {"id": "U_CAPTAIN"}}
-        view = {
-            "private_metadata": CHANNEL_ID,
-            "state": {
-                "values": {
-                    "impact_block": {"impact_update": {"value": "Reduced impact"}},
-                    "todo_block": {"todo_update": {"value": "Monitor overnight"}},
-                }
-            },
-        }
+        view = _make_mitigated_view()
 
         handle_mitigated_submission(ack, body, view, client)
 
-        ack.assert_called_once()
+        ack.assert_called_once_with()
         incident.refresh_from_db()
         assert incident.status == IncidentStatus.MITIGATED
+        assert incident.service_tier == "T1"
+        assert incident.description == "Things broke"
+        assert incident.impact_summary == "Users affected"
         client.chat_postMessage.assert_called_once()
         msg = client.chat_postMessage.call_args[1]["text"]
         assert "Mitigated" in msg
-        assert "Reduced impact" in msg
-        assert "Monitor overnight" in msg
+        assert "Action Items" in msg
 
-    def test_missing_incident_does_not_crash(self, db):
+    @patch("firetower.incidents.serializers.on_status_changed")
+    @patch("firetower.incidents.serializers.on_title_changed")
+    @patch("firetower.slack_app.handlers.mitigated.get_or_create_user_from_slack_id")
+    def test_optional_affected_fields(
+        self,
+        mock_get_user,
+        mock_title_hook,
+        mock_status_hook,
+        user,
+        incident,
+        impact_type_tag,
+    ):
+        mock_get_user.return_value = user
         ack = MagicMock()
         client = MagicMock()
         body = {"user": {"id": "U_CAPTAIN"}}
-        view = {
-            "private_metadata": "C_NONEXISTENT",
-            "state": {
-                "values": {
-                    "impact_block": {"impact_update": {"value": "x"}},
-                    "todo_block": {"todo_update": {"value": "y"}},
-                }
-            },
-        }
+        # Omit affected_service and affected_region — submission should still succeed.
+        view = _make_mitigated_view(affected_service_tags=(), affected_region_tags=())
+
+        handle_mitigated_submission(ack, body, view, client)
+
+        ack.assert_called_once_with()
+        incident.refresh_from_db()
+        assert incident.status == IncidentStatus.MITIGATED
+
+    def test_missing_captain_returns_error(self, incident):
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_CAPTAIN"}}
+        view = _make_mitigated_view(captain=None)
 
         handle_mitigated_submission(ack, body, view, client)
 
         ack.assert_called_once()
-        client.chat_postMessage.assert_not_called()
+        call_kwargs = ack.call_args[1]
+        assert call_kwargs["response_action"] == "errors"
+        assert "captain_block" in call_kwargs["errors"]
+
+    def test_missing_impact_type_returns_error(self, incident):
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_CAPTAIN"}}
+        view = _make_mitigated_view(impact_type_tags=())
+
+        handle_mitigated_submission(ack, body, view, client)
+
+        ack.assert_called_once()
+        call_kwargs = ack.call_args[1]
+        assert call_kwargs["response_action"] == "errors"
+        assert "impact_type_block" in call_kwargs["errors"]
+
+    def test_missing_service_tier_returns_error(self, incident):
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_CAPTAIN"}}
+        view = _make_mitigated_view(service_tier=None)
+
+        handle_mitigated_submission(ack, body, view, client)
+
+        ack.assert_called_once()
+        call_kwargs = ack.call_args[1]
+        assert call_kwargs["response_action"] == "errors"
+        assert "service_tier_block" in call_kwargs["errors"]
+
+    def test_missing_description_returns_error(self, incident):
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_CAPTAIN"}}
+        view = _make_mitigated_view(description="")
+
+        handle_mitigated_submission(ack, body, view, client)
+
+        ack.assert_called_once()
+        call_kwargs = ack.call_args[1]
+        assert call_kwargs["response_action"] == "errors"
+        assert "description_block" in call_kwargs["errors"]
+
+    def test_missing_impact_summary_returns_error(self, incident):
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_CAPTAIN"}}
+        view = _make_mitigated_view(impact_summary="")
+
+        handle_mitigated_submission(ack, body, view, client)
+
+        ack.assert_called_once()
+        call_kwargs = ack.call_args[1]
+        assert call_kwargs["response_action"] == "errors"
+        assert "impact_summary_block" in call_kwargs["errors"]

--- a/src/firetower/slack_app/tests/handlers/test_new_incident.py
+++ b/src/firetower/slack_app/tests/handlers/test_new_incident.py
@@ -56,6 +56,28 @@ class TestNewIncidentModal:
         assert view["callback_id"] == "new_incident_modal"
         assert view["type"] == "modal"
 
+    @patch("firetower.slack_app.bolt.get_bolt_app")
+    def test_new_modal_has_minimal_blocks(self, mock_get_bolt_app):
+        """The /inc new modal should only require title + severity. Tag blocks
+        are deferred to /inc mitigated and /inc resolved."""
+        ack = MagicMock()
+        body = {"trigger_id": "T12345"}
+        command = {"text": "new"}
+        respond = MagicMock()
+
+        handle_new_command(ack, body, command, respond)
+
+        view = mock_get_bolt_app.return_value.client.views_open.call_args[1]["view"]
+        block_ids = [b["block_id"] for b in view["blocks"] if "block_id" in b]
+        assert set(block_ids) == {
+            "captain_block",
+            "severity_block",
+            "title_block",
+            "description_block",
+            "impact_summary_block",
+            "private_block",
+        }
+
 
 @pytest.mark.django_db
 class TestNewIncidentSubmission:

--- a/src/firetower/slack_app/tests/handlers/test_new_incident.py
+++ b/src/firetower/slack_app/tests/handlers/test_new_incident.py
@@ -444,9 +444,6 @@ class TestFallbackChannel:
             "impact_summary": "All users affected",
             "captain_slack_id": "U_CAPTAIN",
             "is_private": False,
-            "impact_type_tags": ["Degraded Service"],
-            "affected_service_tags": ["api"],
-            "affected_region_tags": ["us-east-1"],
         }
 
     @patch("firetower.slack_app.handlers.new_incident._slack_service")
@@ -490,9 +487,6 @@ class TestFallbackChannel:
         assert "Captain: <@U_CAPTAIN>" in metadata_text
         assert "Reporter: <@U_REPORTER>" in metadata_text
         assert "Private: no" in metadata_text
-        assert "Impact Types: Degraded Service" in metadata_text
-        assert "Affected Services: api" in metadata_text
-        assert "Affected Regions: us-east-1" in metadata_text
         mock_slack_svc.pin_message.assert_called_once_with("C_FALLBACK", "1234.5678")
 
     @patch("firetower.slack_app.handlers.new_incident._slack_service")

--- a/src/firetower/slack_app/tests/handlers/test_resolved.py
+++ b/src/firetower/slack_app/tests/handlers/test_resolved.py
@@ -318,3 +318,18 @@ class TestResolvedSubmission:
         call_kwargs = ack.call_args[1]
         assert call_kwargs["response_action"] == "errors"
         assert "service_tier_block" in call_kwargs["errors"]
+
+    @patch("firetower.slack_app.handlers.resolved.get_or_create_user_from_slack_id")
+    def test_captain_resolution_failure(self, mock_get_user, incident):
+        mock_get_user.return_value = None
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_CAPTAIN"}}
+        view = _make_resolved_view()
+
+        handle_resolved_submission(ack, body, view, client)
+
+        ack.assert_called_once_with()
+        client.chat_postMessage.assert_called_once()
+        msg = client.chat_postMessage.call_args[1]["text"]
+        assert "Failed to resolve the selected captain" in msg

--- a/src/firetower/slack_app/tests/handlers/test_resolved.py
+++ b/src/firetower/slack_app/tests/handlers/test_resolved.py
@@ -20,8 +20,8 @@ def _make_resolved_view(
     impact_summary="Updated impact",
     impact_type_tags=("Degraded Service",),
     service_tier="T1",
-    affected_service_tags=(),
-    affected_region_tags=(),
+    affected_service_tags=("api-server",),
+    affected_region_tags=("us-east-1",),
 ):
     def _options(values):
         return [{"value": v} for v in values]
@@ -101,10 +101,9 @@ class TestResolvedModal:
         assert "affected_service_block" in block_ids
         assert "affected_region_block" in block_ids
 
-    def test_required_vs_optional_blocks(self, incident):
+    def test_all_blocks_required(self, incident):
         modal = _build_resolved_modal(incident, CHANNEL_ID)
         by_id = {b["block_id"]: b for b in modal["blocks"] if "block_id" in b}
-        # Required: not marked optional
         for required in (
             "captain_block",
             "severity_block",
@@ -113,11 +112,10 @@ class TestResolvedModal:
             "impact_summary_block",
             "impact_type_block",
             "service_tier_block",
+            "affected_service_block",
+            "affected_region_block",
         ):
             assert by_id[required].get("optional", False) is False
-        # Optional fields
-        assert by_id["affected_service_block"]["optional"] is True
-        assert by_id["affected_region_block"]["optional"] is True
 
     def test_contains_context_message(self, incident):
         modal = _build_resolved_modal(incident, CHANNEL_ID)
@@ -170,6 +168,16 @@ def impact_type_tag(db):
     return Tag.objects.create(name="Degraded Service", type=TagType.IMPACT_TYPE)
 
 
+@pytest.fixture
+def affected_service_tag(db):
+    return Tag.objects.create(name="api-server", type=TagType.AFFECTED_SERVICE)
+
+
+@pytest.fixture
+def affected_region_tag(db):
+    return Tag.objects.create(name="us-east-1", type=TagType.AFFECTED_REGION)
+
+
 @pytest.mark.django_db
 class TestResolvedSubmission:
     @patch("firetower.incidents.serializers.on_status_changed")
@@ -187,6 +195,8 @@ class TestResolvedSubmission:
         user,
         incident,
         impact_type_tag,
+        affected_service_tag,
+        affected_region_tag,
     ):
         mock_get_user.return_value = user
         ack = MagicMock()
@@ -214,6 +224,8 @@ class TestResolvedSubmission:
         user,
         incident,
         impact_type_tag,
+        affected_service_tag,
+        affected_region_tag,
     ):
         mock_get_user.return_value = user
         ack = MagicMock()
@@ -238,6 +250,8 @@ class TestResolvedSubmission:
         user,
         incident,
         impact_type_tag,
+        affected_service_tag,
+        affected_region_tag,
     ):
         mock_get_user.return_value = user
         ack = MagicMock()
@@ -318,6 +332,32 @@ class TestResolvedSubmission:
         call_kwargs = ack.call_args[1]
         assert call_kwargs["response_action"] == "errors"
         assert "service_tier_block" in call_kwargs["errors"]
+
+    def test_missing_affected_service_returns_error(self, incident):
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_CAPTAIN"}}
+        view = _make_resolved_view(affected_service_tags=())
+
+        handle_resolved_submission(ack, body, view, client)
+
+        ack.assert_called_once()
+        call_kwargs = ack.call_args[1]
+        assert call_kwargs["response_action"] == "errors"
+        assert "affected_service_block" in call_kwargs["errors"]
+
+    def test_missing_affected_region_returns_error(self, incident):
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_CAPTAIN"}}
+        view = _make_resolved_view(affected_region_tags=())
+
+        handle_resolved_submission(ack, body, view, client)
+
+        ack.assert_called_once()
+        call_kwargs = ack.call_args[1]
+        assert call_kwargs["response_action"] == "errors"
+        assert "affected_region_block" in call_kwargs["errors"]
 
     @patch("firetower.slack_app.handlers.resolved.get_or_create_user_from_slack_id")
     def test_captain_resolution_failure(self, mock_get_user, incident):

--- a/src/firetower/slack_app/tests/handlers/test_resolved.py
+++ b/src/firetower/slack_app/tests/handlers/test_resolved.py
@@ -12,28 +12,50 @@ from firetower.slack_app.handlers.resolved import (
 from .conftest import CHANNEL_ID
 
 
-def _make_resolved_view(severity="P1", captain="U_CAPTAIN", title="Test Incident"):
-    return {
-        "private_metadata": CHANNEL_ID,
-        "state": {
-            "values": {
-                "severity_block": {
-                    "severity_select": {"selected_option": {"value": severity}}
-                },
-                "captain_block": {"captain_select": {"selected_user": captain}},
-                "title_block": {"title": {"value": title}},
-                "description_block": {"description": {"value": "Updated desc"}},
-                "impact_summary_block": {"impact_summary": {"value": "Updated impact"}},
-                "impact_type_block": {"impact_type_tags": {"selected_options": []}},
-                "affected_service_block": {
-                    "affected_service_tags": {"selected_options": []}
-                },
-                "affected_region_block": {
-                    "affected_region_tags": {"selected_options": []}
-                },
+def _make_resolved_view(
+    severity="P1",
+    captain="U_CAPTAIN",
+    title="Test Incident",
+    description="Updated desc",
+    impact_summary="Updated impact",
+    impact_type_tags=("Degraded Service",),
+    service_tier="T1",
+    affected_service_tags=(),
+    affected_region_tags=(),
+):
+    def _options(values):
+        return [{"value": v} for v in values]
+
+    state_values: dict = {
+        "captain_block": {"captain_select": {"selected_user": captain}},
+        "title_block": {"title": {"value": title}},
+        "description_block": {"description": {"value": description}},
+        "impact_summary_block": {"impact_summary": {"value": impact_summary}},
+        "impact_type_block": {
+            "impact_type_tags": {"selected_options": _options(impact_type_tags)}
+        },
+        "affected_service_block": {
+            "affected_service_tags": {
+                "selected_options": _options(affected_service_tags)
             }
         },
+        "affected_region_block": {
+            "affected_region_tags": {"selected_options": _options(affected_region_tags)}
+        },
     }
+    if severity is not None:
+        state_values["severity_block"] = {
+            "severity_select": {"selected_option": {"value": severity}}
+        }
+    else:
+        state_values["severity_block"] = {"severity_select": {}}
+    if service_tier is not None:
+        state_values["service_tier_block"] = {
+            "service_tier_select": {"selected_option": {"value": service_tier}}
+        }
+    else:
+        state_values["service_tier_block"] = {"service_tier_select": {}}
+    return {"private_metadata": CHANNEL_ID, "state": {"values": state_values}}
 
 
 @pytest.mark.django_db
@@ -75,8 +97,27 @@ class TestResolvedModal:
         assert "description_block" in block_ids
         assert "impact_summary_block" in block_ids
         assert "impact_type_block" in block_ids
+        assert "service_tier_block" in block_ids
         assert "affected_service_block" in block_ids
         assert "affected_region_block" in block_ids
+
+    def test_required_vs_optional_blocks(self, incident):
+        modal = _build_resolved_modal(incident, CHANNEL_ID)
+        by_id = {b["block_id"]: b for b in modal["blocks"] if "block_id" in b}
+        # Required: not marked optional
+        for required in (
+            "captain_block",
+            "severity_block",
+            "title_block",
+            "description_block",
+            "impact_summary_block",
+            "impact_type_block",
+            "service_tier_block",
+        ):
+            assert by_id[required].get("optional", False) is False
+        # Optional fields
+        assert by_id["affected_service_block"]["optional"] is True
+        assert by_id["affected_region_block"]["optional"] is True
 
     def test_contains_context_message(self, incident):
         modal = _build_resolved_modal(incident, CHANNEL_ID)
@@ -124,6 +165,11 @@ class TestResolvedModal:
         assert block["element"]["initial_options"][0]["value"] == "api-server"
 
 
+@pytest.fixture
+def impact_type_tag(db):
+    return Tag.objects.create(name="Degraded Service", type=TagType.IMPACT_TYPE)
+
+
 @pytest.mark.django_db
 class TestResolvedSubmission:
     @patch("firetower.incidents.serializers.on_status_changed")
@@ -140,6 +186,7 @@ class TestResolvedSubmission:
         mock_status_hook,
         user,
         incident,
+        impact_type_tag,
     ):
         mock_get_user.return_value = user
         ack = MagicMock()
@@ -160,7 +207,13 @@ class TestResolvedSubmission:
     @patch("firetower.incidents.serializers.on_title_changed")
     @patch("firetower.slack_app.handlers.resolved.get_or_create_user_from_slack_id")
     def test_p4_goes_to_done(
-        self, mock_get_user, mock_title_hook, mock_status_hook, user, incident
+        self,
+        mock_get_user,
+        mock_title_hook,
+        mock_status_hook,
+        user,
+        incident,
+        impact_type_tag,
     ):
         mock_get_user.return_value = user
         ack = MagicMock()
@@ -178,7 +231,13 @@ class TestResolvedSubmission:
     @patch("firetower.incidents.serializers.on_title_changed")
     @patch("firetower.slack_app.handlers.resolved.get_or_create_user_from_slack_id")
     def test_saves_metadata_fields(
-        self, mock_get_user, mock_title_hook, mock_status_hook, user, incident
+        self,
+        mock_get_user,
+        mock_title_hook,
+        mock_status_hook,
+        user,
+        incident,
+        impact_type_tag,
     ):
         mock_get_user.return_value = user
         ack = MagicMock()
@@ -193,6 +252,7 @@ class TestResolvedSubmission:
         assert incident.title == "Updated Title"
         assert incident.description == "Updated desc"
         assert incident.impact_summary == "Updated impact"
+        assert incident.service_tier == "T1"
 
     def test_missing_captain_returns_error(self, incident):
         ack = MagicMock()
@@ -205,4 +265,56 @@ class TestResolvedSubmission:
         ack.assert_called_once()
         call_kwargs = ack.call_args[1]
         assert call_kwargs["response_action"] == "errors"
-        assert "captain" in str(call_kwargs["errors"]).lower()
+        assert "captain_block" in call_kwargs["errors"]
+
+    def test_missing_description_returns_error(self, incident):
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_CAPTAIN"}}
+        view = _make_resolved_view(description="")
+
+        handle_resolved_submission(ack, body, view, client)
+
+        ack.assert_called_once()
+        call_kwargs = ack.call_args[1]
+        assert call_kwargs["response_action"] == "errors"
+        assert "description_block" in call_kwargs["errors"]
+
+    def test_missing_impact_summary_returns_error(self, incident):
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_CAPTAIN"}}
+        view = _make_resolved_view(impact_summary="")
+
+        handle_resolved_submission(ack, body, view, client)
+
+        ack.assert_called_once()
+        call_kwargs = ack.call_args[1]
+        assert call_kwargs["response_action"] == "errors"
+        assert "impact_summary_block" in call_kwargs["errors"]
+
+    def test_missing_impact_type_returns_error(self, incident):
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_CAPTAIN"}}
+        view = _make_resolved_view(impact_type_tags=())
+
+        handle_resolved_submission(ack, body, view, client)
+
+        ack.assert_called_once()
+        call_kwargs = ack.call_args[1]
+        assert call_kwargs["response_action"] == "errors"
+        assert "impact_type_block" in call_kwargs["errors"]
+
+    def test_missing_service_tier_returns_error(self, incident):
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_CAPTAIN"}}
+        view = _make_resolved_view(service_tier=None)
+
+        handle_resolved_submission(ack, body, view, client)
+
+        ack.assert_called_once()
+        call_kwargs = ack.call_args[1]
+        assert call_kwargs["response_action"] == "errors"
+        assert "service_tier_block" in call_kwargs["errors"]


### PR DESCRIPTION
Implements RELENG-755. Reshapes the /inc new modal to ask only what's known at incident open, and moves the lifecycle metadata capture to /inc mitigated and /inc resolved where the info is actually known. The mitigated modal previously asked for free-text impact/todo and threw both away; now it persists structured fields via the same serializer as resolved. Linear: https://linear.app/getsentry/issue/RELENG-755

/inc new fields:
- Incident Captain (required, defaults to invoking user)
- Severity (required, defaults to P3)
- Title (required)
- Impact Summary (optional)
- Description (optional)
- Private toggle

/inc mitigated and /inc resolved fields (all required except where noted):
- Incident Captain
- Severity
- Title
- Impact Summary
- Description
- Type of impact
- Service Tier (with optional link to Service Registry below, if SERVICE_REGISTRY_URL is configured)
- Affected Services
- Affected Regions
- Context link below points to the incident page so missing service/region tags can be added there

Follow-ups (separate PRs):
- RELENG-767: /inc cancel slack command for noisy-alert incidents that shouldn't go through /inc resolved.
- RELENG-768: inline tag creation in the affected service/region pickers (+ Create option in autocomplete). Will replace the incident-page hint context block once landed.