### PR TITLE
feat(slack): Support /inc commands from status channels

### DIFF
--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -6,6 +6,7 @@ import requests
 from django.db import transaction
 
 from firetower.incidents.models import ExternalLink, ExternalLinkType
+from firetower.integrations.services.slack import SlackService
 from firetower.integrations.services.statuspage import (
     COMPONENT_STATUS_OPTIONS,
     DEFAULT_MESSAGES,
@@ -494,14 +495,25 @@ def _process_statuspage_submission(data: dict[str, Any], client: Any) -> bool:
         )
         return False
 
-    try:
-        client.chat_postMessage(channel=channel_id, text=success_message)
-    except Exception:
-        logger.exception(
-            "Failed to post statuspage success message for incident %s (%s)",
-            incident.id,
-            success_message,
-        )
+    notify_channels = {channel_id}
+    slack = SlackService()
+    for link in incident.external_links.filter(
+        type__in=[ExternalLinkType.SLACK, ExternalLinkType.SLACK_STATUS]
+    ):
+        parsed = slack.parse_channel_id_from_url(link.url)
+        if parsed:
+            notify_channels.add(parsed)
+
+    for ch in notify_channels:
+        try:
+            client.chat_postMessage(channel=ch, text=success_message)
+        except Exception:
+            logger.exception(
+                "Failed to post statuspage success message for incident %s to %s (%s)",
+                incident.id,
+                ch,
+                success_message,
+            )
 
     try:
         from firetower.incidents.hooks import (  # noqa: PLC0415

--- a/src/firetower/slack_app/handlers/utils.py
+++ b/src/firetower/slack_app/handlers/utils.py
@@ -13,7 +13,7 @@ _DEFAULT_SEVERITY = IncidentSeverity.P3
 def get_incident_from_channel(channel_id: str) -> Incident | None:
     link = (
         ExternalLink.objects.filter(
-            type=ExternalLinkType.SLACK,
+            type__in=[ExternalLinkType.SLACK, ExternalLinkType.SLACK_STATUS],
             url__endswith=f"/archives/{channel_id}",
         )
         .select_related("incident")

--- a/src/firetower/slack_app/tests/handlers/conftest.py
+++ b/src/firetower/slack_app/tests/handlers/conftest.py
@@ -11,6 +11,7 @@ from firetower.incidents.models import (
 )
 
 CHANNEL_ID = "C_TEST_CHANNEL"
+STATUS_CHANNEL_ID = "C_TEST_STATUS_CHANNEL"
 
 
 @pytest.fixture
@@ -43,5 +44,10 @@ def incident(user):
         incident=inc,
         type=ExternalLinkType.SLACK,
         url="https://slack.com/archives/C_TEST_CHANNEL",
+    )
+    ExternalLink.objects.create(
+        incident=inc,
+        type=ExternalLinkType.SLACK_STATUS,
+        url="https://slack.com/archives/C_TEST_STATUS_CHANNEL",
     )
     return inc

--- a/src/firetower/slack_app/tests/handlers/test_statuspage.py
+++ b/src/firetower/slack_app/tests/handlers/test_statuspage.py
@@ -13,7 +13,7 @@ from firetower.slack_app.handlers.statuspage import (
     handle_statuspage_submission,
 )
 
-from .conftest import CHANNEL_ID
+from .conftest import CHANNEL_ID, STATUS_CHANNEL_ID
 
 
 class TestBuildStatuspageModal:
@@ -357,6 +357,52 @@ class TestStatuspageSubmission:
         assert link.url == "https://test.statuspage.io/incidents/new_sp_123"
 
         assert "created" in client.chat_postMessage.call_args[1]["text"]
+
+    def test_posts_to_both_incident_and_status_channels(self, incident):
+        ack = MagicMock()
+        body = {}
+        view = self._make_view()
+        client = MagicMock()
+
+        with patch(
+            "firetower.slack_app.handlers.statuspage.StatuspageService"
+        ) as MockService:
+            instance = MockService.return_value
+            instance.configured = True
+            instance.create_incident.return_value = {"id": "sp_dual"}
+            instance.get_incident_url.return_value = (
+                "https://test.statuspage.io/incidents/sp_dual"
+            )
+
+            handle_statuspage_submission(ack, body, view, client)
+
+        posted_channels = {
+            call[1]["channel"] for call in client.chat_postMessage.call_args_list
+        }
+        assert posted_channels == {CHANNEL_ID, STATUS_CHANNEL_ID}
+
+    def test_posts_to_both_channels_when_invoked_from_status_channel(self, incident):
+        ack = MagicMock()
+        body = {}
+        view = self._make_view(channel_id=STATUS_CHANNEL_ID)
+        client = MagicMock()
+
+        with patch(
+            "firetower.slack_app.handlers.statuspage.StatuspageService"
+        ) as MockService:
+            instance = MockService.return_value
+            instance.configured = True
+            instance.create_incident.return_value = {"id": "sp_from_status"}
+            instance.get_incident_url.return_value = (
+                "https://test.statuspage.io/incidents/sp_from_status"
+            )
+
+            handle_statuspage_submission(ack, body, view, client)
+
+        posted_channels = {
+            call[1]["channel"] for call in client.chat_postMessage.call_args_list
+        }
+        assert posted_channels == {CHANNEL_ID, STATUS_CHANNEL_ID}
 
     def test_creates_with_components(self, incident):
         ack = MagicMock()

--- a/src/firetower/slack_app/tests/handlers/test_utils.py
+++ b/src/firetower/slack_app/tests/handlers/test_utils.py
@@ -1,11 +1,15 @@
 from firetower.slack_app.handlers.utils import get_incident_from_channel
 
-from .conftest import CHANNEL_ID
+from .conftest import CHANNEL_ID, STATUS_CHANNEL_ID
 
 
 class TestGetIncidentFromChannel:
     def test_returns_incident(self, incident):
         result = get_incident_from_channel(CHANNEL_ID)
+        assert result == incident
+
+    def test_returns_incident_from_status_channel(self, incident):
+        result = get_incident_from_channel(STATUS_CHANNEL_ID)
         assert result == incident
 
     def test_returns_none_for_unknown_channel(self, db):


### PR DESCRIPTION
Widen Slack channel handling so that all \`/inc\` subcommands and statuspage notifications work seamlessly from both \`#inc-xxxx\` and \`#inc-xxxx-status\` channels.

**Channel lookup** -- \`get_incident_from_channel()\` now matches both \`ExternalLinkType.SLACK\` and \`ExternalLinkType.SLACK_STATUS\`, so commands invoked from the status channel resolve to the correct incident.

**Statuspage notifications** -- when a statuspage is created or updated, the success message is posted to both the incident channel and the status channel (previously it only went to whichever channel the command was invoked from).