### PR TITLE
feat: Make service tier optional in Slack app modals

### DIFF
--- a/src/firetower/slack_app/handlers/utils.py
+++ b/src/firetower/slack_app/handlers/utils.py
@@ -186,9 +186,10 @@ def build_incident_lifecycle_modal(
 ) -> dict[str, Any]:
     """Build the shared 9-field modal used by /inc mitigated and /inc resolved.
 
-    Fields are pre-filled from `incident`. All nine fields (captain, severity,
-    title, impact_summary, description, impact_type, service_tier,
-    affected_service, affected_region) are required by Slack defaults.
+    Fields are pre-filled from `incident`. All fields except service_tier
+    (captain, severity, title, impact_summary, description, impact_type,
+    affected_service, affected_region) are required by Slack defaults;
+    service_tier is optional.
     """
     severity_options = [
         {"text": {"type": "plain_text", "text": sev.label}, "value": sev.value}
@@ -348,6 +349,7 @@ def build_incident_lifecycle_modal(
             "block_id": "service_tier_block",
             "element": service_tier_element,
             "label": {"type": "plain_text", "text": "Service Tier"},
+            "optional": True,
         },
     ]
 
@@ -419,8 +421,6 @@ def validate_lifecycle_form(form: dict[str, Any]) -> dict[str, str]:
         errors["impact_summary_block"] = "Impact summary is required."
     if not form["impact_type_tags"]:
         errors["impact_type_block"] = "Select at least one impact type."
-    if not form["service_tier"]:
-        errors["service_tier_block"] = "Service tier is required."
     if not form["affected_service_tags"]:
         errors["affected_service_block"] = "Select at least one affected service."
     if not form["affected_region_tags"]:

--- a/src/firetower/slack_app/tests/handlers/test_mitigated.py
+++ b/src/firetower/slack_app/tests/handlers/test_mitigated.py
@@ -133,11 +133,15 @@ class TestMitigatedModal:
             "description_block",
             "impact_summary_block",
             "impact_type_block",
-            "service_tier_block",
             "affected_service_block",
             "affected_region_block",
         ):
             assert by_id[required].get("optional", False) is False
+
+    def test_service_tier_block_is_optional(self, incident):
+        modal = _build_mitigated_modal(incident, CHANNEL_ID)
+        by_id = {b["block_id"]: b for b in modal["blocks"] if "block_id" in b}
+        assert by_id["service_tier_block"].get("optional") is True
 
     def test_prefills_title_and_severity(self, incident):
         modal = _build_mitigated_modal(incident, CHANNEL_ID)
@@ -232,7 +236,21 @@ class TestMitigatedSubmission:
         assert call_kwargs["response_action"] == "errors"
         assert "impact_type_block" in call_kwargs["errors"]
 
-    def test_missing_service_tier_returns_error(self, incident):
+    @patch("firetower.incidents.serializers.on_status_changed")
+    @patch("firetower.incidents.serializers.on_title_changed")
+    @patch("firetower.slack_app.handlers.mitigated.get_or_create_user_from_slack_id")
+    def test_missing_service_tier_succeeds(
+        self,
+        mock_get_user,
+        mock_title_hook,
+        mock_status_hook,
+        user,
+        incident,
+        impact_type_tag,
+        affected_service_tag,
+        affected_region_tag,
+    ):
+        mock_get_user.return_value = user
         ack = MagicMock()
         client = MagicMock()
         body = {"user": {"id": "U_CAPTAIN"}}
@@ -240,10 +258,10 @@ class TestMitigatedSubmission:
 
         handle_mitigated_submission(ack, body, view, client)
 
-        ack.assert_called_once()
-        call_kwargs = ack.call_args[1]
-        assert call_kwargs["response_action"] == "errors"
-        assert "service_tier_block" in call_kwargs["errors"]
+        ack.assert_called_once_with()
+        incident.refresh_from_db()
+        assert incident.status == IncidentStatus.MITIGATED
+        assert incident.service_tier is None
 
     def test_missing_description_returns_error(self, incident):
         ack = MagicMock()

--- a/src/firetower/slack_app/tests/handlers/test_resolved.py
+++ b/src/firetower/slack_app/tests/handlers/test_resolved.py
@@ -111,11 +111,15 @@ class TestResolvedModal:
             "description_block",
             "impact_summary_block",
             "impact_type_block",
-            "service_tier_block",
             "affected_service_block",
             "affected_region_block",
         ):
             assert by_id[required].get("optional", False) is False
+
+    def test_service_tier_block_is_optional(self, incident):
+        modal = _build_resolved_modal(incident, CHANNEL_ID)
+        by_id = {b["block_id"]: b for b in modal["blocks"] if "block_id" in b}
+        assert by_id["service_tier_block"].get("optional") is True
 
     def test_contains_context_message(self, incident):
         modal = _build_resolved_modal(incident, CHANNEL_ID)
@@ -320,18 +324,32 @@ class TestResolvedSubmission:
         assert call_kwargs["response_action"] == "errors"
         assert "impact_type_block" in call_kwargs["errors"]
 
-    def test_missing_service_tier_returns_error(self, incident):
+    @patch("firetower.incidents.serializers.on_status_changed")
+    @patch("firetower.incidents.serializers.on_title_changed")
+    @patch("firetower.slack_app.handlers.resolved.get_or_create_user_from_slack_id")
+    def test_missing_service_tier_succeeds(
+        self,
+        mock_get_user,
+        mock_title_hook,
+        mock_status_hook,
+        user,
+        incident,
+        impact_type_tag,
+        affected_service_tag,
+        affected_region_tag,
+    ):
+        mock_get_user.return_value = user
         ack = MagicMock()
         client = MagicMock()
         body = {"user": {"id": "U_CAPTAIN"}}
-        view = _make_resolved_view(service_tier=None)
+        view = _make_resolved_view(severity="P3", service_tier=None)
 
         handle_resolved_submission(ack, body, view, client)
 
-        ack.assert_called_once()
-        call_kwargs = ack.call_args[1]
-        assert call_kwargs["response_action"] == "errors"
-        assert "service_tier_block" in call_kwargs["errors"]
+        ack.assert_called_once_with()
+        incident.refresh_from_db()
+        assert incident.status == IncidentStatus.DONE
+        assert incident.service_tier is None
 
     def test_missing_affected_service_returns_error(self, incident):
         ack = MagicMock()


### PR DESCRIPTION
Makes the service tier field optional in the /inc mitigated and /inc resolved lifecycle modals, reversing the required-ness added in RELENG-755. Sets the service_tier input block to optional so Slack no longer enforces it, drops the server-side validation that errored on a missing value, and lets an omitted service_tier flow through as None to the partial serializer. Updates the mitigated/resolved tests to assert the block is optional and that submission succeeds when service tier is omitted.