### PR TITLE
fix(avatar): Update avatar URL on action as well to account for users changing it

### DIFF
--- a/src/firetower/auth/services.py
+++ b/src/firetower/auth/services.py
@@ -192,7 +192,7 @@ def get_or_create_user_from_email(email: str) -> User | None:
 
     user = _get_or_create_user_by_email(email, first_name, last_name)
 
-    if avatar_url and not user.userprofile.avatar_url:
+    if avatar_url and user.userprofile.avatar_url != avatar_url:
         try:
             URLValidator(schemes=["https"])(avatar_url)
             user.userprofile.avatar_url = avatar_url
@@ -255,7 +255,7 @@ def get_or_create_user_from_slack_id(slack_user_id: str) -> User | None:
 
     user = _get_or_create_user_by_email(email, first_name, last_name)
 
-    if avatar_url and not user.userprofile.avatar_url:
+    if avatar_url and user.userprofile.avatar_url != avatar_url:
         try:
             URLValidator(schemes=["https"])(avatar_url)
             user.userprofile.avatar_url = avatar_url


### PR DESCRIPTION
Hi SRE folks I noticed my avatar was broken on firetower so I took a stab at fixing it. Very low priority, and feel free to close/comment/etc.

---

When a user changes their profile picture (avatar), slack updates the CDN url. The only way to update the url after the fact is via the admin sync slack action. This means after an avatar change, the user's picture will appear broken until fixed:
<img width="227" height="145" alt="image" src="https://github.com/user-attachments/assets/29b9e7ef-c555-4ea9-8f08-8a655d2650f7" />

This PR updates the `avatar_url` when it detects the current and old mismatch. This happens when`get_or_create_user_[...]` is run, typically during an incident lifecycle event (creating, updating, etc.)