### PR TITLE
fix(incidents): Correct _get_slack_user_id references to get_slack_user_id

### DIFF
--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -1474,7 +1474,7 @@ def on_incident_updated(
         lines.append(f"- Severity: {old_severity} -> {incident.severity}")
 
     if captain_changed and incident.captain is not None:
-        slack_id = _get_slack_user_id(incident.captain)
+        slack_id = get_slack_user_id(incident.captain)
         if slack_id:
             captain_ref = f"<@{slack_id}>"
         else:
@@ -1486,7 +1486,7 @@ def on_incident_updated(
     if lines and channel_id:
         # Build header
         if actor and actor.is_authenticated:
-            actor_slack_id = _get_slack_user_id(actor)
+            actor_slack_id = get_slack_user_id(actor)
             if actor_slack_id:
                 header = f"<@{actor_slack_id}> updated incident:"
             else:
@@ -1603,7 +1603,7 @@ def on_incident_updated(
             try:
                 status_channel_id = _get_status_channel_id(incident)
                 if status_channel_id:
-                    slack_id = _get_slack_user_id(incident.captain)
+                    slack_id = get_slack_user_id(incident.captain)
                     _invite_user_to_channel(
                         status_channel_id, incident.captain, slack_user_id=slack_id
                     )

--- a/src/firetower/slack_app/tests/handlers/test_cancel.py
+++ b/src/firetower/slack_app/tests/handlers/test_cancel.py
@@ -29,10 +29,9 @@ class TestCancelCommand:
         assert view["private_metadata"] == CHANNEL_ID
 
     @patch("firetower.slack_app.bolt.get_bolt_app")
-    @patch("firetower.incidents.serializers.on_status_changed")
-    @patch("firetower.incidents.serializers.on_title_changed")
+    @patch("firetower.incidents.serializers.on_incident_updated")
     def test_already_canceled_does_not_open_modal(
-        self, mock_title_hook, mock_status_hook, mock_get_bolt_app, incident
+        self, mock_updated_hook, mock_get_bolt_app, incident
     ):
         incident.status = IncidentStatus.CANCELED
         incident.save()
@@ -63,9 +62,8 @@ class TestCancelCommand:
 
 @pytest.mark.django_db
 class TestCancelSubmission:
-    @patch("firetower.incidents.serializers.on_status_changed")
-    @patch("firetower.incidents.serializers.on_title_changed")
-    def test_transitions_to_canceled(self, mock_title_hook, mock_status_hook, incident):
+    @patch("firetower.incidents.serializers.on_incident_updated")
+    def test_transitions_to_canceled(self, mock_updated_hook, incident):
         ack = MagicMock()
         client = MagicMock()
         body = {"user": {"id": "U_CAPTAIN"}}
@@ -112,11 +110,8 @@ class TestCancelSubmission:
         assert incident.status != IncidentStatus.CANCELED
         client.chat_postMessage.assert_not_called()
 
-    @patch("firetower.incidents.serializers.on_status_changed")
-    @patch("firetower.incidents.serializers.on_title_changed")
-    def test_already_canceled_is_noop(
-        self, mock_title_hook, mock_status_hook, incident
-    ):
+    @patch("firetower.incidents.serializers.on_incident_updated")
+    def test_already_canceled_is_noop(self, mock_updated_hook, incident):
         incident.status = IncidentStatus.CANCELED
         incident.save()
 
@@ -139,11 +134,10 @@ class TestCancelSubmission:
         assert incident.status == IncidentStatus.CANCELED
         client.chat_postMessage.assert_not_called()
 
-    @patch("firetower.incidents.serializers.on_status_changed")
-    @patch("firetower.incidents.serializers.on_title_changed")
+    @patch("firetower.incidents.serializers.on_incident_updated")
     @patch("firetower.slack_app.handlers.cancel.IncidentWriteSerializer")
     def test_invalid_serializer_posts_failure(
-        self, mock_serializer_cls, mock_title_hook, mock_status_hook, incident
+        self, mock_serializer_cls, mock_updated_hook, incident
     ):
         serializer = mock_serializer_cls.return_value
         serializer.is_valid.return_value = False

--- a/src/firetower/slack_app/tests/handlers/test_mitigated.py
+++ b/src/firetower/slack_app/tests/handlers/test_mitigated.py
@@ -263,14 +263,12 @@ class TestMitigatedSubmission:
         assert incident.status == IncidentStatus.MITIGATED
         assert incident.service_tier is None
 
-    @patch("firetower.incidents.serializers.on_status_changed")
-    @patch("firetower.incidents.serializers.on_title_changed")
+    @patch("firetower.incidents.serializers.on_incident_updated")
     @patch("firetower.slack_app.handlers.mitigated.get_or_create_user_from_slack_id")
     def test_missing_description_succeeds(
         self,
         mock_get_user,
-        mock_title_hook,
-        mock_status_hook,
+        mock_updated_hook,
         user,
         incident,
         impact_type_tag,
@@ -303,14 +301,12 @@ class TestMitigatedSubmission:
         assert call_kwargs["response_action"] == "errors"
         assert "impact_summary_block" in call_kwargs["errors"]
 
-    @patch("firetower.incidents.serializers.on_status_changed")
-    @patch("firetower.incidents.serializers.on_title_changed")
+    @patch("firetower.incidents.serializers.on_incident_updated")
     @patch("firetower.slack_app.handlers.mitigated.get_or_create_user_from_slack_id")
     def test_whitespace_only_description_succeeds(
         self,
         mock_get_user,
-        mock_title_hook,
-        mock_status_hook,
+        mock_updated_hook,
         user,
         incident,
         impact_type_tag,

--- a/src/firetower/slack_app/tests/handlers/test_resolved.py
+++ b/src/firetower/slack_app/tests/handlers/test_resolved.py
@@ -279,14 +279,12 @@ class TestResolvedSubmission:
         assert call_kwargs["response_action"] == "errors"
         assert "captain_block" in call_kwargs["errors"]
 
-    @patch("firetower.incidents.serializers.on_status_changed")
-    @patch("firetower.incidents.serializers.on_title_changed")
+    @patch("firetower.incidents.serializers.on_incident_updated")
     @patch("firetower.slack_app.handlers.resolved.get_or_create_user_from_slack_id")
     def test_missing_description_succeeds(
         self,
         mock_get_user,
-        mock_title_hook,
-        mock_status_hook,
+        mock_updated_hook,
         user,
         incident,
         impact_type_tag,


### PR DESCRIPTION
Commit c6cc82f introduced three calls to `_get_slack_user_id` (with underscore prefix) in `on_incident_updated`, but the function is defined as `get_slack_user_id`. This causes a `NameError` at runtime when incidents are reopened or updated via Slack.

Fixes all three call sites at lines 1477, 1489, and 1606 of `src/firetower/incidents/hooks.py`.