### PR TITLE
ref: Incident list and detail UI polish

### DIFF
--- a/frontend/src/routes/$incidentId/components/ActionItemsList.tsx
+++ b/frontend/src/routes/$incidentId/components/ActionItemsList.tsx
@@ -31,8 +31,8 @@ function ActionItemCard({item}: {item: ActionItem}) {
       target="_blank"
       rel="noopener noreferrer"
       className={cn(
-        'flex items-center gap-space-lg rounded-radius-md border-l-4 p-space-lg no-underline transition-all duration-200',
-        'hover:-translate-y-0.5 hover:shadow-md',
+        'flex items-center gap-space-lg rounded-radius-md border-l-4 p-space-lg no-underline transition-colors duration-200',
+        'hover:bg-background-transparent-neutral-muted',
         BORDER_CLASS[item.status]
       )}
     >

--- a/frontend/src/routes/$incidentId/components/SlackLink.tsx
+++ b/frontend/src/routes/$incidentId/components/SlackLink.tsx
@@ -8,7 +8,7 @@ interface SlackLinkProps {
 export function SlackLink({slackUrl, incidentId}: SlackLinkProps) {
   return (
     <a href={slackUrl} target="_blank" rel="noopener noreferrer" className="block">
-      <Card className="cursor-pointer transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg">
+      <Card className="hover:bg-background-transparent-neutral-muted cursor-pointer transition-colors duration-200">
         <div className="flex items-center gap-3">
           <img src="/slack-icon.svg" alt="Slack" className="h-7 w-7" />
           <span className="text-content-headings text-base font-semibold">

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -10,7 +10,7 @@ const RootLayout = () => (
   <TooltipProvider delayDuration={200}>
     <div className="bg-background-tertiary text-content-primary leading-default min-h-screen">
       <Header />
-      <main className="px-space-md py-space-xl md:px-space-xl mx-auto max-w-6xl">
+      <main className="px-space-md py-space-lg md:px-space-lg mx-auto max-w-6xl">
         <Outlet />
       </main>
       <TanStackRouterDevtools />

--- a/frontend/src/routes/components/Header.tsx
+++ b/frontend/src/routes/components/Header.tsx
@@ -51,8 +51,8 @@ export const Header = () => {
                   className={cn(
                     'rounded-radius-sm px-space-lg py-space-sm text-size-sm font-medium transition-colors',
                     isActivePage(page.to)
-                      ? 'bg-background-secondary text-content-headings'
-                      : 'text-content-secondary hover:text-content-headings'
+                      ? 'bg-background-secondary hover:bg-background-transparent-neutral-muted text-content-headings'
+                      : 'text-content-secondary hover:bg-background-transparent-neutral-muted hover:text-content-headings'
                   )}
                 >
                   {page.label}

--- a/frontend/src/routes/components/IncidentCard.tsx
+++ b/frontend/src/routes/components/IncidentCard.tsx
@@ -23,13 +23,13 @@ export const IncidentCard = ({incident}: IncidentCardProps) => {
       >
         <div className="gap-space-xl flex justify-between">
           <div className="min-w-0 flex-1">
-            <span className="text-size-lg text-content-secondary mb-space-sm gap-space-xs flex select-text items-center font-regular leading-none">
-              {incident.is_private && <span aria-label="Private incident">🔒</span>}
-              {incident.id}
-            </span>
             <h3 className="text-size-xl text-content-headings select-text font-semibold">
               {incident.title}
             </h3>
+            <span className="text-size-lg text-content-secondary mt-space-sm gap-space-xs flex select-text items-center font-regular leading-none">
+              {incident.is_private && <span aria-label="Private incident">🔒</span>}
+              {incident.id}
+            </span>
             <div className="gap-space-md mt-space-md flex">
               <Pill variant={incident.severity}>{incident.severity}</Pill>
               <Pill variant={incident.status}>{incident.status}</Pill>

--- a/frontend/src/routes/components/IncidentCard.tsx
+++ b/frontend/src/routes/components/IncidentCard.tsx
@@ -16,17 +16,22 @@ export const IncidentCard = ({incident}: IncidentCardProps) => {
       params={{incidentId: incident.id}}
       className="block no-underline"
       preload={'intent'}
+      onClick={e => {
+        if (window.getSelection()?.toString()) {
+          e.preventDefault();
+        }
+      }}
     >
       <div
-        className="bg-background-primary rounded-radius-lg p-space-xl cursor-pointer shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md"
+        className="bg-background-primary hover:bg-background-transparent-neutral-muted rounded-radius-lg p-space-xl cursor-pointer shadow-sm transition-colors duration-200"
         data-testid={`incident-card-${incident.id}`}
       >
         <div className="gap-space-xl mb-space-md flex flex-wrap items-center md:flex-nowrap">
-          <span className="text-size-md text-content-secondary font-regular gap-space-xs flex items-center leading-none">
+          <span className="text-size-lg text-content-secondary gap-space-xs flex select-text items-center font-regular leading-none">
             {incident.is_private && <span aria-label="Private incident">🔒</span>}
             {incident.id}
           </span>
-          <div className="text-size-sm text-content-secondary ml-auto text-right md:order-last">
+          <div className="text-size-sm text-content-secondary ml-auto select-none text-right md:order-last">
             <time dateTime={incident.created_at}>
               {createdAt.toLocaleDateString('en-US', {
                 month: 'short',
@@ -44,7 +49,7 @@ export const IncidentCard = ({incident}: IncidentCardProps) => {
               })}
             </p>
           </div>
-          <h3 className="text-size-xl text-content-headings w-full font-semibold md:w-auto md:flex-1">
+          <h3 className="text-size-xl text-content-headings w-full select-text font-semibold md:w-auto md:flex-1">
             {incident.title}
           </h3>
         </div>
@@ -56,15 +61,17 @@ export const IncidentCard = ({incident}: IncidentCardProps) => {
             {incident.is_private && <Pill variant="private">Private</Pill>}
           </div>
           {incident.captain && (
-            <p className="text-content-secondary text-size-sm">
+            <p className="text-content-secondary text-size-sm select-none">
               Captain: {incident.captain}
             </p>
           )}
         </div>
 
-        <p className="text-content-secondary text-size-sm leading-comfortable">
-          {incident.description}
-        </p>
+        {incident.description ? (
+          <p className="text-content-secondary text-size-sm leading-comfortable line-clamp-1 select-none">
+            {incident.description}
+          </p>
+        ) : null}
       </div>
     </Link>
   );

--- a/frontend/src/routes/components/IncidentCard.tsx
+++ b/frontend/src/routes/components/IncidentCard.tsx
@@ -21,12 +21,27 @@ export const IncidentCard = ({incident}: IncidentCardProps) => {
         className="bg-background-primary hover:bg-background-transparent-neutral-muted rounded-radius-lg p-space-xl cursor-pointer shadow-sm transition-colors duration-200"
         data-testid={`incident-card-${incident.id}`}
       >
-        <div className="gap-space-xl mb-space-md flex flex-wrap items-center md:flex-nowrap">
-          <span className="text-size-lg text-content-secondary gap-space-xs flex select-text items-center font-regular leading-none">
-            {incident.is_private && <span aria-label="Private incident">🔒</span>}
-            {incident.id}
-          </span>
-          <div className="text-size-sm text-content-secondary ml-auto select-none text-right md:order-last">
+        <div className="gap-space-xl flex justify-between">
+          <div className="min-w-0 flex-1">
+            <span className="text-size-lg text-content-secondary mb-space-sm gap-space-xs flex select-text items-center font-regular leading-none">
+              {incident.is_private && <span aria-label="Private incident">🔒</span>}
+              {incident.id}
+            </span>
+            <h3 className="text-size-xl text-content-headings select-text font-semibold">
+              {incident.title}
+            </h3>
+            <div className="gap-space-md mt-space-md flex">
+              <Pill variant={incident.severity}>{incident.severity}</Pill>
+              <Pill variant={incident.status}>{incident.status}</Pill>
+              {incident.is_private && <Pill variant="private">Private</Pill>}
+            </div>
+            {incident.description ? (
+              <p className="text-content-secondary text-size-sm leading-comfortable line-clamp-1 mt-space-md select-none">
+                {incident.description}
+              </p>
+            ) : null}
+          </div>
+          <div className="text-size-sm text-content-secondary shrink-0 select-none text-right">
             <time dateTime={incident.created_at}>
               {createdAt.toLocaleDateString('en-US', {
                 month: 'short',
@@ -43,30 +58,11 @@ export const IncidentCard = ({incident}: IncidentCardProps) => {
                 timeZoneName: 'short',
               })}
             </p>
+            {incident.captain && (
+              <p className="mt-space-xs">Captain: {incident.captain}</p>
+            )}
           </div>
-          <h3 className="text-size-xl text-content-headings w-full select-text font-semibold md:w-auto md:flex-1">
-            {incident.title}
-          </h3>
         </div>
-
-        <div className="mb-space-lg flex items-center justify-between">
-          <div className="gap-space-md flex">
-            <Pill variant={incident.severity}>{incident.severity}</Pill>
-            <Pill variant={incident.status}>{incident.status}</Pill>
-            {incident.is_private && <Pill variant="private">Private</Pill>}
-          </div>
-          {incident.captain && (
-            <p className="text-content-secondary text-size-sm select-none">
-              Captain: {incident.captain}
-            </p>
-          )}
-        </div>
-
-        {incident.description ? (
-          <p className="text-content-secondary text-size-sm leading-comfortable line-clamp-1 select-none">
-            {incident.description}
-          </p>
-        ) : null}
       </div>
     </Link>
   );

--- a/frontend/src/routes/components/IncidentCard.tsx
+++ b/frontend/src/routes/components/IncidentCard.tsx
@@ -16,11 +16,6 @@ export const IncidentCard = ({incident}: IncidentCardProps) => {
       params={{incidentId: incident.id}}
       className="block no-underline"
       preload={'intent'}
-      onClick={e => {
-        if (window.getSelection()?.toString()) {
-          e.preventDefault();
-        }
-      }}
     >
       <div
         className="bg-background-primary hover:bg-background-transparent-neutral-muted rounded-radius-lg p-space-xl cursor-pointer shadow-sm transition-colors duration-200"

--- a/frontend/src/routes/components/StatusFilter.tsx
+++ b/frontend/src/routes/components/StatusFilter.tsx
@@ -22,9 +22,10 @@ function FilterLink({statuses, label, isActive, testId}: FilterLinkProps) {
       className={cn(
         'rounded-radius-sm px-space-lg py-space-sm text-size-sm font-medium transition-colors',
         {
-          'bg-background-primary dark:bg-background-transparent-neutral-muted text-content-headings shadow-sm':
+          'bg-background-primary dark:bg-background-transparent-neutral-muted hover:bg-background-transparent-neutral-muted text-content-headings shadow-sm':
             isActive,
-          'text-content-secondary hover:text-black dark:hover:text-white': !isActive,
+          'text-content-secondary hover:bg-background-transparent-neutral-muted hover:text-black dark:hover:text-white':
+            !isActive,
         }
       )}
     >

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -44,13 +44,12 @@ function IncidentsLayout({children}: {children: React.ReactNode}) {
   const [open, setOpen] = useState(activeCount > 0);
 
   return (
-    <div className="gap-space-sm flex flex-col">
+    <div className="gap-space-lg flex flex-col">
       <div className="flex items-center justify-between">
         <StatusFilter />
         <FilterTrigger open={open} onToggle={() => setOpen(prev => !prev)} />
       </div>
       {open ? <FilterPanel /> : null}
-      <hr className="border-secondary" />
       {children}
     </div>
   );

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -53,6 +53,10 @@ body {
   font-family: 'Rubik', sans-serif;
 }
 
+html {
+  scrollbar-gutter: stable;
+}
+
 input[type='number']::-webkit-inner-spin-button,
 input[type='number']::-webkit-outer-spin-button {
   -webkit-appearance: none;


### PR DESCRIPTION
A batch of small incident UI polish items from #team-sre feedback.

- Reserve the scrollbar gutter so the incident detail page no longer shifts horizontally when content height changes.
- Incident list cards: larger INC ID, one-line (clamped) description, and selectable INC ID and title.
- Replace the card lift hover with a consistent background-tone hover, and apply that same hover to action items, the status filter tabs, header nav, and the Slack link block.