### PR TITLE
ref: Remove async worker Datadog fix attempts

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -14,7 +14,7 @@ elif [ z"$1" = "zserver" ]; then
 elif [ z"$1" = "zslack-bot" ]; then
     exec /app/.venv/bin/ddtrace-run /app/.venv/bin/django-admin run_slack_bot --settings firetower.settings
 elif [ z"$1" = "zworker" ]; then
-    exec /app/.venv/bin/ddtrace-run /app/.venv/bin/django-admin wrapped_worker --settings firetower.settings
+    exec /app/.venv/bin/django-admin wrapped_worker --settings firetower.settings
 else
     echo "Usage: $0 (migrate|server|slack-bot|worker)"
     exit 1

--- a/src/firetower/incidents/tasks.py
+++ b/src/firetower/incidents/tasks.py
@@ -59,15 +59,6 @@ def datadog_log(f: NamedFunction) -> NamedFunction:
             raise e
         else:
             statsd.increment("django_q.task.success", 1, tags)
-        finally:
-            # TODO(taylor-osler-sentry): Figure out if/why this is necessary?
-            try:
-                statsd.flush()
-            except Exception as e:
-                logger.error(
-                    f"Error while flushing datadog metrics: {e}", exc_info=True
-                )
-                # Don't re-raise; it's more important we raise the inner exception, if present
 
     return wrapper
 


### PR DESCRIPTION
Cleanup follow-up to RELENG-562. The async django-q2 worker wasn't emitting Datadog metrics; the real fix was infra (the Cloud Run async service used terraform command instead of args, which overrode the Docker datadog-init ENTRYPOINT so the DogStatsD sidecar never started) and has been deployed in ops, with metrics now confirmed flowing in prod. This removes two app-side fix attempts: the statsd.flush() finally block in the datadog_log decorator (the default DogStatsd client sends each increment immediately over UDP, so flush was a no-op) and the redundant ddtrace-run on the worker line of entrypoint.sh (the actual qcluster child is already wrapped in ddtrace-run inside wrapped_worker.py, so APM tracing is preserved). No behavior change to metric emission.