### PR TITLE
feat(incidents): Invite new IC to status channel on captain reassignment

### DIFF
--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -244,6 +244,15 @@ def _get_channel_id(incident: Incident) -> str | None:
     return _slack_service.parse_channel_id_from_url(slack_link.url)
 
 
+def _get_status_channel_id(incident: Incident) -> str | None:
+    slack_link = incident.external_links.filter(
+        type=ExternalLinkType.SLACK_STATUS
+    ).first()
+    if not slack_link:
+        return None
+    return _slack_service.parse_channel_id_from_url(slack_link.url)
+
+
 def _invite_user_to_channel(
     channel_id: str, user: User, slack_user_id: str | None = None
 ) -> None:
@@ -1374,5 +1383,12 @@ def on_captain_changed(incident: Incident) -> None:
                 f"Incident captain updated to {captain_ref}\n<{incident_url}|View in Firetower>",
             )
             _invite_user_to_channel(channel_id, incident.captain)
+
+            if incident.severity in HIGH_SEVERITIES:
+                status_channel_id = _get_status_channel_id(incident)
+                if status_channel_id:
+                    _invite_user_to_channel(
+                        status_channel_id, incident.captain, slack_user_id=slack_id
+                    )
     except Exception:
         logger.exception(f"Error in on_captain_changed for incident {incident.id}")

--- a/src/firetower/incidents/tests/test_hooks.py
+++ b/src/firetower/incidents/tests/test_hooks.py
@@ -694,6 +694,82 @@ class TestOnCaptainChanged:
         mock_slack.post_message.assert_not_called()
 
     @patch("firetower.incidents.hooks._slack_service")
+    def test_invites_captain_to_status_channel_for_high_severity(self, mock_slack):
+        mock_slack.parse_channel_id_from_url.side_effect = (
+            lambda url: "C12345" if "C12345" in url else "CSTATUS"
+        )
+
+        captain = User.objects.create_user(
+            username="newcaptain@example.com",
+            email="newcaptain@example.com",
+            first_name="New",
+            last_name="Captain",
+        )
+        ExternalProfile.objects.create(
+            user=captain,
+            type=ExternalProfileType.SLACK,
+            external_id="U_NEW",
+        )
+
+        incident = Incident.objects.create(
+            title="Test",
+            severity=IncidentSeverity.P1,
+            captain=captain,
+        )
+        ExternalLink.objects.create(
+            incident=incident,
+            type=ExternalLinkType.SLACK,
+            url="https://slack.com/archives/C12345",
+        )
+        ExternalLink.objects.create(
+            incident=incident,
+            type=ExternalLinkType.SLACK_STATUS,
+            url="https://slack.com/archives/CSTATUS",
+        )
+
+        on_captain_changed(incident)
+
+        assert mock_slack.invite_to_channel.call_count == 2
+        mock_slack.invite_to_channel.assert_any_call("C12345", ["U_NEW"])
+        mock_slack.invite_to_channel.assert_any_call("CSTATUS", ["U_NEW"])
+
+    @patch("firetower.incidents.hooks._slack_service")
+    def test_skips_status_channel_invite_for_low_severity(self, mock_slack):
+        mock_slack.parse_channel_id_from_url.return_value = "C12345"
+
+        captain = User.objects.create_user(
+            username="newcaptain@example.com",
+            email="newcaptain@example.com",
+            first_name="New",
+            last_name="Captain",
+        )
+        ExternalProfile.objects.create(
+            user=captain,
+            type=ExternalProfileType.SLACK,
+            external_id="U_NEW",
+        )
+
+        incident = Incident.objects.create(
+            title="Test",
+            severity=IncidentSeverity.P3,
+            captain=captain,
+        )
+        ExternalLink.objects.create(
+            incident=incident,
+            type=ExternalLinkType.SLACK,
+            url="https://slack.com/archives/C12345",
+        )
+        ExternalLink.objects.create(
+            incident=incident,
+            type=ExternalLinkType.SLACK_STATUS,
+            url="https://slack.com/archives/CSTATUS",
+        )
+
+        on_captain_changed(incident)
+
+        mock_slack.invite_to_channel.assert_called_once_with("C12345", ["U_NEW"])
+
+    @patch("firetower.incidents.hooks._slack_service")
     def test_noop_without_slack_link(self, mock_slack):
         incident = Incident.objects.create(
             title="Test",


### PR DESCRIPTION
When the IC for a P0/P1 incident is reassigned, the new captain wasn't guarenteed to be in the status channel. This adds an invite to the `-status` channel, so the new IC has visibility into the status update stream without needing to manually join.

Adds a `_get_status_channel_id()` helper (mirrors `_get_channel_id()` but queries `SLACK_STATUS` links) and wires it into `on_captain_changed()` behind the existing `HIGH_SEVERITIES` gate.

Two new tests cover the happy path (P1 with status channel) and the no-op path (P3 skips status channel invite).


Agent transcript: https://claudescope.sentry.dev/share/q-eMbz4E9FaBgK7mo6-FbwPmJSjzeIGTj5DlMxANN4w