### PR TITLE
Use templates for SLO nags

### DIFF
--- a/src/firetower/config.py
+++ b/src/firetower/config.py
@@ -77,8 +77,20 @@ class LinearConfig:
     project_id: str = ""
     sync_identifiers: bool = False
     api_key: str = ""
-    action_item_nag_comment_high_priority: str = ""
-    action_item_nag_comment_medium_priority: str = ""
+    action_item_nag_comment_high_priority: str = (
+        "{% if slo_passed %}This action item is **{{ days_past_due }} day(s) "
+        "past due**. {% endif %}"
+        "The SLO for completing P0/P1 incident action items is {{ slo_days }} "
+        "days from incident creation. Please prioritize this work or close "
+        "out the issue if it is no longer relevant."
+    )
+    action_item_nag_comment_medium_priority: str = (
+        "{% if slo_passed %}This action item is **{{ days_past_due }} day(s) "
+        "past due**. {% endif %}"
+        "The SLO for completing P2 incident action items is {{ slo_days }} "
+        "days from incident creation. Please prioritize this work or close "
+        "out the issue if it is no longer relevant."
+    )
 
 
 @deserialize

--- a/src/firetower/config.py
+++ b/src/firetower/config.py
@@ -77,6 +77,8 @@ class LinearConfig:
     project_id: str = ""
     sync_identifiers: bool = False
     api_key: str = ""
+    action_item_slo_days_high_priority: int = 14
+    action_item_slo_days_medium_priority: int = 30
     action_item_nag_comment_high_priority: str = (
         "{% if days_past_due > 0 %}This action item is **{{ days_past_due }} day(s) "
         "past due**. {% endif %}"

--- a/src/firetower/config.py
+++ b/src/firetower/config.py
@@ -78,14 +78,14 @@ class LinearConfig:
     sync_identifiers: bool = False
     api_key: str = ""
     action_item_nag_comment_high_priority: str = (
-        "{% if slo_passed %}This action item is **{{ days_past_due }} day(s) "
+        "{% if days_past_due > 0 %}This action item is **{{ days_past_due }} day(s) "
         "past due**. {% endif %}"
         "The SLO for completing P0/P1 incident action items is {{ slo_days }} "
         "days from incident creation. Please prioritize this work or close "
         "out the issue if it is no longer relevant."
     )
     action_item_nag_comment_medium_priority: str = (
-        "{% if slo_passed %}This action item is **{{ days_past_due }} day(s) "
+        "{% if days_past_due > 0 %}This action item is **{{ days_past_due }} day(s) "
         "past due**. {% endif %}"
         "The SLO for completing P2 incident action items is {{ slo_days }} "
         "days from incident creation. Please prioritize this work or close "

--- a/src/firetower/incidents/tasks/action_items.py
+++ b/src/firetower/incidents/tasks/action_items.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 
 from django.conf import settings
 from django.utils import timezone
+from jinja2 import Environment, TemplateError
 
 from firetower.incidents.hooks import HIGH_SEVERITIES
 from firetower.incidents.models import (
@@ -19,6 +20,18 @@ logger = logging.getLogger(__name__)
 
 ACTION_ITEM_REMINDER_MAX_AGE_DAYS = 90
 ACTION_ITEM_REMINDER_NAG_EVERY_DAYS = 7
+
+# Per-tier minimum incident age (in days) before we nag, and the settings.LINEAR
+# key holding the comment for that tier.
+# Linear priority values: 1 = Urgent (P0), 2 = High (P1), 3 = Medium (P2).
+ACTION_ITEM_NAG_TIERS: dict[int, tuple[int, str]] = {
+    1: (7, "ACTION_ITEM_NAG_COMMENT_HIGH_PRIORITY"),
+    2: (7, "ACTION_ITEM_NAG_COMMENT_HIGH_PRIORITY"),
+    3: (21, "ACTION_ITEM_NAG_COMMENT_MEDIUM_PRIORITY"),
+}
+ACTION_ITEM_REMINDER_PRIORITIES = tuple(ACTION_ITEM_NAG_TIERS.keys())
+
+_NAG_TEMPLATE_ENV = Environment(autoescape=False)
 
 # Per-tier minimum incident age (in days) before we nag, and the settings.LINEAR
 # key holding the comment for that tier.
@@ -69,8 +82,25 @@ def send_action_item_reminder() -> None:
             now - timedelta(days=ACTION_ITEM_REMINDER_NAG_EVERY_DAYS)
         )
 
-    def _nag(action_item: ActionItem) -> None:
-        comment = comments_by_priority[action_item.priority]
+    def _nag(action_item: ActionItem, incident: Incident) -> None:
+        template_source = comments_by_priority[action_item.priority]
+        tier_min_age_days, _ = ACTION_ITEM_NAG_TIERS[action_item.priority]
+        incident_age_days = (timezone.now() - incident.created_at).days
+        try:
+            comment = _NAG_TEMPLATE_ENV.from_string(template_source).render(
+                slo_days=tier_min_age_days,
+                incident_age_days=incident_age_days,
+                days_past_due=max(0, incident_age_days - tier_min_age_days),
+                days_left=max(0, tier_min_age_days - incident_age_days),
+                slo_passed=incident_age_days >= tier_min_age_days,
+                action_item=action_item,
+                incident=incident,
+            )
+        except TemplateError:
+            logger.exception(
+                f"Failed to render nag comment template for action item {action_item.linear_identifier}"
+            )
+            return
         try:
             success = LinearService().create_comment(
                 action_item.linear_issue_id, comment
@@ -110,4 +140,4 @@ def send_action_item_reminder() -> None:
         ]
 
         for action_item in eligible:
-            _nag(action_item)
+            _nag(action_item, incident)

--- a/src/firetower/incidents/tasks/action_items.py
+++ b/src/firetower/incidents/tasks/action_items.py
@@ -1,4 +1,5 @@
 import logging
+from dataclasses import dataclass
 from datetime import timedelta
 
 from django.conf import settings
@@ -21,46 +22,54 @@ logger = logging.getLogger(__name__)
 ACTION_ITEM_REMINDER_MAX_AGE_DAYS = 90
 ACTION_ITEM_REMINDER_NAG_EVERY_DAYS = 7
 
-# Per-tier minimum incident age (in days) before we nag, and the settings.LINEAR
-# key holding the comment for that tier.
+
 # Linear priority values: 1 = Urgent (P0), 2 = High (P1), 3 = Medium (P2).
-ACTION_ITEM_NAG_TIERS: dict[int, tuple[int, str]] = {
-    1: (7, "ACTION_ITEM_NAG_COMMENT_HIGH_PRIORITY"),
-    2: (7, "ACTION_ITEM_NAG_COMMENT_HIGH_PRIORITY"),
-    3: (21, "ACTION_ITEM_NAG_COMMENT_MEDIUM_PRIORITY"),
+@dataclass(frozen=True)
+class NagTier:
+    notify_after_days: int
+    slo_days: int
+    comment_setting_key: str
+
+
+ACTION_ITEM_NAG_TIERS: dict[int, NagTier] = {
+    1: NagTier(
+        notify_after_days=7,
+        slo_days=14,
+        comment_setting_key="ACTION_ITEM_NAG_COMMENT_HIGH_PRIORITY",
+    ),
+    2: NagTier(
+        notify_after_days=7,
+        slo_days=14,
+        comment_setting_key="ACTION_ITEM_NAG_COMMENT_HIGH_PRIORITY",
+    ),
+    3: NagTier(
+        notify_after_days=23,
+        slo_days=30,
+        comment_setting_key="ACTION_ITEM_NAG_COMMENT_MEDIUM_PRIORITY",
+    ),
 }
 ACTION_ITEM_REMINDER_PRIORITIES = tuple(ACTION_ITEM_NAG_TIERS.keys())
 
 _NAG_TEMPLATE_ENV = Environment(autoescape=False)
-
-# Per-tier minimum incident age (in days) before we nag, and the settings.LINEAR
-# key holding the comment for that tier.
-# Linear priority values: 1 = Urgent (P0), 2 = High (P1), 3 = Medium (P2).
-ACTION_ITEM_NAG_TIERS: dict[int, tuple[int, str]] = {
-    1: (7, "ACTION_ITEM_NAG_COMMENT_HIGH_PRIORITY"),
-    2: (7, "ACTION_ITEM_NAG_COMMENT_HIGH_PRIORITY"),
-    3: (21, "ACTION_ITEM_NAG_COMMENT_MEDIUM_PRIORITY"),
-}
-ACTION_ITEM_REMINDER_PRIORITIES = tuple(ACTION_ITEM_NAG_TIERS.keys())
 
 
 @datadog_log
 def send_action_item_reminder() -> None:
     linear = settings.LINEAR or {}
     comments_by_priority: dict[int, str] = {
-        priority: linear.get(setting_key, "")
-        for priority, (_, setting_key) in ACTION_ITEM_NAG_TIERS.items()
+        priority: linear.get(tier.comment_setting_key, "")
+        for priority, tier in ACTION_ITEM_NAG_TIERS.items()
     }
     if not any(comments_by_priority.values()):
         logger.warning("No Linear nag comments configured, skipping job")
         return
 
     now = timezone.now()
-    earliest_min_age_days = min(
-        min_age for min_age, _ in ACTION_ITEM_NAG_TIERS.values()
+    earliest_notify_after_days = min(
+        tier.notify_after_days for tier in ACTION_ITEM_NAG_TIERS.values()
     )
     min_age = now - timedelta(days=ACTION_ITEM_REMINDER_MAX_AGE_DAYS)
-    max_age = now - timedelta(days=earliest_min_age_days)
+    max_age = now - timedelta(days=earliest_notify_after_days)
 
     def _action_item_eligible(action_item: ActionItem, incident: Incident) -> bool:
         if action_item.status not in [
@@ -71,10 +80,9 @@ def send_action_item_reminder() -> None:
         tier = ACTION_ITEM_NAG_TIERS.get(action_item.priority)
         if not tier:
             return False
-        tier_min_age_days, _ = tier
         if not comments_by_priority.get(action_item.priority):
             return False
-        if incident.created_at > now - timedelta(days=tier_min_age_days):
+        if incident.created_at > now - timedelta(days=tier.notify_after_days):
             return False
         if action_item.last_nag is None:
             return True
@@ -84,15 +92,15 @@ def send_action_item_reminder() -> None:
 
     def _nag(action_item: ActionItem, incident: Incident) -> None:
         template_source = comments_by_priority[action_item.priority]
-        tier_min_age_days, _ = ACTION_ITEM_NAG_TIERS[action_item.priority]
+        tier = ACTION_ITEM_NAG_TIERS[action_item.priority]
         incident_age_days = (timezone.now() - incident.created_at).days
         try:
             comment = _NAG_TEMPLATE_ENV.from_string(template_source).render(
-                slo_days=tier_min_age_days,
+                slo_days=tier.slo_days,
                 incident_age_days=incident_age_days,
-                days_past_due=max(0, incident_age_days - tier_min_age_days),
-                days_left=max(0, tier_min_age_days - incident_age_days),
-                slo_passed=incident_age_days >= tier_min_age_days,
+                days_past_due=max(0, incident_age_days - tier.slo_days),
+                days_left=max(0, tier.slo_days - incident_age_days),
+                slo_passed=incident_age_days >= tier.slo_days,
                 action_item=action_item,
                 incident=incident,
             )

--- a/src/firetower/incidents/tasks/action_items.py
+++ b/src/firetower/incidents/tasks/action_items.py
@@ -36,18 +36,35 @@ class NagTier:
 
 
 def _build_nag_tiers(linear: dict) -> dict[int, NagTier]:
-    high_tier = NagTier(
-        slo_days=linear.get("ACTION_ITEM_SLO_DAYS_HIGH_PRIORITY", 14),
-        comment_setting_key="ACTION_ITEM_NAG_COMMENT_HIGH_PRIORITY",
-    )
-    medium_tier = NagTier(
-        slo_days=linear.get("ACTION_ITEM_SLO_DAYS_MEDIUM_PRIORITY", 30),
-        comment_setting_key="ACTION_ITEM_NAG_COMMENT_MEDIUM_PRIORITY",
-    )
-    return {
-        **dict.fromkeys(HIGH_PRIORITY_VALUES, high_tier),
-        **dict.fromkeys(MEDIUM_PRIORITY_VALUES, medium_tier),
-    }
+    candidates: list[tuple[tuple[int, ...], NagTier]] = [
+        (
+            HIGH_PRIORITY_VALUES,
+            NagTier(
+                slo_days=linear.get("ACTION_ITEM_SLO_DAYS_HIGH_PRIORITY", 14),
+                comment_setting_key="ACTION_ITEM_NAG_COMMENT_HIGH_PRIORITY",
+            ),
+        ),
+        (
+            MEDIUM_PRIORITY_VALUES,
+            NagTier(
+                slo_days=linear.get("ACTION_ITEM_SLO_DAYS_MEDIUM_PRIORITY", 30),
+                comment_setting_key="ACTION_ITEM_NAG_COMMENT_MEDIUM_PRIORITY",
+            ),
+        ),
+    ]
+    tiers: dict[int, NagTier] = {}
+    for priorities, tier in candidates:
+        if tier.slo_days < ACTION_ITEM_REMINDER_NAG_EVERY_DAYS:
+            logger.warning(
+                "Skipping %s nag tier: configured SLO of %d day(s) is below "
+                "the %d-day nag cadence",
+                tier.comment_setting_key,
+                tier.slo_days,
+                ACTION_ITEM_REMINDER_NAG_EVERY_DAYS,
+            )
+            continue
+        tiers.update(dict.fromkeys(priorities, tier))
+    return tiers
 
 
 _NAG_TEMPLATE_ENV = Environment(autoescape=False)

--- a/src/firetower/incidents/tasks/action_items.py
+++ b/src/firetower/incidents/tasks/action_items.py
@@ -24,31 +24,31 @@ ACTION_ITEM_REMINDER_NAG_EVERY_DAYS = 7
 
 
 # Linear priority values: 1 = Urgent (P0), 2 = High (P1), 3 = Medium (P2).
+HIGH_PRIORITY_VALUES = (1, 2)
+MEDIUM_PRIORITY_VALUES = (3,)
+ACTION_ITEM_REMINDER_PRIORITIES = HIGH_PRIORITY_VALUES + MEDIUM_PRIORITY_VALUES
+
+
 @dataclass(frozen=True)
 class NagTier:
-    notify_after_days: int
     slo_days: int
     comment_setting_key: str
 
 
-ACTION_ITEM_NAG_TIERS: dict[int, NagTier] = {
-    1: NagTier(
-        notify_after_days=7,
-        slo_days=14,
+def _build_nag_tiers(linear: dict) -> dict[int, NagTier]:
+    high_tier = NagTier(
+        slo_days=linear.get("ACTION_ITEM_SLO_DAYS_HIGH_PRIORITY", 14),
         comment_setting_key="ACTION_ITEM_NAG_COMMENT_HIGH_PRIORITY",
-    ),
-    2: NagTier(
-        notify_after_days=7,
-        slo_days=14,
-        comment_setting_key="ACTION_ITEM_NAG_COMMENT_HIGH_PRIORITY",
-    ),
-    3: NagTier(
-        notify_after_days=23,
-        slo_days=30,
+    )
+    medium_tier = NagTier(
+        slo_days=linear.get("ACTION_ITEM_SLO_DAYS_MEDIUM_PRIORITY", 30),
         comment_setting_key="ACTION_ITEM_NAG_COMMENT_MEDIUM_PRIORITY",
-    ),
-}
-ACTION_ITEM_REMINDER_PRIORITIES = tuple(ACTION_ITEM_NAG_TIERS.keys())
+    )
+    return {
+        **dict.fromkeys(HIGH_PRIORITY_VALUES, high_tier),
+        **dict.fromkeys(MEDIUM_PRIORITY_VALUES, medium_tier),
+    }
+
 
 _NAG_TEMPLATE_ENV = Environment(autoescape=False)
 
@@ -56,17 +56,19 @@ _NAG_TEMPLATE_ENV = Environment(autoescape=False)
 @datadog_log
 def send_action_item_reminder() -> None:
     linear = settings.LINEAR or {}
+    nag_tiers = _build_nag_tiers(linear)
     comments_by_priority: dict[int, str] = {
         priority: linear.get(tier.comment_setting_key, "")
-        for priority, tier in ACTION_ITEM_NAG_TIERS.items()
+        for priority, tier in nag_tiers.items()
     }
     if not any(comments_by_priority.values()):
         logger.warning("No Linear nag comments configured, skipping job")
         return
 
     now = timezone.now()
-    earliest_notify_after_days = min(
-        tier.notify_after_days for tier in ACTION_ITEM_NAG_TIERS.values()
+    earliest_notify_after_days = (
+        min(tier.slo_days for tier in nag_tiers.values())
+        - ACTION_ITEM_REMINDER_NAG_EVERY_DAYS
     )
     min_age = now - timedelta(days=ACTION_ITEM_REMINDER_MAX_AGE_DAYS)
     max_age = now - timedelta(days=earliest_notify_after_days)
@@ -77,12 +79,13 @@ def send_action_item_reminder() -> None:
             ActionItemStatus.IN_PROGRESS,
         ]:
             return False
-        tier = ACTION_ITEM_NAG_TIERS.get(action_item.priority)
+        tier = nag_tiers.get(action_item.priority)
         if not tier:
             return False
         if not comments_by_priority.get(action_item.priority):
             return False
-        if incident.created_at > now - timedelta(days=tier.notify_after_days):
+        notify_after_days = tier.slo_days - ACTION_ITEM_REMINDER_NAG_EVERY_DAYS
+        if incident.created_at > now - timedelta(days=notify_after_days):
             return False
         if action_item.last_nag is None:
             return True
@@ -92,7 +95,7 @@ def send_action_item_reminder() -> None:
 
     def _nag(action_item: ActionItem, incident: Incident) -> None:
         template_source = comments_by_priority[action_item.priority]
-        tier = ACTION_ITEM_NAG_TIERS[action_item.priority]
+        tier = nag_tiers[action_item.priority]
         incident_age_days = (timezone.now() - incident.created_at).days
         try:
             comment = _NAG_TEMPLATE_ENV.from_string(template_source).render(

--- a/src/firetower/incidents/tests/test_tasks.py
+++ b/src/firetower/incidents/tests/test_tasks.py
@@ -1050,7 +1050,7 @@ class TestSendActionItemReminder:
             send_action_item_reminder()
 
         expected = (
-            f"SLO=7 age=10 past=3 left=0 passed=True "
+            f"SLO=14 age=10 past=0 left=4 passed=False "
             f"id={action_item.linear_identifier} title=Some outage"
         )
         mock_linear.create_comment.assert_called_once_with(
@@ -1062,13 +1062,13 @@ class TestSendActionItemReminder:
         with patch.dict(
             settings.LINEAR, {"ACTION_ITEM_NAG_COMMENT_MEDIUM_PRIORITY": template}
         ):
-            incident = self._make_incident(days_old=30)
+            incident = self._make_incident(days_old=35)
             action_item = self._make_action_item(incident, priority=3)
 
             send_action_item_reminder()
 
         mock_linear.create_comment.assert_called_once_with(
-            action_item.linear_issue_id, "SLO=21 past=9"
+            action_item.linear_issue_id, "SLO=30 past=5"
         )
 
     def test_skips_when_template_has_syntax_error(self, mock_linear):

--- a/src/firetower/incidents/tests/test_tasks.py
+++ b/src/firetower/incidents/tests/test_tasks.py
@@ -1033,3 +1033,54 @@ class TestSendActionItemReminder:
         mock_linear.create_comment.assert_called_once_with(
             action_item.linear_issue_id, self.CONFIGURED_HIGH_PRIORITY_COMMENT
         )
+
+    def test_renders_template_variables(self, mock_linear):
+        template = (
+            "SLO={{ slo_days }} age={{ incident_age_days }} "
+            "past={{ days_past_due }} left={{ days_left }} "
+            "passed={{ slo_passed }} id={{ action_item.linear_identifier }} "
+            "title={{ incident.title }}"
+        )
+        with patch.dict(
+            settings.LINEAR, {"ACTION_ITEM_NAG_COMMENT_HIGH_PRIORITY": template}
+        ):
+            incident = self._make_incident(days_old=10, title="Some outage")
+            action_item = self._make_action_item(incident, priority=1)
+
+            send_action_item_reminder()
+
+        expected = (
+            f"SLO=7 age=10 past=3 left=0 passed=True "
+            f"id={action_item.linear_identifier} title=Some outage"
+        )
+        mock_linear.create_comment.assert_called_once_with(
+            action_item.linear_issue_id, expected
+        )
+
+    def test_renders_medium_tier_variables(self, mock_linear):
+        template = "SLO={{ slo_days }} past={{ days_past_due }}"
+        with patch.dict(
+            settings.LINEAR, {"ACTION_ITEM_NAG_COMMENT_MEDIUM_PRIORITY": template}
+        ):
+            incident = self._make_incident(days_old=30)
+            action_item = self._make_action_item(incident, priority=3)
+
+            send_action_item_reminder()
+
+        mock_linear.create_comment.assert_called_once_with(
+            action_item.linear_issue_id, "SLO=21 past=9"
+        )
+
+    def test_skips_when_template_has_syntax_error(self, mock_linear):
+        with patch.dict(
+            settings.LINEAR,
+            {"ACTION_ITEM_NAG_COMMENT_HIGH_PRIORITY": "{{ unterminated "},
+        ):
+            incident = self._make_incident()
+            action_item = self._make_action_item(incident, priority=1)
+
+            send_action_item_reminder()
+
+        mock_linear.create_comment.assert_not_called()
+        action_item.refresh_from_db()
+        assert action_item.last_nag is None

--- a/src/firetower/settings.py
+++ b/src/firetower/settings.py
@@ -313,6 +313,8 @@ LINEAR: dict | None = (
         "TEAM_ID": config.linear.team_id,
         "PROJECT_ID": config.linear.project_id,
         "SYNC_IDENTIFIERS": config.linear.sync_identifiers,
+        "ACTION_ITEM_SLO_DAYS_HIGH_PRIORITY": config.linear.action_item_slo_days_high_priority,
+        "ACTION_ITEM_SLO_DAYS_MEDIUM_PRIORITY": config.linear.action_item_slo_days_medium_priority,
         "ACTION_ITEM_NAG_COMMENT_HIGH_PRIORITY": config.linear.action_item_nag_comment_high_priority,
         "ACTION_ITEM_NAG_COMMENT_MEDIUM_PRIORITY": config.linear.action_item_nag_comment_medium_priority,
     }


### PR DESCRIPTION
This allows us to have more descriptive and reactive messages. I'm also setting a more sensible default in the code, but it can be overwritten in the settings.

Stack on https://github.com/getsentry/firetower/pull/240