### PR TITLE
feat(slack): Batch incident update notifications into a single message

### DIFF
--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -1487,7 +1487,7 @@ def on_incident_updated(
 
     if lines and channel_id:
         # Build header
-        if actor:
+        if actor and actor.is_authenticated:
             actor_slack_id = _get_slack_user_id(actor)
             if actor_slack_id:
                 header = f"<@{actor_slack_id}> updated incident:"

--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -1614,10 +1614,6 @@ def on_incident_updated(
                     f"Failed to invite captain to status channel in on_incident_updated for incident {incident.id}"
                 )
 
-    # Title change: sync linear
-    if old_title is not None:
-        _sync_linear_title(incident)
-
-    # Visibility change: sync linear
-    if visibility_changed:
+    # Title or visibility change: sync linear
+    if old_title is not None or visibility_changed:
         _sync_linear_title(incident)

--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -1435,3 +1435,189 @@ def on_captain_changed(incident: Incident) -> None:
                     )
     except Exception:
         logger.exception(f"Error in on_captain_changed for incident {incident.id}")
+
+
+def on_incident_updated(
+    incident: Incident,
+    *,
+    old_title: str | None = None,
+    old_status: str | None = None,
+    old_severity: str | None = None,
+    captain_changed: bool = False,
+    visibility_changed: bool = False,
+    actor: User | None = None,
+) -> None:
+    channel_id: str | None = None
+    try:
+        channel_id = _get_channel_id(incident)
+    except Exception:
+        logger.exception(
+            f"Error getting channel id in on_incident_updated for incident {incident.id}"
+        )
+
+    # --- Set topic once if any topic-relevant field changed ---
+    if channel_id and (
+        old_title is not None or old_severity is not None or captain_changed
+    ):
+        try:
+            _slack_service.set_channel_topic(channel_id, build_channel_topic(incident))
+        except Exception:
+            logger.exception(
+                f"Error setting channel topic in on_incident_updated for incident {incident.id}"
+            )
+
+    # --- Build combined notification lines ---
+    lines: list[str] = []
+
+    if old_status is not None:
+        lines.append(f"- Status: {old_status} -> {incident.status}")
+
+    if old_severity is not None:
+        lines.append(f"- Severity: {old_severity} -> {incident.severity}")
+
+    if captain_changed and incident.captain is not None:
+        slack_id = _get_slack_user_id(incident.captain)
+        if slack_id:
+            captain_ref = f"<@{slack_id}>"
+        else:
+            captain_ref = escape_slack_text(
+                incident.captain.get_full_name() or incident.captain.username
+            )
+        lines.append(f"- Captain: {captain_ref}")
+
+    if lines and channel_id:
+        # Build header
+        if actor:
+            actor_slack_id = _get_slack_user_id(actor)
+            if actor_slack_id:
+                header = f"<@{actor_slack_id}> updated incident:"
+            else:
+                actor_name = escape_slack_text(actor.get_full_name() or actor.username)
+                header = f"{actor_name} updated incident:"
+        else:
+            header = "Incident updated:"
+
+        incident_url = _build_incident_url(incident)
+        body = "\n".join(lines)
+        message = f"{header}\n{body}\n<{incident_url}|View in Firetower>"
+        try:
+            _slack_service.post_message(channel_id, message)
+        except Exception:
+            logger.exception(
+                f"Error posting combined message in on_incident_updated for incident {incident.id}"
+            )
+
+    # --- Visibility gets its own separate message (same as on_visibility_changed) ---
+    if visibility_changed and channel_id:
+        try:
+            visibility = "private" if incident.is_private else "public"
+            incident_url = _build_incident_url(incident)
+            vis_message = (
+                f"This incident has been marked as *{visibility}* in Firetower. "
+                f"If you want to make this channel {visibility}, you will need a Slack admin to make the change.\n"
+                f"<{incident_url}|View in Firetower>"
+            )
+            _slack_service.post_message(channel_id, vis_message)
+        except Exception:
+            logger.exception(
+                f"Error posting visibility message in on_incident_updated for incident {incident.id}"
+            )
+
+    # --- Side effects ---
+
+    # Status change: trigger slack dump for resolve-like statuses
+    if (
+        old_status is not None
+        and incident.status
+        in (IncidentStatus.MITIGATED, IncidentStatus.DONE, IncidentStatus.POSTMORTEM)
+        and channel_id
+    ):
+        try:
+            from firetower.slack_app.bolt import get_bolt_app  # noqa: PLC0415
+            from firetower.slack_app.handlers.dumpslack import (  # noqa: PLC0415
+                trigger_slack_dump_async,
+            )
+
+            trigger_slack_dump_async(get_bolt_app().client, channel_id, incident)
+        except Exception:
+            logger.exception(
+                f"Failed to trigger slack dump in on_incident_updated for incident {incident.id}"
+            )
+
+    # Severity escalation: page, invite oncall, create status channel, schedule reminders
+    if (
+        old_severity is not None
+        and old_severity not in HIGH_SEVERITIES
+        and incident.severity in HIGH_SEVERITIES
+        and incident.status in ACTIVE_STATUSES
+    ):
+        paged_policies: set[str] = set()
+        try:
+            paged_policies = _page_if_needed(incident, channel_id=channel_id)
+        except Exception:
+            logger.exception(
+                f"Failed to page in on_incident_updated for incident {incident.id}"
+            )
+
+        if channel_id:
+            try:
+                _invite_oncall_users(
+                    incident, channel_id, paged_policies=paged_policies
+                )
+            except Exception:
+                logger.exception(
+                    f"Failed to invite oncall users in on_incident_updated for incident {incident.id}"
+                )
+
+            try:
+                _create_status_channel(incident, channel_id)
+            except Exception:
+                logger.exception(
+                    f"Failed to create status channel in on_incident_updated for incident {incident.id}"
+                )
+
+        try:
+            _schedule_statuspage_reminder(
+                incident, reference_time=timezone.now(), allow_update=True
+            )
+        except Exception:
+            logger.exception(
+                f"Failed to schedule statuspage reminder in on_incident_updated for incident {incident.id}"
+            )
+
+        try:
+            schedule_statuspage_followup_reminder(incident)
+        except Exception:
+            logger.exception(
+                f"Failed to schedule statuspage followup in on_incident_updated for incident {incident.id}"
+            )
+
+    # Captain change: invite captain to channels
+    if captain_changed and incident.captain is not None and channel_id:
+        try:
+            _invite_user_to_channel(channel_id, incident.captain)
+        except Exception:
+            logger.exception(
+                f"Failed to invite captain in on_incident_updated for incident {incident.id}"
+            )
+
+        if incident.severity in HIGH_SEVERITIES:
+            try:
+                status_channel_id = _get_status_channel_id(incident)
+                if status_channel_id:
+                    slack_id = _get_slack_user_id(incident.captain)
+                    _invite_user_to_channel(
+                        status_channel_id, incident.captain, slack_user_id=slack_id
+                    )
+            except Exception:
+                logger.exception(
+                    f"Failed to invite captain to status channel in on_incident_updated for incident {incident.id}"
+                )
+
+    # Title change: sync linear
+    if old_title is not None:
+        _sync_linear_title(incident)
+
+    # Visibility change: sync linear
+    if visibility_changed:
+        _sync_linear_title(incident)

--- a/src/firetower/incidents/serializers.py
+++ b/src/firetower/incidents/serializers.py
@@ -10,12 +10,8 @@ from rest_framework import serializers
 from firetower.auth.services import get_or_create_user_from_email
 
 from .hooks import (
-    on_captain_changed,
     on_incident_created,
-    on_severity_changed,
-    on_status_changed,
-    on_title_changed,
-    on_visibility_changed,
+    on_incident_updated,
 )
 from .models import (
     USER_ADDABLE_TAG_TYPES,
@@ -624,16 +620,21 @@ class IncidentWriteSerializer(serializers.ModelSerializer):
         self._auto_compute_downtime(instance, validated_data)
 
         if settings.HOOKS_ENABLED:
-            if instance.title != old_title:
-                on_title_changed(instance)
-            if instance.status != old_status:
-                on_status_changed(instance, old_status)
-            if instance.severity != old_severity:
-                on_severity_changed(instance, old_severity)
-            if instance.captain_id != old_captain_id:
-                on_captain_changed(instance)
-            if instance.is_private != old_is_private:
-                on_visibility_changed(instance)
+            request = self.context.get("request")
+            actor = self.context.get("acting_user") or (
+                request.user if request else None
+            )
+            on_incident_updated(
+                instance,
+                old_title=old_title if instance.title != old_title else None,
+                old_status=old_status if instance.status != old_status else None,
+                old_severity=old_severity
+                if instance.severity != old_severity
+                else None,
+                captain_changed=instance.captain_id != old_captain_id,
+                visibility_changed=instance.is_private != old_is_private,
+                actor=actor,
+            )
 
         return instance
 

--- a/src/firetower/incidents/tests/test_hooks.py
+++ b/src/firetower/incidents/tests/test_hooks.py
@@ -22,6 +22,7 @@ from firetower.incidents.hooks import (
     create_linear_parent_issue,
     on_captain_changed,
     on_incident_created,
+    on_incident_updated,
     on_severity_changed,
     on_status_changed,
     on_title_changed,
@@ -3199,3 +3200,284 @@ class TestCreateLinearParentIssueBookmark:
         create_linear_parent_issue(incident, channel_id="C99999")
 
         mock_slack.add_bookmark.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestOnIncidentUpdated:
+    def _make_incident(self, **kwargs):
+        defaults = {
+            "title": "Test Incident",
+            "severity": IncidentSeverity.P2,
+            "status": IncidentStatus.ACTIVE,
+        }
+        defaults.update(kwargs)
+        return Incident.objects.create(**defaults)
+
+    def _link_slack(self, incident, channel_id="C12345"):
+        ExternalLink.objects.create(
+            incident=incident,
+            type=ExternalLinkType.SLACK,
+            url=f"https://slack.com/archives/{channel_id}",
+        )
+
+    @patch("firetower.incidents.hooks._slack_service")
+    def test_posts_single_message_for_multiple_changes(self, mock_slack):
+        mock_slack.parse_channel_id_from_url.return_value = "C12345"
+
+        captain = User.objects.create_user(
+            username="cap@example.com",
+            email="cap@example.com",
+            first_name="Jane",
+            last_name="Doe",
+        )
+        ExternalProfile.objects.create(
+            user=captain,
+            type=ExternalProfileType.SLACK,
+            external_id="U_CAP",
+        )
+        incident = self._make_incident(
+            severity=IncidentSeverity.P1,
+            status=IncidentStatus.MITIGATED,
+            captain=captain,
+        )
+        self._link_slack(incident)
+
+        on_incident_updated(
+            incident,
+            old_status=IncidentStatus.ACTIVE,
+            old_severity=IncidentSeverity.P2,
+            captain_changed=True,
+        )
+
+        mock_slack.post_message.assert_called_once()
+        msg = mock_slack.post_message.call_args[0][1]
+        assert "- Status:" in msg
+        assert "- Severity:" in msg
+        assert "- Captain: <@U_CAP>" in msg
+
+    @patch("firetower.incidents.hooks._slack_service")
+    def test_posts_bullet_for_single_change(self, mock_slack):
+        mock_slack.parse_channel_id_from_url.return_value = "C12345"
+
+        incident = self._make_incident(status=IncidentStatus.MITIGATED)
+        self._link_slack(incident)
+
+        on_incident_updated(incident, old_status=IncidentStatus.ACTIVE)
+
+        mock_slack.post_message.assert_called_once()
+        msg = mock_slack.post_message.call_args[0][1]
+        assert "- Status: Active -> Mitigated" in msg
+
+    @patch("firetower.incidents.hooks._slack_service")
+    def test_includes_actor_attribution(self, mock_slack):
+        mock_slack.parse_channel_id_from_url.return_value = "C12345"
+
+        actor = User.objects.create_user(
+            username="actor@example.com", email="actor@example.com"
+        )
+        ExternalProfile.objects.create(
+            user=actor,
+            type=ExternalProfileType.SLACK,
+            external_id="U_ACTOR",
+        )
+        incident = self._make_incident(status=IncidentStatus.MITIGATED)
+        self._link_slack(incident)
+
+        on_incident_updated(incident, old_status=IncidentStatus.ACTIVE, actor=actor)
+
+        msg = mock_slack.post_message.call_args[0][1]
+        assert "<@U_ACTOR>" in msg
+        assert "updated incident:" in msg
+
+    @patch("firetower.incidents.hooks._slack_service")
+    def test_actor_name_fallback_when_no_slack_profile(self, mock_slack):
+        mock_slack.parse_channel_id_from_url.return_value = "C12345"
+
+        actor = User.objects.create_user(
+            username="actor@example.com",
+            email="actor@example.com",
+            first_name="Alice",
+            last_name="Smith",
+        )
+        incident = self._make_incident(status=IncidentStatus.MITIGATED)
+        self._link_slack(incident)
+
+        on_incident_updated(incident, old_status=IncidentStatus.ACTIVE, actor=actor)
+
+        msg = mock_slack.post_message.call_args[0][1]
+        assert "Alice Smith updated incident:" in msg
+
+    @patch("firetower.incidents.hooks._slack_service")
+    def test_no_actor_falls_back_to_generic_header(self, mock_slack):
+        mock_slack.parse_channel_id_from_url.return_value = "C12345"
+
+        incident = self._make_incident(status=IncidentStatus.MITIGATED)
+        self._link_slack(incident)
+
+        on_incident_updated(incident, old_status=IncidentStatus.ACTIVE)
+
+        msg = mock_slack.post_message.call_args[0][1]
+        assert msg.startswith("Incident updated:")
+
+    @patch("firetower.incidents.hooks._slack_service")
+    def test_sets_topic_once_when_severity_and_captain_change(self, mock_slack):
+        mock_slack.parse_channel_id_from_url.return_value = "C12345"
+
+        captain = User.objects.create_user(
+            username="cap2@example.com",
+            email="cap2@example.com",
+            first_name="Bob",
+            last_name="Lead",
+        )
+        ExternalProfile.objects.create(
+            user=captain,
+            type=ExternalProfileType.SLACK,
+            external_id="U_CAP2",
+        )
+        incident = self._make_incident(severity=IncidentSeverity.P3, captain=captain)
+        self._link_slack(incident)
+
+        on_incident_updated(
+            incident, old_severity=IncidentSeverity.P4, captain_changed=True
+        )
+
+        mock_slack.set_channel_topic.assert_called_once()
+
+    @patch("firetower.incidents.hooks._slack_service")
+    def test_no_message_when_nothing_changed(self, mock_slack):
+        mock_slack.parse_channel_id_from_url.return_value = "C12345"
+
+        incident = self._make_incident()
+        self._link_slack(incident)
+
+        on_incident_updated(incident)
+
+        mock_slack.post_message.assert_not_called()
+
+    @patch("firetower.incidents.hooks._slack_service")
+    def test_no_message_without_slack_link(self, mock_slack):
+        mock_slack.parse_channel_id_from_url.return_value = None
+
+        incident = self._make_incident()
+
+        on_incident_updated(incident, old_status=IncidentStatus.ACTIVE)
+
+        mock_slack.post_message.assert_not_called()
+
+    @patch("firetower.incidents.hooks._slack_service")
+    def test_captain_name_fallback_when_no_slack_profile(self, mock_slack):
+        mock_slack.parse_channel_id_from_url.return_value = "C12345"
+
+        captain = User.objects.create_user(
+            username="cap3@example.com",
+            email="cap3@example.com",
+            first_name="Carol",
+            last_name="Jones",
+        )
+        incident = self._make_incident(captain=captain)
+        self._link_slack(incident)
+
+        on_incident_updated(incident, captain_changed=True)
+
+        msg = mock_slack.post_message.call_args[0][1]
+        assert "Carol Jones" in msg
+
+    @patch("firetower.incidents.hooks._slack_service")
+    def test_no_captain_line_when_captain_cleared(self, mock_slack):
+        mock_slack.parse_channel_id_from_url.return_value = "C12345"
+
+        incident = self._make_incident(captain=None)
+        self._link_slack(incident)
+
+        on_incident_updated(incident, captain_changed=True)
+
+        mock_slack.set_channel_topic.assert_called_once()
+        mock_slack.post_message.assert_not_called()
+
+    @patch("firetower.slack_app.handlers.dumpslack.trigger_slack_dump_async")
+    @patch("firetower.slack_app.bolt.get_bolt_app")
+    @patch("firetower.incidents.hooks._slack_service")
+    def test_triggers_slack_dump_on_resolved_status(
+        self, mock_slack, mock_bolt, mock_dump_async
+    ):
+        mock_slack.parse_channel_id_from_url.return_value = "C12345"
+        mock_client = MagicMock()
+        mock_bolt.return_value.client = mock_client
+
+        incident = self._make_incident(status=IncidentStatus.POSTMORTEM)
+        self._link_slack(incident)
+
+        on_incident_updated(incident, old_status=IncidentStatus.MITIGATED)
+
+        mock_dump_async.assert_called_once_with(mock_client, "C12345", incident)
+
+    @patch("firetower.incidents.hooks.schedule_statuspage_followup_reminder")
+    @patch("firetower.incidents.hooks._schedule_statuspage_reminder")
+    @patch("firetower.incidents.hooks._create_status_channel")
+    @patch("firetower.incidents.hooks._invite_oncall_users")
+    @patch("firetower.incidents.hooks._page_if_needed")
+    @patch("firetower.incidents.hooks._slack_service")
+    def test_severity_escalation_side_effects(
+        self,
+        mock_slack,
+        mock_page,
+        mock_invite_oncall,
+        mock_status_channel,
+        mock_statuspage,
+        mock_followup,
+    ):
+        mock_slack.parse_channel_id_from_url.return_value = "C12345"
+
+        incident = self._make_incident(
+            severity=IncidentSeverity.P0,
+            status=IncidentStatus.ACTIVE,
+        )
+        self._link_slack(incident)
+
+        on_incident_updated(incident, old_severity=IncidentSeverity.P2)
+
+        mock_page.assert_called_once()
+        mock_invite_oncall.assert_called_once()
+        mock_status_channel.assert_called_once()
+        mock_statuspage.assert_called_once()
+        mock_followup.assert_called_once()
+
+    @patch("firetower.incidents.hooks._slack_service")
+    def test_captain_invited_to_channel(self, mock_slack):
+        mock_slack.parse_channel_id_from_url.return_value = "C12345"
+
+        captain = User.objects.create_user(
+            username="cap4@example.com",
+            email="cap4@example.com",
+            first_name="Dave",
+            last_name="Lead",
+        )
+        ExternalProfile.objects.create(
+            user=captain,
+            type=ExternalProfileType.SLACK,
+            external_id="U_CAP4",
+        )
+        incident = self._make_incident(captain=captain)
+        self._link_slack(incident)
+
+        on_incident_updated(incident, captain_changed=True)
+
+        mock_slack.invite_to_channel.assert_called_once_with("C12345", ["U_CAP4"])
+
+    @patch("firetower.incidents.hooks._slack_service")
+    def test_visibility_posted_separately(self, mock_slack):
+        mock_slack.parse_channel_id_from_url.return_value = "C12345"
+
+        incident = self._make_incident(status=IncidentStatus.MITIGATED, is_private=True)
+        self._link_slack(incident)
+
+        on_incident_updated(
+            incident,
+            old_status=IncidentStatus.ACTIVE,
+            visibility_changed=True,
+        )
+
+        assert mock_slack.post_message.call_count == 2
+        messages = [c[0][1] for c in mock_slack.post_message.call_args_list]
+        assert any("- Status:" in m for m in messages)
+        assert any("private" in m for m in messages)

--- a/src/firetower/incidents/tests/test_hooks.py
+++ b/src/firetower/incidents/tests/test_hooks.py
@@ -3470,8 +3470,10 @@ class TestOnIncidentUpdated:
 
         mock_slack.invite_to_channel.assert_called_once_with("C12345", ["U_CAP4"])
 
+    @patch("firetower.slack_app.handlers.dumpslack.trigger_slack_dump_async")
+    @patch("firetower.slack_app.bolt.get_bolt_app")
     @patch("firetower.incidents.hooks._slack_service")
-    def test_visibility_posted_separately(self, mock_slack):
+    def test_visibility_posted_separately(self, mock_slack, mock_bolt, mock_dump_async):
         mock_slack.parse_channel_id_from_url.return_value = "C12345"
 
         incident = self._make_incident(status=IncidentStatus.MITIGATED, is_private=True)

--- a/src/firetower/incidents/tests/test_hooks.py
+++ b/src/firetower/incidents/tests/test_hooks.py
@@ -3220,9 +3220,15 @@ class TestOnIncidentUpdated:
             url=f"https://slack.com/archives/{channel_id}",
         )
 
+    @patch("firetower.incidents.hooks._create_status_channel")
+    @patch("firetower.incidents.hooks._invite_oncall_users")
+    @patch("firetower.incidents.hooks._page_if_needed")
     @patch("firetower.incidents.hooks._slack_service")
-    def test_posts_single_message_for_multiple_changes(self, mock_slack):
+    def test_posts_single_message_for_multiple_changes(
+        self, mock_slack, mock_page, mock_invite_oncall, mock_status_channel
+    ):
         mock_slack.parse_channel_id_from_url.return_value = "C12345"
+        mock_page.return_value = set()
 
         captain = User.objects.create_user(
             username="cap@example.com",

--- a/src/firetower/incidents/tests/test_serializers.py
+++ b/src/firetower/incidents/tests/test_serializers.py
@@ -183,8 +183,8 @@ class TestIncidentWriteSerializerHooks:
         incident = serializer.save()
         mock_hook.assert_called_once_with(incident)
 
-    @patch("firetower.incidents.serializers.on_status_changed")
-    def test_update_calls_on_status_changed(self, mock_hook):
+    @patch("firetower.incidents.serializers.on_incident_updated")
+    def test_update_calls_on_incident_updated_with_status(self, mock_hook):
         incident = Incident.objects.create(
             title="Test",
             severity=IncidentSeverity.P1,
@@ -199,10 +199,18 @@ class TestIncidentWriteSerializerHooks:
         )
         assert serializer.is_valid(), serializer.errors
         serializer.save()
-        mock_hook.assert_called_once_with(incident, IncidentStatus.ACTIVE)
+        mock_hook.assert_called_once_with(
+            incident,
+            old_title=None,
+            old_status=IncidentStatus.ACTIVE,
+            old_severity=None,
+            captain_changed=False,
+            visibility_changed=False,
+            actor=None,
+        )
 
-    @patch("firetower.incidents.serializers.on_severity_changed")
-    def test_update_calls_on_severity_changed(self, mock_hook):
+    @patch("firetower.incidents.serializers.on_incident_updated")
+    def test_update_calls_on_incident_updated_with_severity(self, mock_hook):
         incident = Incident.objects.create(
             title="Test",
             severity=IncidentSeverity.P2,
@@ -216,10 +224,18 @@ class TestIncidentWriteSerializerHooks:
         )
         assert serializer.is_valid(), serializer.errors
         serializer.save()
-        mock_hook.assert_called_once_with(incident, IncidentSeverity.P2)
+        mock_hook.assert_called_once_with(
+            incident,
+            old_title=None,
+            old_status=None,
+            old_severity=IncidentSeverity.P2,
+            captain_changed=False,
+            visibility_changed=False,
+            actor=None,
+        )
 
-    @patch("firetower.incidents.serializers.on_captain_changed")
-    def test_update_calls_on_captain_changed(self, mock_hook):
+    @patch("firetower.incidents.serializers.on_incident_updated")
+    def test_update_calls_on_incident_updated_with_captain(self, mock_hook):
         incident = Incident.objects.create(
             title="Test",
             severity=IncidentSeverity.P1,
@@ -237,14 +253,18 @@ class TestIncidentWriteSerializerHooks:
         )
         assert serializer.is_valid(), serializer.errors
         serializer.save()
-        mock_hook.assert_called_once_with(incident)
+        mock_hook.assert_called_once_with(
+            incident,
+            old_title=None,
+            old_status=None,
+            old_severity=None,
+            captain_changed=True,
+            visibility_changed=False,
+            actor=None,
+        )
 
-    @patch("firetower.incidents.serializers.on_status_changed")
-    @patch("firetower.incidents.serializers.on_severity_changed")
-    @patch("firetower.incidents.serializers.on_captain_changed")
-    def test_update_no_hooks_when_fields_unchanged(
-        self, mock_captain, mock_severity, mock_status
-    ):
+    @patch("firetower.incidents.serializers.on_incident_updated")
+    def test_update_no_hook_when_fields_unchanged(self, mock_hook):
         incident = Incident.objects.create(
             title="Test",
             severity=IncidentSeverity.P1,
@@ -258,9 +278,56 @@ class TestIncidentWriteSerializerHooks:
         )
         assert serializer.is_valid(), serializer.errors
         serializer.save()
-        mock_status.assert_not_called()
-        mock_severity.assert_not_called()
-        mock_captain.assert_not_called()
+        mock_hook.assert_called_once_with(
+            incident,
+            old_title="Test",
+            old_status=None,
+            old_severity=None,
+            captain_changed=False,
+            visibility_changed=False,
+            actor=None,
+        )
+
+    @patch("firetower.incidents.serializers.on_incident_updated")
+    def test_update_passes_actor_from_request(self, mock_hook):
+        incident = Incident.objects.create(
+            title="Test",
+            severity=IncidentSeverity.P1,
+            status=IncidentStatus.ACTIVE,
+            captain=self.captain,
+            reporter=self.reporter,
+        )
+        mock_request = type("Request", (), {"user": self.captain})()
+        serializer = IncidentWriteSerializer(
+            instance=incident,
+            data={"status": "Mitigated"},
+            partial=True,
+            context={"request": mock_request},
+        )
+        assert serializer.is_valid(), serializer.errors
+        serializer.save()
+        mock_hook.assert_called_once()
+        assert mock_hook.call_args[1]["actor"] == self.captain
+
+    @patch("firetower.incidents.serializers.on_incident_updated")
+    def test_update_passes_actor_from_acting_user_context(self, mock_hook):
+        incident = Incident.objects.create(
+            title="Test",
+            severity=IncidentSeverity.P1,
+            status=IncidentStatus.ACTIVE,
+            captain=self.captain,
+            reporter=self.reporter,
+        )
+        serializer = IncidentWriteSerializer(
+            instance=incident,
+            data={"status": "Mitigated"},
+            partial=True,
+            context={"acting_user": self.reporter},
+        )
+        assert serializer.is_valid(), serializer.errors
+        serializer.save()
+        mock_hook.assert_called_once()
+        assert mock_hook.call_args[1]["actor"] == self.reporter
 
     @patch("firetower.incidents.hooks._slack_service")
     def test_update_same_status_string_does_not_fire_hook(self, mock_slack):

--- a/src/firetower/slack_app/handlers/captain.py
+++ b/src/firetower/slack_app/handlers/captain.py
@@ -103,8 +103,12 @@ def handle_captain_submission(ack: Any, body: dict, view: dict, client: Any) -> 
         )
         return
 
+    acting_user = get_or_create_user_from_slack_id(body["user"]["id"])
     serializer = IncidentWriteSerializer(
-        instance=incident, data={"captain": captain_user.email}, partial=True
+        instance=incident,
+        data={"captain": captain_user.email},
+        partial=True,
+        context={"acting_user": acting_user},
     )
     if not serializer.is_valid():
         logger.error("Captain update failed: %s", serializer.errors)

--- a/src/firetower/slack_app/handlers/mitigated.py
+++ b/src/firetower/slack_app/handlers/mitigated.py
@@ -80,7 +80,10 @@ def handle_mitigated_submission(ack: Any, body: dict, view: dict, client: Any) -
         form, IncidentStatus.MITIGATED, captain_user.email
     )
 
-    serializer = IncidentWriteSerializer(instance=incident, data=data, partial=True)
+    acting_user = get_or_create_user_from_slack_id(body["user"]["id"])
+    serializer = IncidentWriteSerializer(
+        instance=incident, data=data, partial=True, context={"acting_user": acting_user}
+    )
     if not serializer.is_valid():
         logger.error("Mitigated update failed: %s", serializer.errors)
         client.chat_postMessage(

--- a/src/firetower/slack_app/handlers/reopen.py
+++ b/src/firetower/slack_app/handlers/reopen.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any
 
+from firetower.auth.services import get_or_create_user_from_slack_id
 from firetower.incidents.models import IncidentStatus
 from firetower.incidents.serializers import IncidentWriteSerializer
 from firetower.slack_app.handlers.utils import get_incident_from_channel
@@ -20,8 +21,12 @@ def handle_reopen_command(ack: Any, body: dict, command: dict, respond: Any) -> 
         respond(f"{incident.incident_number} is already Active.")
         return
 
+    acting_user = get_or_create_user_from_slack_id(body.get("user_id", ""))
     serializer = IncidentWriteSerializer(
-        instance=incident, data={"status": IncidentStatus.ACTIVE}, partial=True
+        instance=incident,
+        data={"status": IncidentStatus.ACTIVE},
+        partial=True,
+        context={"acting_user": acting_user},
     )
     if serializer.is_valid():
         serializer.save()

--- a/src/firetower/slack_app/handlers/resolved.py
+++ b/src/firetower/slack_app/handlers/resolved.py
@@ -82,7 +82,10 @@ def handle_resolved_submission(ack: Any, body: dict, view: dict, client: Any) ->
 
     data = build_incident_update_data(form, target_status, captain_user.email)
 
-    serializer = IncidentWriteSerializer(instance=incident, data=data, partial=True)
+    acting_user = get_or_create_user_from_slack_id(body["user"]["id"])
+    serializer = IncidentWriteSerializer(
+        instance=incident, data=data, partial=True, context={"acting_user": acting_user}
+    )
     if not serializer.is_valid():
         logger.error("Resolved update failed: %s", serializer.errors)
         client.chat_postMessage(

--- a/src/firetower/slack_app/handlers/severity.py
+++ b/src/firetower/slack_app/handlers/severity.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any
 
+from firetower.auth.services import get_or_create_user_from_slack_id
 from firetower.incidents.models import IncidentSeverity
 from firetower.incidents.serializers import IncidentWriteSerializer
 from firetower.slack_app.handlers.utils import get_incident_from_channel
@@ -26,8 +27,12 @@ def handle_severity_command(
         respond(f"Invalid severity `{new_severity}`. Must be one of: {valid}")
         return
 
+    acting_user = get_or_create_user_from_slack_id(body.get("user_id", ""))
     serializer = IncidentWriteSerializer(
-        instance=incident, data={"severity": normalized}, partial=True
+        instance=incident,
+        data={"severity": normalized},
+        partial=True,
+        context={"acting_user": acting_user},
     )
     if serializer.is_valid():
         serializer.save()

--- a/src/firetower/slack_app/handlers/subject.py
+++ b/src/firetower/slack_app/handlers/subject.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any
 
+from firetower.auth.services import get_or_create_user_from_slack_id
 from firetower.incidents.serializers import IncidentWriteSerializer
 from firetower.slack_app.handlers.utils import get_incident_from_channel
 
@@ -17,8 +18,12 @@ def handle_subject_command(
         respond("Could not find an incident associated with this channel.")
         return
 
+    acting_user = get_or_create_user_from_slack_id(body.get("user_id", ""))
     serializer = IncidentWriteSerializer(
-        instance=incident, data={"title": new_subject}, partial=True
+        instance=incident,
+        data={"title": new_subject},
+        partial=True,
+        context={"acting_user": acting_user},
     )
     if serializer.is_valid():
         serializer.save()

--- a/src/firetower/slack_app/handlers/update_incident.py
+++ b/src/firetower/slack_app/handlers/update_incident.py
@@ -273,7 +273,10 @@ def handle_update_incident_submission(
         if captain_user:
             data["captain"] = captain_user.email
 
-    serializer = IncidentWriteSerializer(instance=incident, data=data, partial=True)
+    acting_user = get_or_create_user_from_slack_id(body["user"]["id"])
+    serializer = IncidentWriteSerializer(
+        instance=incident, data=data, partial=True, context={"acting_user": acting_user}
+    )
     if not serializer.is_valid():
         logger.error("Incident update validation failed: %s", serializer.errors)
         client.chat_postMessage(

--- a/src/firetower/slack_app/tests/handlers/test_captain.py
+++ b/src/firetower/slack_app/tests/handlers/test_captain.py
@@ -71,12 +71,9 @@ class TestCaptainCommand:
 
 @pytest.mark.django_db
 class TestCaptainSubmission:
-    @patch("firetower.incidents.serializers.on_captain_changed")
-    @patch("firetower.incidents.serializers.on_title_changed")
+    @patch("firetower.incidents.serializers.on_incident_updated")
     @patch("firetower.slack_app.handlers.captain.get_or_create_user_from_slack_id")
-    def test_sets_captain(
-        self, mock_get_user, mock_title_hook, mock_captain_hook, user, incident
-    ):
+    def test_sets_captain(self, mock_get_user, mock_hook, user, incident):
         mock_get_user.return_value = user
         ack = MagicMock()
         body = {"user": {"id": "U_SUBMITTER"}}

--- a/src/firetower/slack_app/tests/handlers/test_mitigated.py
+++ b/src/firetower/slack_app/tests/handlers/test_mitigated.py
@@ -152,14 +152,12 @@ class TestMitigatedModal:
 
 @pytest.mark.django_db
 class TestMitigatedSubmission:
-    @patch("firetower.incidents.serializers.on_status_changed")
-    @patch("firetower.incidents.serializers.on_title_changed")
+    @patch("firetower.incidents.serializers.on_incident_updated")
     @patch("firetower.slack_app.handlers.mitigated.get_or_create_user_from_slack_id")
     def test_transitions_to_mitigated(
         self,
         mock_get_user,
-        mock_title_hook,
-        mock_status_hook,
+        mock_hook,
         user,
         incident,
         impact_type_tag,
@@ -236,14 +234,12 @@ class TestMitigatedSubmission:
         assert call_kwargs["response_action"] == "errors"
         assert "impact_type_block" in call_kwargs["errors"]
 
-    @patch("firetower.incidents.serializers.on_status_changed")
-    @patch("firetower.incidents.serializers.on_title_changed")
+    @patch("firetower.incidents.serializers.on_incident_updated")
     @patch("firetower.slack_app.handlers.mitigated.get_or_create_user_from_slack_id")
     def test_missing_service_tier_succeeds(
         self,
         mock_get_user,
-        mock_title_hook,
-        mock_status_hook,
+        mock_hook,
         user,
         incident,
         impact_type_tag,

--- a/src/firetower/slack_app/tests/handlers/test_reopen.py
+++ b/src/firetower/slack_app/tests/handlers/test_reopen.py
@@ -10,11 +10,8 @@ from .conftest import CHANNEL_ID
 
 @pytest.mark.django_db
 class TestReopenCommand:
-    @patch("firetower.incidents.serializers.on_status_changed")
-    @patch("firetower.incidents.serializers.on_title_changed")
-    def test_reopens_mitigated_incident(
-        self, mock_title_hook, mock_status_hook, incident
-    ):
+    @patch("firetower.incidents.serializers.on_incident_updated")
+    def test_reopens_mitigated_incident(self, mock_hook, incident):
         incident.status = IncidentStatus.MITIGATED
         incident.save()
 

--- a/src/firetower/slack_app/tests/handlers/test_resolved.py
+++ b/src/firetower/slack_app/tests/handlers/test_resolved.py
@@ -184,18 +184,12 @@ def affected_region_tag(db):
 
 @pytest.mark.django_db
 class TestResolvedSubmission:
-    @patch("firetower.incidents.serializers.on_status_changed")
-    @patch("firetower.incidents.serializers.on_severity_changed")
-    @patch("firetower.incidents.serializers.on_captain_changed")
-    @patch("firetower.incidents.serializers.on_title_changed")
+    @patch("firetower.incidents.serializers.on_incident_updated")
     @patch("firetower.slack_app.handlers.resolved.get_or_create_user_from_slack_id")
     def test_p1_goes_to_postmortem(
         self,
         mock_get_user,
-        mock_title_hook,
-        mock_captain_hook,
-        mock_sev_hook,
-        mock_status_hook,
+        mock_hook,
         user,
         incident,
         impact_type_tag,
@@ -217,14 +211,12 @@ class TestResolvedSubmission:
         client.chat_postMessage.assert_called_once()
         assert "Postmortem" in client.chat_postMessage.call_args[1]["text"]
 
-    @patch("firetower.incidents.serializers.on_status_changed")
-    @patch("firetower.incidents.serializers.on_title_changed")
+    @patch("firetower.incidents.serializers.on_incident_updated")
     @patch("firetower.slack_app.handlers.resolved.get_or_create_user_from_slack_id")
     def test_p4_goes_to_done(
         self,
         mock_get_user,
-        mock_title_hook,
-        mock_status_hook,
+        mock_hook,
         user,
         incident,
         impact_type_tag,
@@ -243,14 +235,12 @@ class TestResolvedSubmission:
         incident.refresh_from_db()
         assert incident.status == IncidentStatus.DONE
 
-    @patch("firetower.incidents.serializers.on_status_changed")
-    @patch("firetower.incidents.serializers.on_title_changed")
+    @patch("firetower.incidents.serializers.on_incident_updated")
     @patch("firetower.slack_app.handlers.resolved.get_or_create_user_from_slack_id")
     def test_saves_metadata_fields(
         self,
         mock_get_user,
-        mock_title_hook,
-        mock_status_hook,
+        mock_hook,
         user,
         incident,
         impact_type_tag,
@@ -324,14 +314,12 @@ class TestResolvedSubmission:
         assert call_kwargs["response_action"] == "errors"
         assert "impact_type_block" in call_kwargs["errors"]
 
-    @patch("firetower.incidents.serializers.on_status_changed")
-    @patch("firetower.incidents.serializers.on_title_changed")
+    @patch("firetower.incidents.serializers.on_incident_updated")
     @patch("firetower.slack_app.handlers.resolved.get_or_create_user_from_slack_id")
     def test_missing_service_tier_succeeds(
         self,
         mock_get_user,
-        mock_title_hook,
-        mock_status_hook,
+        mock_hook,
         user,
         incident,
         impact_type_tag,

--- a/src/firetower/slack_app/tests/handlers/test_severity.py
+++ b/src/firetower/slack_app/tests/handlers/test_severity.py
@@ -10,9 +10,8 @@ from .conftest import CHANNEL_ID
 
 @pytest.mark.django_db
 class TestSeverityCommand:
-    @patch("firetower.incidents.serializers.on_severity_changed")
-    @patch("firetower.incidents.serializers.on_title_changed")
-    def test_changes_severity(self, mock_title_hook, mock_sev_hook, incident):
+    @patch("firetower.incidents.serializers.on_incident_updated")
+    def test_changes_severity(self, mock_hook, incident):
         ack = MagicMock()
         body = {"channel_id": CHANNEL_ID}
         command = {"command": "/ft"}
@@ -42,7 +41,7 @@ class TestSeverityCommand:
         command = {"command": "/ft"}
         respond = MagicMock()
 
-        with patch("firetower.incidents.serializers.on_severity_changed"):
+        with patch("firetower.incidents.serializers.on_incident_updated"):
             handle_severity_command(ack, body, command, respond, new_severity="p1")
 
         incident.refresh_from_db()

--- a/src/firetower/slack_app/tests/handlers/test_subject.py
+++ b/src/firetower/slack_app/tests/handlers/test_subject.py
@@ -9,8 +9,8 @@ from .conftest import CHANNEL_ID
 
 @pytest.mark.django_db
 class TestSubjectCommand:
-    @patch("firetower.incidents.serializers.on_title_changed")
-    def test_updates_title(self, mock_title_hook, incident):
+    @patch("firetower.incidents.serializers.on_incident_updated")
+    def test_updates_title(self, mock_hook, incident):
         ack = MagicMock()
         body = {"channel_id": CHANNEL_ID}
         command = {"command": "/ft"}

--- a/src/firetower/slack_app/tests/handlers/test_update_incident.py
+++ b/src/firetower/slack_app/tests/handlers/test_update_incident.py
@@ -163,8 +163,8 @@ class TestUpdateIncidentModal:
 
 @pytest.mark.django_db
 class TestUpdateIncidentSubmission:
-    @patch("firetower.incidents.serializers.on_title_changed")
-    def test_updates_incident(self, mock_title_hook, incident):
+    @patch("firetower.incidents.serializers.on_incident_updated")
+    def test_updates_incident(self, mock_hook, incident):
         ack = MagicMock()
         client = MagicMock()
         body = {"user": {"id": "U_CAPTAIN"}}


### PR DESCRIPTION
When multiple incident fields change in a single update (e.g., resolving an incident sets status, severity, and captain at once), the bot previously posted a separate Slack message for each field change. This batches them into a single message with bullet points and adds attribution showing who triggered the change.

Before:
```
Incident status updated: Active -> Postmortem
View in Firetower

Incident severity updated: P2 -> P1
View in Firetower

Incident captain updated to @Richard Gibert
View in Firetower
```

After:
```
@Richard Gibert updated incident:
- Status: Active -> Postmortem
- Severity: P2 -> P1
- Captain: @Jane Doe
View in Firetower
```

The implementation adds `on_incident_updated` in hooks.py which the serializer calls instead of individual `on_*_changed` hooks. It gets the channel ID once, sets the topic once, posts one combined message, then runs all side effects (slack dump, paging, oncall invites, captain invite, linear sync). The existing individual hook functions are unchanged so their test suites keep passing.

For attribution, the serializer extracts the acting user from `request.user` (API path) or `context["acting_user"]` (Slack handler path). All 7 Slack handlers that update incidents via the serializer now resolve the acting Slack user and pass it through. When no actor is available, the message falls back to a generic "Incident updated:" header.

Visibility changes still get their own separate message since the format and intent are different from field updates.

Replaces https://github.com/getsentry/firetower/pull/229

Agent transcript: https://claudescope.sentry.dev/share/kREYIXj--jVtngyekmq5hT0FDq_enq1tmMQD7E_3wVI