### PR TITLE
send nag notifications over slack

### DIFF
--- a/src/firetower/incidents/tasks/action_items.py
+++ b/src/firetower/incidents/tasks/action_items.py
@@ -151,13 +151,14 @@ def send_action_item_reminder() -> None:
         template_source = comments_by_priority[action_item.priority]
         tier = nag_tiers[action_item.priority]
         incident_age_days = (timezone.now() - incident.created_at).days
+        slo_passed = incident_age_days >= tier.slo_days
         try:
             comment = _NAG_TEMPLATE_ENV.from_string(template_source).render(
                 slo_days=tier.slo_days,
                 incident_age_days=incident_age_days,
                 days_past_due=max(0, incident_age_days - tier.slo_days),
                 days_left=max(0, tier.slo_days - incident_age_days),
-                slo_passed=incident_age_days >= tier.slo_days,
+                slo_passed=slo_passed,
                 action_item=action_item,
                 incident=incident,
             )
@@ -178,7 +179,8 @@ def send_action_item_reminder() -> None:
         if not success:
             return
 
-        _send_slack_nag_dm(action_item, incident, comment)
+        if slo_passed:
+            _send_slack_nag_dm(action_item, incident, comment)
 
         action_item.last_nag = timezone.now()
         action_item.save(update_fields=["last_nag"])

--- a/src/firetower/incidents/tasks/action_items.py
+++ b/src/firetower/incidents/tasks/action_items.py
@@ -17,7 +17,7 @@ from firetower.incidents.models import (
 from firetower.incidents.services import sync_action_items_from_linear
 from firetower.incidents.tasks.decorators import datadog_log
 from firetower.integrations.services.linear import LinearService
-from firetower.integrations.services.slack import SlackService
+from firetower.integrations.services.slack import SlackService, escape_slack_text
 
 logger = logging.getLogger(__name__)
 
@@ -136,7 +136,7 @@ def send_action_item_reminder() -> None:
 
         slack_message = (
             f"<{action_item.url}|{action_item.linear_identifier}>: "
-            f"{action_item.title}\n\n{message}"
+            f"{escape_slack_text(action_item.title)}\n\n{message}"
         )
 
         try:

--- a/src/firetower/incidents/tasks/action_items.py
+++ b/src/firetower/incidents/tasks/action_items.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.utils import timezone
 from jinja2 import Environment, TemplateError
 
+from firetower.auth.models import ExternalProfileType
 from firetower.incidents.hooks import HIGH_SEVERITIES
 from firetower.incidents.models import (
     ActionItem,
@@ -16,6 +17,7 @@ from firetower.incidents.models import (
 from firetower.incidents.services import sync_action_items_from_linear
 from firetower.incidents.tasks.decorators import datadog_log
 from firetower.integrations.services.linear import LinearService
+from firetower.integrations.services.slack import SlackService
 
 logger = logging.getLogger(__name__)
 
@@ -110,6 +112,41 @@ def send_action_item_reminder() -> None:
             now - timedelta(days=ACTION_ITEM_REMINDER_NAG_EVERY_DAYS)
         )
 
+    def _send_slack_nag_dm(
+        action_item: ActionItem, incident: Incident, message: str
+    ) -> None:
+        recipient = action_item.assignee or incident.captain
+        if recipient is None:
+            logger.info(
+                "No assignee or captain for action item %s, skipping Slack DM",
+                action_item.linear_identifier,
+            )
+            return
+
+        profile = recipient.external_profiles.filter(
+            type=ExternalProfileType.SLACK
+        ).first()
+        if profile is None:
+            logger.info(
+                "No Slack profile for user %s, skipping DM for action item %s",
+                recipient.email or recipient.username,
+                action_item.linear_identifier,
+            )
+            return
+
+        slack_message = (
+            f"<{action_item.url}|{action_item.linear_identifier}>: "
+            f"{action_item.title}\n\n{message}"
+        )
+
+        try:
+            SlackService().post_message(profile.external_id, slack_message)
+        except Exception:
+            logger.exception(
+                "Failed to send Slack nag DM for action item %s",
+                action_item.linear_identifier,
+            )
+
     def _nag(action_item: ActionItem, incident: Incident) -> None:
         template_source = comments_by_priority[action_item.priority]
         tier = nag_tiers[action_item.priority]
@@ -138,9 +175,13 @@ def send_action_item_reminder() -> None:
                 f"Failed to post nag comment for action item {action_item.linear_identifier}"
             )
             return
-        if success:
-            action_item.last_nag = timezone.now()
-            action_item.save(update_fields=["last_nag"])
+        if not success:
+            return
+
+        _send_slack_nag_dm(action_item, incident, comment)
+
+        action_item.last_nag = timezone.now()
+        action_item.save(update_fields=["last_nag"])
 
     incidents = Incident.objects.filter(
         created_at__gte=min_age,

--- a/src/firetower/incidents/tests/test_tasks.py
+++ b/src/firetower/incidents/tests/test_tasks.py
@@ -826,6 +826,23 @@ class TestSendActionItemReminder:
         ):
             yield mock
 
+    @pytest.fixture(autouse=True)
+    def mock_slack(self):
+        mock = MagicMock()
+        mock.post_message.return_value = "1.0"
+        with patch("firetower.incidents.tasks.SlackService", return_value=mock):
+            yield mock
+
+    def _make_user(self, name: str, slack_id: str | None = None) -> User:
+        user = User.objects.create_user(username=name, email=f"{name}@example.com")
+        if slack_id is not None:
+            ExternalProfile.objects.create(
+                user=user,
+                type=ExternalProfileType.SLACK,
+                external_id=slack_id,
+            )
+        return user
+
     def _make_incident(self, days_old: int = 45, **kwargs) -> Incident:
         defaults = {
             "title": "Test Incident",
@@ -1084,3 +1101,58 @@ class TestSendActionItemReminder:
         mock_linear.create_comment.assert_not_called()
         action_item.refresh_from_db()
         assert action_item.last_nag is None
+
+    def test_dms_assignee_when_action_item_owned(self, mock_linear, mock_slack):
+        assignee = self._make_user("alice", slack_id="U_ALICE")
+        captain = self._make_user("bob", slack_id="U_BOB")
+        incident = self._make_incident(captain=captain)
+        action_item = self._make_action_item(incident, assignee=assignee)
+
+        send_action_item_reminder()
+
+        expected = (
+            f"<{action_item.url}|{action_item.linear_identifier}>: "
+            f"{action_item.title}\n\n{self.CONFIGURED_HIGH_PRIORITY_COMMENT}"
+        )
+        mock_slack.post_message.assert_called_once_with("U_ALICE", expected)
+
+    def test_dms_captain_when_action_item_unowned(self, mock_linear, mock_slack):
+        captain = self._make_user("bob", slack_id="U_BOB")
+        incident = self._make_incident(captain=captain)
+        action_item = self._make_action_item(incident)
+
+        send_action_item_reminder()
+
+        expected = (
+            f"<{action_item.url}|{action_item.linear_identifier}>: "
+            f"{action_item.title}\n\n{self.CONFIGURED_HIGH_PRIORITY_COMMENT}"
+        )
+        mock_slack.post_message.assert_called_once_with("U_BOB", expected)
+
+    def test_no_dm_when_no_assignee_and_no_captain(self, mock_linear, mock_slack):
+        incident = self._make_incident()
+        self._make_action_item(incident)
+
+        send_action_item_reminder()
+
+        mock_slack.post_message.assert_not_called()
+
+    def test_no_dm_when_recipient_has_no_slack_profile(self, mock_linear, mock_slack):
+        assignee = self._make_user("alice")
+        incident = self._make_incident()
+        self._make_action_item(incident, assignee=assignee)
+
+        send_action_item_reminder()
+
+        mock_slack.post_message.assert_not_called()
+
+    def test_slack_failure_does_not_block_last_nag(self, mock_linear, mock_slack):
+        assignee = self._make_user("alice", slack_id="U_ALICE")
+        incident = self._make_incident()
+        action_item = self._make_action_item(incident, assignee=assignee)
+        mock_slack.post_message.side_effect = RuntimeError("slack down")
+
+        send_action_item_reminder()
+
+        action_item.refresh_from_db()
+        assert action_item.last_nag is not None

--- a/src/firetower/incidents/tests/test_tasks.py
+++ b/src/firetower/incidents/tests/test_tasks.py
@@ -830,7 +830,10 @@ class TestSendActionItemReminder:
     def mock_slack(self):
         mock = MagicMock()
         mock.post_message.return_value = "1.0"
-        with patch("firetower.incidents.tasks.SlackService", return_value=mock):
+        with patch(
+            "firetower.incidents.tasks.action_items.SlackService",
+            return_value=mock,
+        ):
             yield mock
 
     def _make_user(self, name: str, slack_id: str | None = None) -> User:


### PR DESCRIPTION
Sends Slack DM nags when an action item is overdue, in addition to commenting on the action item.

This is a stacked PR on https://github.com/getsentry/firetower/pull/235, the merge into feat/slo-nag-template is just for reviewer clarity.

# Test & Deploy Plan
- [x] Remove config keys from test config so it uses defaults
- [x] Push to test with an overdue action item, observe that it works
- [x] Unstack PR and rebase before land!!!
- [ ] Once Deployed, remove config keys from prod config

<img width="1453" height="546" alt="image" src="https://github.com/user-attachments/assets/fc717c2f-7546-437a-af81-d112ef0bbbd3" />
