### PR TITLE
feat: Add /inc cancel slack command

### DIFF
--- a/src/firetower/slack_app/bolt.py
+++ b/src/firetower/slack_app/bolt.py
@@ -12,6 +12,10 @@ from firetower.slack_app.handlers.backfill_incident import (
     handle_backfill_command,
     handle_backfill_submission,
 )
+from firetower.slack_app.handlers.cancel import (
+    handle_cancel_command,
+    handle_cancel_submission,
+)
 from firetower.slack_app.handlers.captain import (
     handle_captain_command,
     handle_captain_submission,
@@ -61,6 +65,7 @@ KNOWN_SUBCOMMANDS = {
     "resolved",
     "fixed",
     "reopen",
+    "cancel",
     "list",
     "ls",
     "severity",
@@ -144,6 +149,8 @@ def handle_command(
             handle_resolved_command(ack, body, command, respond)
         elif subcommand == "reopen":
             handle_reopen_command(ack, body, command, respond)
+        elif subcommand == "cancel":
+            handle_cancel_command(ack, body, command, respond)
         elif subcommand in ("list", "ls"):
             handle_list_command(ack, body, command, respond, client=client)
         elif subcommand in ("severity", "sev", "setseverity"):
@@ -219,6 +226,9 @@ def _register_views(app: App) -> None:
     )
     app.view("mitigated_incident_modal")(
         _with_metrics("mitigated_incident_modal")(handle_mitigated_submission)
+    )
+    app.view("cancel_incident_modal")(
+        _with_metrics("cancel_incident_modal")(handle_cancel_submission)
     )
     app.view("resolved_incident_modal")(
         _with_metrics("resolved_incident_modal")(handle_resolved_submission)

--- a/src/firetower/slack_app/handlers/cancel.py
+++ b/src/firetower/slack_app/handlers/cancel.py
@@ -89,6 +89,12 @@ def handle_cancel_submission(ack: Any, body: dict, view: dict, client: Any) -> N
         logger.error("Cancel submission: no incident for channel %s", channel_id)
         return
 
+    if incident.status == IncidentStatus.CANCELED:
+        logger.info(
+            "Cancel submission: %s already Canceled, no-op", incident.incident_number
+        )
+        return
+
     serializer = IncidentWriteSerializer(
         instance=incident, data={"status": IncidentStatus.CANCELED}, partial=True
     )

--- a/src/firetower/slack_app/handlers/cancel.py
+++ b/src/firetower/slack_app/handlers/cancel.py
@@ -35,7 +35,7 @@ def _build_cancel_modal(incident_number: str, channel_id: str) -> dict:
                     "multiline": True,
                     "placeholder": {
                         "type": "plain_text",
-                        "text": "Why is this incident being canceled?",
+                        "text": "e.g. Duplicate, false alarm",
                     },
                 },
                 "label": {"type": "plain_text", "text": "Reason"},

--- a/src/firetower/slack_app/handlers/cancel.py
+++ b/src/firetower/slack_app/handlers/cancel.py
@@ -1,0 +1,114 @@
+import logging
+from typing import Any
+
+from django.conf import settings
+
+from firetower.incidents.models import IncidentStatus
+from firetower.incidents.serializers import IncidentWriteSerializer
+from firetower.slack_app.handlers.utils import get_incident_from_channel
+
+logger = logging.getLogger(__name__)
+
+
+def _build_cancel_modal(channel_id: str) -> dict:
+    return {
+        "type": "modal",
+        "callback_id": "cancel_incident_modal",
+        "private_metadata": channel_id,
+        "title": {"type": "plain_text", "text": "Cancel incident"},
+        "submit": {"type": "plain_text", "text": "Cancel incident"},
+        "close": {"type": "plain_text", "text": "Back"},
+        "blocks": [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "Cancel this incident. Please provide a reason.",
+                },
+            },
+            {
+                "type": "input",
+                "block_id": "reason_block",
+                "element": {
+                    "type": "plain_text_input",
+                    "action_id": "reason",
+                    "multiline": True,
+                    "placeholder": {
+                        "type": "plain_text",
+                        "text": "Why is this incident being canceled?",
+                    },
+                },
+                "label": {"type": "plain_text", "text": "Reason"},
+            },
+        ],
+    }
+
+
+def handle_cancel_command(ack: Any, body: dict, command: dict, respond: Any) -> None:
+    ack()
+    channel_id = body.get("channel_id", "")
+    incident = get_incident_from_channel(channel_id)
+    if not incident:
+        respond("Could not find an incident associated with this channel.")
+        return
+
+    if incident.status == IncidentStatus.CANCELED:
+        respond(f"{incident.incident_number} is already Canceled.")
+        return
+
+    trigger_id = body.get("trigger_id")
+    if not trigger_id:
+        respond("Could not open modal — missing trigger_id.")
+        return
+
+    from firetower.slack_app.bolt import get_bolt_app  # noqa: PLC0415
+
+    get_bolt_app().client.views_open(
+        trigger_id=trigger_id,
+        view=_build_cancel_modal(channel_id),
+    )
+
+
+def handle_cancel_submission(ack: Any, body: dict, view: dict, client: Any) -> None:
+    values = view.get("state", {}).get("values", {})
+    reason = values.get("reason_block", {}).get("reason", {}).get("value", "") or ""
+    reason = reason.strip()
+
+    if not reason:
+        ack(
+            response_action="errors",
+            errors={"reason_block": "A reason is required."},
+        )
+        return
+
+    ack()
+
+    channel_id = view.get("private_metadata", "")
+    incident = get_incident_from_channel(channel_id)
+    if not incident:
+        logger.error("Cancel submission: no incident for channel %s", channel_id)
+        return
+
+    serializer = IncidentWriteSerializer(
+        instance=incident, data={"status": IncidentStatus.CANCELED}, partial=True
+    )
+    if not serializer.is_valid():
+        logger.error("Cancel status update failed: %s", serializer.errors)
+        client.chat_postMessage(
+            channel=channel_id,
+            text=f"Failed to cancel incident: {serializer.errors}",
+        )
+        return
+    serializer.save()
+
+    canceller_id = body.get("user", {}).get("id", "")
+    incident_url = f"{settings.FIRETOWER_BASE_URL}/{incident.incident_number}"
+    client.chat_postMessage(
+        channel=channel_id,
+        text=(
+            f"<{incident_url}|{incident.incident_number}> has been Canceled "
+            f"by <@{canceller_id}>.\n"
+            f"*Reason*:\n"
+            f"```{reason}```"
+        ),
+    )

--- a/src/firetower/slack_app/handlers/cancel.py
+++ b/src/firetower/slack_app/handlers/cancel.py
@@ -10,12 +10,12 @@ from firetower.slack_app.handlers.utils import get_incident_from_channel
 logger = logging.getLogger(__name__)
 
 
-def _build_cancel_modal(channel_id: str) -> dict:
+def _build_cancel_modal(incident_number: str, channel_id: str) -> dict:
     return {
         "type": "modal",
         "callback_id": "cancel_incident_modal",
         "private_metadata": channel_id,
-        "title": {"type": "plain_text", "text": "Cancel incident"},
+        "title": {"type": "plain_text", "text": incident_number},
         "submit": {"type": "plain_text", "text": "Cancel incident"},
         "close": {"type": "plain_text", "text": "Back"},
         "blocks": [
@@ -65,7 +65,7 @@ def handle_cancel_command(ack: Any, body: dict, command: dict, respond: Any) -> 
 
     get_bolt_app().client.views_open(
         trigger_id=trigger_id,
-        view=_build_cancel_modal(channel_id),
+        view=_build_cancel_modal(incident.incident_number, channel_id),
     )
 
 

--- a/src/firetower/slack_app/handlers/help.py
+++ b/src/firetower/slack_app/handlers/help.py
@@ -17,6 +17,7 @@ def handle_help_command(ack: Any, command: dict, respond: Any) -> None:
         f"  `{cmd} mitigated`        - Mark incident as mitigated (alias: `{cmd} mit`)\n"
         f"  `{cmd} resolved`         - Mark incident as resolved (alias: `{cmd} fixed`)\n"
         f"  `{cmd} reopen`           - Reopen an incident\n"
+        f"  `{cmd} cancel`           - Cancel an incident\n"
         f"  `{cmd} status`           - Show current incident status and IC\n"
         f"  `{cmd} severity <P0-P4>` - Change incident severity (alias: `{cmd} sev`)\n"
         f"  `{cmd} statuspage`       - Create or update a statuspage post\n"

--- a/src/firetower/slack_app/tests/handlers/test_cancel.py
+++ b/src/firetower/slack_app/tests/handlers/test_cancel.py
@@ -1,0 +1,131 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from firetower.incidents.models import IncidentStatus
+from firetower.slack_app.handlers.cancel import (
+    handle_cancel_command,
+    handle_cancel_submission,
+)
+
+from .conftest import CHANNEL_ID
+
+
+@pytest.mark.django_db
+class TestCancelCommand:
+    @patch("firetower.slack_app.bolt.get_bolt_app")
+    def test_opens_modal(self, mock_get_bolt_app, incident):
+        ack = MagicMock()
+        body = {"channel_id": CHANNEL_ID, "trigger_id": "T12345"}
+        command = {"command": "/ft"}
+        respond = MagicMock()
+
+        handle_cancel_command(ack, body, command, respond)
+
+        ack.assert_called_once()
+        mock_get_bolt_app.return_value.client.views_open.assert_called_once()
+        view = mock_get_bolt_app.return_value.client.views_open.call_args[1]["view"]
+        assert view["callback_id"] == "cancel_incident_modal"
+        assert view["private_metadata"] == CHANNEL_ID
+
+    @patch("firetower.slack_app.bolt.get_bolt_app")
+    @patch("firetower.incidents.serializers.on_status_changed")
+    @patch("firetower.incidents.serializers.on_title_changed")
+    def test_already_canceled_does_not_open_modal(
+        self, mock_title_hook, mock_status_hook, mock_get_bolt_app, incident
+    ):
+        incident.status = IncidentStatus.CANCELED
+        incident.save()
+
+        ack = MagicMock()
+        body = {"channel_id": CHANNEL_ID, "trigger_id": "T12345"}
+        command = {"command": "/ft"}
+        respond = MagicMock()
+
+        handle_cancel_command(ack, body, command, respond)
+
+        ack.assert_called_once()
+        mock_get_bolt_app.return_value.client.views_open.assert_not_called()
+        assert "already Canceled" in respond.call_args[0][0]
+
+    def test_no_incident_responds_error(self, db):
+        ack = MagicMock()
+        body = {"channel_id": "C_UNKNOWN", "trigger_id": "T12345"}
+        command = {"command": "/ft"}
+        respond = MagicMock()
+
+        handle_cancel_command(ack, body, command, respond)
+
+        ack.assert_called_once()
+        respond.assert_called_once()
+        assert "Could not find" in respond.call_args[0][0]
+
+
+@pytest.mark.django_db
+class TestCancelSubmission:
+    @patch("firetower.incidents.serializers.on_status_changed")
+    @patch("firetower.incidents.serializers.on_title_changed")
+    def test_transitions_to_canceled(self, mock_title_hook, mock_status_hook, incident):
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_CAPTAIN"}}
+        view = {
+            "private_metadata": CHANNEL_ID,
+            "state": {
+                "values": {
+                    "reason_block": {"reason": {"value": "Duplicate of INC-123"}},
+                }
+            },
+        }
+
+        handle_cancel_submission(ack, body, view, client)
+
+        ack.assert_called_once()
+        incident.refresh_from_db()
+        assert incident.status == IncidentStatus.CANCELED
+        client.chat_postMessage.assert_called_once()
+        msg = client.chat_postMessage.call_args[1]["text"]
+        assert "Canceled" in msg
+        assert "Duplicate of INC-123" in msg
+        assert "<@U_CAPTAIN>" in msg
+
+    def test_empty_reason_returns_errors(self, incident):
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_CAPTAIN"}}
+        view = {
+            "private_metadata": CHANNEL_ID,
+            "state": {
+                "values": {
+                    "reason_block": {"reason": {"value": "   "}},
+                }
+            },
+        }
+
+        handle_cancel_submission(ack, body, view, client)
+
+        ack.assert_called_once_with(
+            response_action="errors",
+            errors={"reason_block": "A reason is required."},
+        )
+        incident.refresh_from_db()
+        assert incident.status != IncidentStatus.CANCELED
+        client.chat_postMessage.assert_not_called()
+
+    def test_missing_incident_does_not_crash(self, db):
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_CAPTAIN"}}
+        view = {
+            "private_metadata": "C_NONEXISTENT",
+            "state": {
+                "values": {
+                    "reason_block": {"reason": {"value": "some reason"}},
+                }
+            },
+        }
+
+        handle_cancel_submission(ack, body, view, client)
+
+        ack.assert_called_once()
+        client.chat_postMessage.assert_not_called()

--- a/src/firetower/slack_app/tests/handlers/test_cancel.py
+++ b/src/firetower/slack_app/tests/handlers/test_cancel.py
@@ -112,6 +112,61 @@ class TestCancelSubmission:
         assert incident.status != IncidentStatus.CANCELED
         client.chat_postMessage.assert_not_called()
 
+    @patch("firetower.incidents.serializers.on_status_changed")
+    @patch("firetower.incidents.serializers.on_title_changed")
+    def test_already_canceled_is_noop(
+        self, mock_title_hook, mock_status_hook, incident
+    ):
+        incident.status = IncidentStatus.CANCELED
+        incident.save()
+
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_CAPTAIN"}}
+        view = {
+            "private_metadata": CHANNEL_ID,
+            "state": {
+                "values": {
+                    "reason_block": {"reason": {"value": "Duplicate of INC-123"}},
+                }
+            },
+        }
+
+        handle_cancel_submission(ack, body, view, client)
+
+        ack.assert_called_once()
+        incident.refresh_from_db()
+        assert incident.status == IncidentStatus.CANCELED
+        client.chat_postMessage.assert_not_called()
+
+    @patch("firetower.incidents.serializers.on_status_changed")
+    @patch("firetower.incidents.serializers.on_title_changed")
+    @patch("firetower.slack_app.handlers.cancel.IncidentWriteSerializer")
+    def test_invalid_serializer_posts_failure(
+        self, mock_serializer_cls, mock_title_hook, mock_status_hook, incident
+    ):
+        serializer = mock_serializer_cls.return_value
+        serializer.is_valid.return_value = False
+        serializer.errors = {"status": ["bad"]}
+
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_CAPTAIN"}}
+        view = {
+            "private_metadata": CHANNEL_ID,
+            "state": {
+                "values": {
+                    "reason_block": {"reason": {"value": "some reason"}},
+                }
+            },
+        }
+
+        handle_cancel_submission(ack, body, view, client)
+
+        serializer.save.assert_not_called()
+        client.chat_postMessage.assert_called_once()
+        assert "Failed to cancel" in client.chat_postMessage.call_args[1]["text"]
+
     def test_missing_incident_does_not_crash(self, db):
         ack = MagicMock()
         client = MagicMock()


### PR DESCRIPTION
Adds a `/inc cancel` Slack command so noisy or false-positive incidents can be cancelled without the heavy `/inc resolved` flow (which now requires 9 fields after RELENG-755). It opens a modal with a required reason (placeholder suggests examples like Duplicate / false alarm), sets the incident status to Canceled via the standard IncidentWriteSerializer path, and posts the reason plus who cancelled to the incident channel. Cancelling deliberately does not trigger a postmortem doc or transcript dump (those only fire for Mitigated/Done/Postmortem). No-op if the incident is already Canceled. Reason is posted to the channel only, not persisted (aside from slack transcript) — capturing it on the record can come later with timeline events.
