### PR TITLE
feat(slack): Add attribution to channel actions

### DIFF
--- a/src/firetower/slack_app/handlers/captain.py
+++ b/src/firetower/slack_app/handlers/captain.py
@@ -73,6 +73,7 @@ def handle_captain_command(ack: Any, body: dict, command: dict, respond: Any) ->
 def handle_captain_submission(ack: Any, body: dict, view: dict, client: Any) -> None:
     values = view.get("state", {}).get("values", {})
     channel_id = view.get("private_metadata", "")
+    actor_slack_id = body.get("user", {}).get("id", "")
 
     captain_slack_id = (
         values.get("captain_block", {}).get("captain_select", {}).get("selected_user")
@@ -115,3 +116,7 @@ def handle_captain_submission(ack: Any, body: dict, view: dict, client: Any) -> 
         return
 
     serializer.save()
+    client.chat_postMessage(
+        channel=channel_id,
+        text=f"<@{actor_slack_id}> updated *{incident.incident_number}* captain to <@{captain_slack_id}>",
+    )

--- a/src/firetower/slack_app/handlers/dumpslack.py
+++ b/src/firetower/slack_app/handlers/dumpslack.py
@@ -29,7 +29,9 @@ _PRIVATE_INCIDENT_PM_MESSAGE = (
 )
 
 
-def _trigger_slack_dump(client: Any, channel_id: str, incident: Any) -> None:
+def _trigger_slack_dump(
+    client: Any, channel_id: str, incident: Any, actor_slack_id: str = ""
+) -> None:
     if incident.is_private:
         try:
             client.chat_postMessage(
@@ -165,9 +167,10 @@ def _trigger_slack_dump(client: Any, channel_id: str, incident: Any) -> None:
         except Exception:
             logger.exception("Failed to add Notion bookmark to channel %s", channel_id)
 
+    attribution = f" by <@{actor_slack_id}>" if actor_slack_id else ""
     try:
         client.chat_postMessage(
-            channel=channel_id, text=f"{action} postmortem doc: {page_url}"
+            channel=channel_id, text=f"{action} postmortem doc{attribution}: {page_url}"
         )
     except Exception:
         logger.exception(
@@ -211,12 +214,14 @@ def _backfill_milestones(incident: Any, timeline_md: str) -> None:
         )
 
 
-def trigger_slack_dump_async(client: Any, channel_id: str, incident: Any) -> None:
+def trigger_slack_dump_async(
+    client: Any, channel_id: str, incident: Any, actor_slack_id: str = ""
+) -> None:
     def _run() -> None:
         from django.db import connection  # noqa: PLC0415
 
         try:
-            _trigger_slack_dump(client, channel_id, incident)
+            _trigger_slack_dump(client, channel_id, incident, actor_slack_id)
         except Exception:
             logger.exception("Background dumpslack failed for incident %s", incident.id)
             statsd.increment("slack_app.commands.failed", tags=["subcommand:dumpslack"])
@@ -255,10 +260,11 @@ def handle_dumpslack_command(
         respond(_PRIVATE_INCIDENT_PM_MESSAGE)
         return
 
+    actor_slack_id = body.get("user_id", "")
     respond(
         "Fetching Slack history and generating postmortem doc, this may take a moment..."
     )
-    trigger_slack_dump_async(client, channel_id, incident)
+    trigger_slack_dump_async(client, channel_id, incident, actor_slack_id)
 
 
 def _resolve_user_emails(

--- a/src/firetower/slack_app/handlers/reopen.py
+++ b/src/firetower/slack_app/handlers/reopen.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 def handle_reopen_command(ack: Any, body: dict, command: dict, respond: Any) -> None:
     ack()
     channel_id = body.get("channel_id", "")
+    actor_slack_id = body.get("user_id", "")
     incident = get_incident_from_channel(channel_id)
     if not incident:
         respond("Could not find an incident associated with this channel.")
@@ -25,6 +26,9 @@ def handle_reopen_command(ack: Any, body: dict, command: dict, respond: Any) -> 
     )
     if serializer.is_valid():
         serializer.save()
-        respond(f"{incident.incident_number} has been reopened.")
+        respond(
+            f"<@{actor_slack_id}> reopened {incident.incident_number}.",
+            response_type="in_channel",
+        )
     else:
         respond(f"Failed to reopen incident: {serializer.errors}")

--- a/src/firetower/slack_app/handlers/resolved.py
+++ b/src/firetower/slack_app/handlers/resolved.py
@@ -216,6 +216,7 @@ def handle_resolved_command(ack: Any, body: dict, command: dict, respond: Any) -
 def handle_resolved_submission(ack: Any, body: dict, view: dict, client: Any) -> None:
     form = parse_incident_form_values(view)
     channel_id = view.get("private_metadata", "")
+    actor_slack_id = body.get("user", {}).get("id", "")
 
     values = view.get("state", {}).get("values", {})
 
@@ -291,7 +292,7 @@ def handle_resolved_submission(ack: Any, body: dict, view: dict, client: Any) ->
     client.chat_postMessage(
         channel=channel_id,
         text=(
-            f"*{incident.incident_number} marked as {target_status}*\n"
+            f"<@{actor_slack_id}> marked *{incident.incident_number}* as {target_status}\n"
             f"Severity: {severity} | Captain: {captain_user.get_full_name()}"
         ),
     )

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -415,7 +415,9 @@ def _build_component_warning_modal(
     }
 
 
-def _process_statuspage_submission(data: dict[str, Any], client: Any) -> bool:
+def _process_statuspage_submission(
+    data: dict[str, Any], client: Any, actor_slack_id: str = ""
+) -> bool:
     channel_id = data["channel_id"]
     status = data["status"]
     title = data["title"]
@@ -473,7 +475,10 @@ def _process_statuspage_submission(data: dict[str, Any], client: Any) -> bool:
                     components=components or None,
                 )
                 statuspage_url = service.get_incident_url(result["id"])
-                success_message = f"Statuspage has been updated: {statuspage_url}"
+                attribution = f" by <@{actor_slack_id}>" if actor_slack_id else ""
+                success_message = (
+                    f"Statuspage has been updated{attribution}: {statuspage_url}"
+                )
             else:
                 result = service.create_incident(
                     title=title,
@@ -485,7 +490,10 @@ def _process_statuspage_submission(data: dict[str, Any], client: Any) -> bool:
                 statuspage_url = service.get_incident_url(result["id"])
                 statuspage_link.url = statuspage_url
                 statuspage_link.save(update_fields=["url"])
-                success_message = f"Statuspage post created: {statuspage_url}"
+                attribution = f" by <@{actor_slack_id}>" if actor_slack_id else ""
+                success_message = (
+                    f"Statuspage post created{attribution}: {statuspage_url}"
+                )
     except Exception:
         logger.exception("Failed to create/update statuspage incident")
         client.chat_postMessage(
@@ -520,6 +528,7 @@ def _process_statuspage_submission(data: dict[str, Any], client: Any) -> bool:
 
 def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) -> None:
     values = view.get("state", {}).get("values", {})
+    actor_slack_id = body.get("user", {}).get("id", "")
     errors: dict[str, str] = {}
     message = values.get("message_block", {}).get("message_input", {}).get("value", "")
     if not message:
@@ -533,6 +542,7 @@ def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) 
         return
 
     data = _extract_submission_data(view)
+    data["actor_slack_id"] = actor_slack_id
 
     if data["status"] == "resolved":
         non_operational = [
@@ -561,7 +571,7 @@ def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) 
             return
 
     ack()
-    _process_statuspage_submission(data, client)
+    _process_statuspage_submission(data, client, actor_slack_id=actor_slack_id)
 
 
 def handle_component_impact_select(ack: Any, body: dict) -> None:
@@ -572,8 +582,11 @@ def handle_statuspage_reset_and_resolve(ack: Any, body: dict, client: Any) -> No
     ack()
     view = body.get("view", {})
     data = json.loads(view.get("private_metadata", "{}"))
+    actor_slack_id = data.pop("actor_slack_id", "")
     data["components"] = dict.fromkeys(data.get("components", {}), "operational")
-    success = _process_statuspage_submission(data, client)
+    success = _process_statuspage_submission(
+        data, client, actor_slack_id=actor_slack_id
+    )
     from firetower.slack_app.bolt import get_bolt_app  # noqa: PLC0415
 
     if success:
@@ -601,7 +614,10 @@ def handle_statuspage_resolve_anyway(ack: Any, body: dict, client: Any) -> None:
     ack()
     view = body.get("view", {})
     data = json.loads(view.get("private_metadata", "{}"))
-    success = _process_statuspage_submission(data, client)
+    actor_slack_id = data.pop("actor_slack_id", "")
+    success = _process_statuspage_submission(
+        data, client, actor_slack_id=actor_slack_id
+    )
     from firetower.slack_app.bolt import get_bolt_app  # noqa: PLC0415
 
     if success:

--- a/src/firetower/slack_app/handlers/subject.py
+++ b/src/firetower/slack_app/handlers/subject.py
@@ -12,6 +12,7 @@ def handle_subject_command(
 ) -> None:
     ack()
     channel_id = body.get("channel_id", "")
+    actor_slack_id = body.get("user_id", "")
     incident = get_incident_from_channel(channel_id)
     if not incident:
         respond("Could not find an incident associated with this channel.")
@@ -22,6 +23,9 @@ def handle_subject_command(
     )
     if serializer.is_valid():
         serializer.save()
-        respond(f"{incident.incident_number} subject updated to: {new_subject}")
+        respond(
+            f"<@{actor_slack_id}> updated {incident.incident_number} subject to: {new_subject}",
+            response_type="in_channel",
+        )
     else:
         respond(f"Failed to update subject: {serializer.errors}")

--- a/src/firetower/slack_app/tests/handlers/test_captain.py
+++ b/src/firetower/slack_app/tests/handlers/test_captain.py
@@ -95,7 +95,10 @@ class TestCaptainSubmission:
         ack.assert_called_once()
         incident.refresh_from_db()
         assert incident.captain == user
-        client.chat_postMessage.assert_not_called()
+        client.chat_postMessage.assert_called_once()
+        msg = client.chat_postMessage.call_args[1]["text"]
+        assert "<@U_SUBMITTER>" in msg
+        assert "<@U_CAPTAIN>" in msg
 
     @patch("firetower.slack_app.handlers.captain.get_or_create_user_from_slack_id")
     def test_user_not_found(self, mock_get_user, incident):

--- a/src/firetower/slack_app/tests/handlers/test_dumpslack.py
+++ b/src/firetower/slack_app/tests/handlers/test_dumpslack.py
@@ -641,7 +641,7 @@ class TestHandleDumpslackCommand:
 
         ack.assert_called_once()
         respond.assert_called()
-        mock_async.assert_called_once_with(client, "C123", mock_incident)
+        mock_async.assert_called_once_with(client, "C123", mock_incident, "")
 
 
 @pytest.mark.django_db

--- a/src/firetower/slack_app/tests/handlers/test_statuspage.py
+++ b/src/firetower/slack_app/tests/handlers/test_statuspage.py
@@ -525,6 +525,7 @@ class TestStatuspageSubmission:
             "message": "Looking into it",
             "impact": "major",
             "components": {"c1": "major_outage"},
+            "actor_slack_id": "",
         }
         assert pushed_view["private_metadata"] == json.dumps(expected_data)
 
@@ -656,7 +657,7 @@ class TestStatuspageResolveAnyway:
             handle_statuspage_resolve_anyway(ack, body, client)
 
         ack.assert_called_once_with()
-        mock_process.assert_called_once_with(data, client)
+        mock_process.assert_called_once_with(data, client, actor_slack_id="")
         passed_data = mock_process.call_args[0][0]
         assert passed_data["components"] == {
             "c1": "major_outage",


### PR DESCRIPTION
When actions are performed via Slack slash commands (captain change, statuspage update, resolve, reopen, subject change, dumpslack), the resulting channel messages now show who performed the action using Slack's `<@user_id>` mention format.

Previously most success messages were anonymous ("INC-X has been reopened") or missing entirely (captain change posted no success message at all). Now each message attributes the action to the user who triggered it.

For `reopen` and `subject` commands, this also changes `respond()` to use `response_type="in_channel"` -- previously these were ephemeral (only visible to the actor), which made attribution meaningless. The other handlers already used `client.chat_postMessage` which posts to the full channel.

The `dumpslack` and `statuspage` handlers thread the actor's Slack ID through their async/internal call chains. When triggered automatically (e.g., dumpslack on status change via hooks), `actor_slack_id` defaults to empty and attribution is omitted.


Agent transcript: https://claudescope.sentry.dev/share/jtHwEvih0imvqwfutiVyrqjLtm7j1M8aQEX4oTT9H-Q