### PR TITLE
fix(incidents): Prevent Linear parent issue from moving to Done while incident is active

### DIFF
--- a/src/firetower/incidents/services.py
+++ b/src/firetower/incidents/services.py
@@ -17,6 +17,7 @@ from firetower.incidents.models import (
     ActionItemStatus,
     ExternalLinkType,
     Incident,
+    IncidentStatus,
 )
 from firetower.integrations.services import LinearService, SlackService
 
@@ -195,7 +196,10 @@ def _update_parent_issue_status(
         return
 
     statuses = list(incident.action_items.values_list("status", flat=True))
-    all_complete = not statuses or all(s in COMPLETED_STATUSES for s in statuses)
+    incident_done = incident.status == IncidentStatus.DONE
+    all_complete = incident_done and (
+        not statuses or all(s in COMPLETED_STATUSES for s in statuses)
+    )
 
     states = linear_service.get_workflow_states(team_id)
     if not states:

--- a/src/firetower/incidents/tests/test_action_items.py
+++ b/src/firetower/incidents/tests/test_action_items.py
@@ -407,7 +407,7 @@ class TestSyncActionItemsFromLinear:
 
     def test_auto_completes_parent_when_all_done(self, settings):
         settings.LINEAR = {"TEAM_ID": "team-1"}
-        incident = self._make_incident()
+        incident = self._make_incident(status=IncidentStatus.DONE)
 
         children = [
             _make_linear_issue(
@@ -465,7 +465,7 @@ class TestSyncActionItemsFromLinear:
 
     def test_completes_parent_when_no_action_items(self, settings):
         settings.LINEAR = {"TEAM_ID": "team-1"}
-        incident = self._make_incident()
+        incident = self._make_incident(status=IncidentStatus.DONE)
 
         with patch("firetower.incidents.services._get_linear_service") as mock_get:
             mock_service = mock_get.return_value

--- a/src/firetower/incidents/tests/test_services.py
+++ b/src/firetower/incidents/tests/test_services.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from django.contrib.auth.models import User
@@ -7,13 +7,18 @@ from django.utils import timezone
 
 from firetower.auth.models import ExternalProfile, ExternalProfileType
 from firetower.incidents.models import (
+    ActionItem,
+    ActionItemStatus,
     ExternalLink,
     ExternalLinkType,
     Incident,
     IncidentSeverity,
     IncidentStatus,
 )
-from firetower.incidents.services import sync_incident_participants_from_slack
+from firetower.incidents.services import (
+    _update_parent_issue_status,
+    sync_incident_participants_from_slack,
+)
 
 
 @pytest.mark.django_db
@@ -407,3 +412,122 @@ class TestSyncIncidentParticipantsFromSlack:
                 assert incident.participants.count() == 1
                 assert active_user in incident.participants.all()
                 assert inactive_user not in incident.participants.all()
+
+
+@pytest.mark.django_db
+class TestUpdateParentIssueStatus:
+    def _make_incident(self, status=IncidentStatus.ACTIVE):
+        return Incident.objects.create(
+            title="Test Incident",
+            status=status,
+            severity=IncidentSeverity.P1,
+            linear_parent_issue_id="lin-123",
+        )
+
+    def _make_linear_service(self):
+        svc = MagicMock()
+        svc.get_workflow_states.return_value = {
+            "started": "state-started",
+            "completed": "state-completed",
+        }
+        return svc
+
+    @pytest.fixture(autouse=True)
+    def _linear_settings(self, settings):
+        settings.LINEAR = {"TEAM_ID": "team-1", "API_KEY": "key"}
+
+    def test_active_incident_no_action_items_sets_started(self):
+        incident = self._make_incident(status=IncidentStatus.ACTIVE)
+        svc = self._make_linear_service()
+
+        _update_parent_issue_status(incident, svc)
+
+        svc.update_issue.assert_called_once_with("lin-123", state_id="state-started")
+
+    def test_active_incident_all_items_done_sets_started(self):
+        incident = self._make_incident(status=IncidentStatus.ACTIVE)
+        ActionItem.objects.create(
+            incident=incident,
+            linear_issue_id="li-1",
+            linear_identifier="INC-1",
+            title="Item 1",
+            status=ActionItemStatus.DONE,
+            url="https://linear.app/issue/1",
+        )
+        svc = self._make_linear_service()
+
+        _update_parent_issue_status(incident, svc)
+
+        svc.update_issue.assert_called_once_with("lin-123", state_id="state-started")
+
+    def test_done_incident_no_action_items_sets_completed(self):
+        incident = self._make_incident(status=IncidentStatus.DONE)
+        svc = self._make_linear_service()
+
+        _update_parent_issue_status(incident, svc)
+
+        svc.update_issue.assert_called_once_with("lin-123", state_id="state-completed")
+
+    def test_done_incident_all_items_done_sets_completed(self):
+        incident = self._make_incident(status=IncidentStatus.DONE)
+        ActionItem.objects.create(
+            incident=incident,
+            linear_issue_id="li-1",
+            linear_identifier="INC-1",
+            title="Item 1",
+            status=ActionItemStatus.DONE,
+            url="https://linear.app/issue/1",
+        )
+        ActionItem.objects.create(
+            incident=incident,
+            linear_issue_id="li-2",
+            linear_identifier="INC-2",
+            title="Item 2",
+            status=ActionItemStatus.CANCELED,
+            url="https://linear.app/issue/2",
+        )
+        svc = self._make_linear_service()
+
+        _update_parent_issue_status(incident, svc)
+
+        svc.update_issue.assert_called_once_with("lin-123", state_id="state-completed")
+
+    def test_done_incident_incomplete_items_sets_started(self):
+        incident = self._make_incident(status=IncidentStatus.DONE)
+        ActionItem.objects.create(
+            incident=incident,
+            linear_issue_id="li-1",
+            linear_identifier="INC-1",
+            title="Item 1",
+            status=ActionItemStatus.DONE,
+            url="https://linear.app/issue/1",
+        )
+        ActionItem.objects.create(
+            incident=incident,
+            linear_issue_id="li-2",
+            linear_identifier="INC-2",
+            title="Item 2",
+            status=ActionItemStatus.IN_PROGRESS,
+            url="https://linear.app/issue/2",
+        )
+        svc = self._make_linear_service()
+
+        _update_parent_issue_status(incident, svc)
+
+        svc.update_issue.assert_called_once_with("lin-123", state_id="state-started")
+
+    def test_mitigated_incident_all_items_done_sets_started(self):
+        incident = self._make_incident(status=IncidentStatus.MITIGATED)
+        ActionItem.objects.create(
+            incident=incident,
+            linear_issue_id="li-1",
+            linear_identifier="INC-1",
+            title="Item 1",
+            status=ActionItemStatus.DONE,
+            url="https://linear.app/issue/1",
+        )
+        svc = self._make_linear_service()
+
+        _update_parent_issue_status(incident, svc)
+
+        svc.update_issue.assert_called_once_with("lin-123", state_id="state-started")


### PR DESCRIPTION
`_update_parent_issue_status()` treated empty action item lists and fully-completed action items as "all complete", which moved the linked Linear parent issue to Done even when the Firetower incident was still Active or Mitigated (e.g. INC-2205).

The root cause was `not statuses or all(...)` defaulting the empty-list case to "completed". Now the Linear parent issue only transitions to the completed workflow state when the incident itself is in Done status AND all action items are done/canceled.

Added test coverage for `_update_parent_issue_status()` across all relevant incident status / action item combinations.


Agent transcript: https://claudescope.sentry.dev/share/fq2tUdxXLhATOSidaus1ydo593cKp4_GcSDlfGkaU-A