### PR TITLE
ref(incidents): Split tasks.py into a package

### DIFF
--- a/src/firetower/incidents/tasks/__init__.py
+++ b/src/firetower/incidents/tasks/__init__.py
@@ -1,10 +1,6 @@
-import functools
 import logging
-import re
 from datetime import datetime, timedelta
-from typing import Any, Protocol
 
-from datadog import statsd
 from django.conf import settings
 from django.utils import timezone
 from django_q.tasks import Schedule
@@ -17,15 +13,25 @@ from firetower.incidents.hooks import (
     get_statuspage_initial_reminder_delay_minutes,
 )
 from firetower.incidents.models import (
-    ActionItem,
-    ActionItemStatus,
     ExternalLinkType,
     Incident,
-    IncidentStatus,
 )
-from firetower.incidents.services import sync_action_items_from_linear
-from firetower.integrations.services.linear import LinearService
+from firetower.incidents.tasks.action_items import send_action_item_reminder
+from firetower.incidents.tasks.decorators import datadog_log
 from firetower.integrations.services.slack import SlackService
+
+__all__ = [
+    "SCHEDULES",
+    "STATUSPAGE_FOLLOWUP_REMINDER_MESSAGE",
+    "STATUSPAGE_REMINDER_MESSAGE",
+    "datadog_log",
+    "schedule_demo",
+    "send_action_item_reminder",
+    "send_statuspage_followup_reminder",
+    "send_statuspage_reminder",
+]
+
+logger = logging.getLogger(__name__)
 
 SCHEDULES = {
     "schedule_demo": {
@@ -41,51 +47,6 @@ SCHEDULES = {
         "repeats": -1,
     },
 }
-
-ACTION_ITEM_REMINDER_MAX_AGE_DAYS = 90
-ACTION_ITEM_REMINDER_NAG_EVERY_DAYS = 7
-
-# Per-tier minimum incident age (in days) before we nag, and the settings.LINEAR
-# key holding the comment for that tier.
-# Linear priority values: 1 = Urgent (P0), 2 = High (P1), 3 = Medium (P2).
-ACTION_ITEM_NAG_TIERS: dict[int, tuple[int, str]] = {
-    1: (7, "ACTION_ITEM_NAG_COMMENT_HIGH_PRIORITY"),
-    2: (7, "ACTION_ITEM_NAG_COMMENT_HIGH_PRIORITY"),
-    3: (21, "ACTION_ITEM_NAG_COMMENT_MEDIUM_PRIORITY"),
-}
-ACTION_ITEM_REMINDER_PRIORITIES = tuple(ACTION_ITEM_NAG_TIERS.keys())
-
-DATADOG_INVALID_CHARS = re.compile(r"[^A-Za-z0-9-_.\/]")
-
-
-logger = logging.getLogger(__name__)
-
-
-class NamedFunction(Protocol):
-    __name__: str
-
-    def __call__(self, *args: Any, **kwargs: Any) -> None: ...
-
-
-def datadog_log(f: NamedFunction) -> NamedFunction:
-    task_name: str = DATADOG_INVALID_CHARS.sub("_", f.__name__)
-    tags = [f"task:{task_name}"]
-
-    @functools.wraps(f)
-    def wrapper(*args: Any, **kwargs: Any) -> None:
-        statsd.increment("django_q.task.run", 1, tags)
-        try:
-            f(*args, **kwargs)
-        except Exception as e:
-            statsd.increment("django_q.task.error", 1, tags)
-            logger.error(
-                f"Error while executing task '{task_name}': {e}", exc_info=True
-            )
-            raise e
-        else:
-            statsd.increment("django_q.task.success", 1, tags)
-
-    return wrapper
 
 
 @datadog_log
@@ -259,85 +220,3 @@ def send_statuspage_followup_reminder(
                 logger.exception(
                     f"Failed to reschedule followup reminder for incident {incident_id}"
                 )
-
-
-@datadog_log
-def send_action_item_reminder() -> None:
-    linear = settings.LINEAR or {}
-    comments_by_priority: dict[int, str] = {
-        priority: linear.get(setting_key, "")
-        for priority, (_, setting_key) in ACTION_ITEM_NAG_TIERS.items()
-    }
-    if not any(comments_by_priority.values()):
-        logger.warning("No Linear nag comments configured, skipping job")
-        return
-
-    now = timezone.now()
-    earliest_min_age_days = min(
-        min_age for min_age, _ in ACTION_ITEM_NAG_TIERS.values()
-    )
-    min_age = now - timedelta(days=ACTION_ITEM_REMINDER_MAX_AGE_DAYS)
-    max_age = now - timedelta(days=earliest_min_age_days)
-
-    def _action_item_eligible(action_item: ActionItem, incident: Incident) -> bool:
-        if action_item.status not in [
-            ActionItemStatus.TODO,
-            ActionItemStatus.IN_PROGRESS,
-        ]:
-            return False
-        tier = ACTION_ITEM_NAG_TIERS.get(action_item.priority)
-        if not tier:
-            return False
-        tier_min_age_days, _ = tier
-        if not comments_by_priority.get(action_item.priority):
-            return False
-        if incident.created_at > now - timedelta(days=tier_min_age_days):
-            return False
-        if action_item.last_nag is None:
-            return True
-        return action_item.last_nag < (
-            now - timedelta(days=ACTION_ITEM_REMINDER_NAG_EVERY_DAYS)
-        )
-
-    def _nag(action_item: ActionItem) -> None:
-        comment = comments_by_priority[action_item.priority]
-        try:
-            success = LinearService().create_comment(
-                action_item.linear_issue_id, comment
-            )
-        except Exception:
-            logger.exception(
-                f"Failed to post nag comment for action item {action_item.linear_identifier}"
-            )
-            return
-        if success:
-            action_item.last_nag = timezone.now()
-            action_item.save(update_fields=["last_nag"])
-
-    incidents = Incident.objects.filter(
-        created_at__gte=min_age,
-        created_at__lte=max_age,
-        severity__in=HIGH_SEVERITIES,
-    ).exclude(status=IncidentStatus.CANCELED)
-
-    for incident in incidents:
-        try:
-            sync_action_items_from_linear(incident)
-        except Exception:
-            logger.exception(
-                f"Failed to refresh action items for incident {incident.id}"
-            )
-            continue
-
-        action_items = incident.action_items.filter(
-            priority__in=ACTION_ITEM_REMINDER_PRIORITIES
-        )
-
-        eligible: list[ActionItem] = [
-            action_item
-            for action_item in action_items
-            if _action_item_eligible(action_item, incident)
-        ]
-
-        for action_item in eligible:
-            _nag(action_item)

--- a/src/firetower/incidents/tasks/__init__.py
+++ b/src/firetower/incidents/tasks/__init__.py
@@ -1,24 +1,16 @@
 import logging
-from datetime import datetime, timedelta
 
-from django.conf import settings
-from django.utils import timezone
 from django_q.tasks import Schedule
 
-from firetower.incidents.hooks import (
-    ACTIVE_STATUSES,
-    HIGH_SEVERITIES,
-    get_slack_user_id,
-    get_statuspage_followup_reminder_delay_minutes,
-    get_statuspage_initial_reminder_delay_minutes,
-)
-from firetower.incidents.models import (
-    ExternalLinkType,
-    Incident,
-)
+from firetower.incidents.models import Incident
 from firetower.incidents.tasks.action_items import send_action_item_reminder
 from firetower.incidents.tasks.decorators import datadog_log
-from firetower.integrations.services.slack import SlackService
+from firetower.incidents.tasks.statuspage import (
+    STATUSPAGE_FOLLOWUP_REMINDER_MESSAGE,
+    STATUSPAGE_REMINDER_MESSAGE,
+    send_statuspage_followup_reminder,
+    send_statuspage_reminder,
+)
 
 __all__ = [
     "SCHEDULES",
@@ -57,166 +49,3 @@ def schedule_demo() -> None:
         logger.info(f"Most recent incident: INC-{incident.id}: {title}")
     else:
         logger.info("No incidents found.")
-
-
-MAX_FOLLOWUP_RESCHEDULES = 20
-
-STATUSPAGE_REMINDER_MESSAGE = (
-    ":rotating_light: *Statuspage Reminder* :rotating_light:\n"
-    "This is a *{severity}* incident. The SLO for posting an initial "
-    "Statuspage update is *{slo_minutes} minutes* from declaration. "
-    "The SLO will be violated in *{minutes_remaining} minutes*.\n\n"
-    "No Statuspage update has been posted yet. "
-    "Please run `{slash_command} statuspage` to create a Statuspage incident now."
-    "{ic_mention}"
-)
-
-STATUSPAGE_FOLLOWUP_REMINDER_MESSAGE = (
-    ":rotating_light: *Statuspage Update Reminder* :rotating_light:\n"
-    "This is a *{severity}* incident. The next Statuspage update "
-    "is due in *{minutes_until_due} minutes*.\n\n"
-    "Please run `{slash_command} statuspage` to post a Statuspage update."
-    "{ic_mention}"
-)
-
-
-def _build_ic_mention(incident: Incident) -> str:
-    if not incident.captain:
-        return ""
-    slack_id = get_slack_user_id(incident.captain)
-    if slack_id:
-        return f"\n<@{slack_id}>"
-
-    # If no slack handle, just return empty since we wouldn't be pinging them anyways.
-    return ""
-
-
-@datadog_log
-def send_statuspage_reminder(incident_id: int, scheduled_at: str | None = None) -> None:
-    slo_minutes = get_statuspage_initial_reminder_delay_minutes()
-    if slo_minutes is None:
-        return
-
-    try:
-        incident = Incident.objects.get(pk=incident_id)
-    except Incident.DoesNotExist:
-        logger.warning(f"Incident {incident_id} not found for statuspage reminder")
-        return
-
-    if incident.severity not in HIGH_SEVERITIES:
-        return
-    if incident.status not in ACTIVE_STATUSES:
-        return
-
-    has_statuspage = incident.external_links.filter(
-        type=ExternalLinkType.STATUSPAGE
-    ).exists()
-    if has_statuspage:
-        return
-
-    status_link = incident.external_links.filter(
-        type=ExternalLinkType.SLACK_STATUS
-    ).first()
-    slack_link = (
-        status_link
-        or incident.external_links.filter(type=ExternalLinkType.SLACK).first()
-    )
-    if not slack_link:
-        return
-
-    slack = SlackService()
-    channel_id = slack.parse_channel_id_from_url(slack_link.url)
-    if not channel_id:
-        return
-
-    slash_command = settings.SLACK.get("SLASH_COMMAND", "/inc")
-    reference_time = (
-        datetime.fromisoformat(scheduled_at) if scheduled_at else incident.created_at
-    )
-    slo_deadline = reference_time + timedelta(minutes=slo_minutes)
-    minutes_remaining = max(
-        0, int((slo_deadline - timezone.now()).total_seconds() / 60)
-    )
-    message = STATUSPAGE_REMINDER_MESSAGE.format(
-        severity=incident.severity,
-        slash_command=slash_command,
-        slo_minutes=slo_minutes,
-        minutes_remaining=minutes_remaining,
-        ic_mention=_build_ic_mention(incident),
-    )
-    slack.post_message(channel_id, message)
-
-
-@datadog_log
-def send_statuspage_followup_reminder(
-    incident_id: int,
-    scheduled_at: str | None = None,
-    reschedule_count: int = 0,
-) -> None:
-    followup_minutes = get_statuspage_followup_reminder_delay_minutes()
-    if followup_minutes is None:
-        return
-
-    try:
-        incident = Incident.objects.get(pk=incident_id)
-    except Incident.DoesNotExist:
-        logger.warning(
-            f"Incident {incident_id} not found for statuspage followup reminder"
-        )
-        return
-
-    if incident.severity not in HIGH_SEVERITIES:
-        return
-    if incident.status not in ACTIVE_STATUSES:
-        return
-
-    has_statuspage = incident.external_links.filter(
-        type=ExternalLinkType.STATUSPAGE
-    ).exists()
-    if not has_statuspage:
-        return
-
-    status_link = incident.external_links.filter(
-        type=ExternalLinkType.SLACK_STATUS
-    ).first()
-    slack_link = (
-        status_link
-        or incident.external_links.filter(type=ExternalLinkType.SLACK).first()
-    )
-    if not slack_link:
-        return
-
-    slack = SlackService()
-    channel_id = slack.parse_channel_id_from_url(slack_link.url)
-    if not channel_id:
-        return
-
-    reference_time = (
-        datetime.fromisoformat(scheduled_at) if scheduled_at else timezone.now()
-    )
-    deadline = reference_time + timedelta(minutes=followup_minutes)
-    minutes_until_due = max(0, int((deadline - timezone.now()).total_seconds() / 60))
-
-    slash_command = settings.SLACK.get("SLASH_COMMAND", "/inc")
-    message = STATUSPAGE_FOLLOWUP_REMINDER_MESSAGE.format(
-        severity=incident.severity,
-        slash_command=slash_command,
-        minutes_until_due=minutes_until_due,
-        ic_mention=_build_ic_mention(incident),
-    )
-    try:
-        slack.post_message(channel_id, message)
-    finally:
-        if reschedule_count < MAX_FOLLOWUP_RESCHEDULES:
-            try:
-                from firetower.incidents.hooks import (  # noqa: PLC0415
-                    schedule_statuspage_followup_reminder,
-                )
-
-                schedule_statuspage_followup_reminder(
-                    incident, reschedule_count=reschedule_count + 1
-                )
-            except Exception:
-                logger.exception(
-                    f"Failed to reschedule followup reminder for incident {incident_id}"
-                )

--- a/src/firetower/incidents/tasks/action_items.py
+++ b/src/firetower/incidents/tasks/action_items.py
@@ -1,0 +1,113 @@
+import logging
+from datetime import timedelta
+
+from django.conf import settings
+from django.utils import timezone
+
+from firetower.incidents.hooks import HIGH_SEVERITIES
+from firetower.incidents.models import (
+    ActionItem,
+    ActionItemStatus,
+    Incident,
+    IncidentStatus,
+)
+from firetower.incidents.services import sync_action_items_from_linear
+from firetower.incidents.tasks.decorators import datadog_log
+from firetower.integrations.services.linear import LinearService
+
+logger = logging.getLogger(__name__)
+
+ACTION_ITEM_REMINDER_MAX_AGE_DAYS = 90
+ACTION_ITEM_REMINDER_NAG_EVERY_DAYS = 7
+
+# Per-tier minimum incident age (in days) before we nag, and the settings.LINEAR
+# key holding the comment for that tier.
+# Linear priority values: 1 = Urgent (P0), 2 = High (P1), 3 = Medium (P2).
+ACTION_ITEM_NAG_TIERS: dict[int, tuple[int, str]] = {
+    1: (7, "ACTION_ITEM_NAG_COMMENT_HIGH_PRIORITY"),
+    2: (7, "ACTION_ITEM_NAG_COMMENT_HIGH_PRIORITY"),
+    3: (21, "ACTION_ITEM_NAG_COMMENT_MEDIUM_PRIORITY"),
+}
+ACTION_ITEM_REMINDER_PRIORITIES = tuple(ACTION_ITEM_NAG_TIERS.keys())
+
+
+@datadog_log
+def send_action_item_reminder() -> None:
+    linear = settings.LINEAR or {}
+    comments_by_priority: dict[int, str] = {
+        priority: linear.get(setting_key, "")
+        for priority, (_, setting_key) in ACTION_ITEM_NAG_TIERS.items()
+    }
+    if not any(comments_by_priority.values()):
+        logger.warning("No Linear nag comments configured, skipping job")
+        return
+
+    now = timezone.now()
+    earliest_min_age_days = min(
+        min_age for min_age, _ in ACTION_ITEM_NAG_TIERS.values()
+    )
+    min_age = now - timedelta(days=ACTION_ITEM_REMINDER_MAX_AGE_DAYS)
+    max_age = now - timedelta(days=earliest_min_age_days)
+
+    def _action_item_eligible(action_item: ActionItem, incident: Incident) -> bool:
+        if action_item.status not in [
+            ActionItemStatus.TODO,
+            ActionItemStatus.IN_PROGRESS,
+        ]:
+            return False
+        tier = ACTION_ITEM_NAG_TIERS.get(action_item.priority)
+        if not tier:
+            return False
+        tier_min_age_days, _ = tier
+        if not comments_by_priority.get(action_item.priority):
+            return False
+        if incident.created_at > now - timedelta(days=tier_min_age_days):
+            return False
+        if action_item.last_nag is None:
+            return True
+        return action_item.last_nag < (
+            now - timedelta(days=ACTION_ITEM_REMINDER_NAG_EVERY_DAYS)
+        )
+
+    def _nag(action_item: ActionItem) -> None:
+        comment = comments_by_priority[action_item.priority]
+        try:
+            success = LinearService().create_comment(
+                action_item.linear_issue_id, comment
+            )
+        except Exception:
+            logger.exception(
+                f"Failed to post nag comment for action item {action_item.linear_identifier}"
+            )
+            return
+        if success:
+            action_item.last_nag = timezone.now()
+            action_item.save(update_fields=["last_nag"])
+
+    incidents = Incident.objects.filter(
+        created_at__gte=min_age,
+        created_at__lte=max_age,
+        severity__in=HIGH_SEVERITIES,
+    ).exclude(status=IncidentStatus.CANCELED)
+
+    for incident in incidents:
+        try:
+            sync_action_items_from_linear(incident)
+        except Exception:
+            logger.exception(
+                f"Failed to refresh action items for incident {incident.id}"
+            )
+            continue
+
+        action_items = incident.action_items.filter(
+            priority__in=ACTION_ITEM_REMINDER_PRIORITIES
+        )
+
+        eligible: list[ActionItem] = [
+            action_item
+            for action_item in action_items
+            if _action_item_eligible(action_item, incident)
+        ]
+
+        for action_item in eligible:
+            _nag(action_item)

--- a/src/firetower/incidents/tasks/decorators.py
+++ b/src/firetower/incidents/tasks/decorators.py
@@ -1,0 +1,37 @@
+import functools
+import logging
+import re
+from typing import Any, Protocol
+
+from datadog import statsd
+
+DATADOG_INVALID_CHARS = re.compile(r"[^A-Za-z0-9-_.\/]")
+
+logger = logging.getLogger(__name__)
+
+
+class NamedFunction(Protocol):
+    __name__: str
+
+    def __call__(self, *args: Any, **kwargs: Any) -> None: ...
+
+
+def datadog_log(f: NamedFunction) -> NamedFunction:
+    task_name: str = DATADOG_INVALID_CHARS.sub("_", f.__name__)
+    tags = [f"task:{task_name}"]
+
+    @functools.wraps(f)
+    def wrapper(*args: Any, **kwargs: Any) -> None:
+        statsd.increment("django_q.task.run", 1, tags)
+        try:
+            f(*args, **kwargs)
+        except Exception as e:
+            statsd.increment("django_q.task.error", 1, tags)
+            logger.error(
+                f"Error while executing task '{task_name}': {e}", exc_info=True
+            )
+            raise e
+        else:
+            statsd.increment("django_q.task.success", 1, tags)
+
+    return wrapper

--- a/src/firetower/incidents/tasks/statuspage.py
+++ b/src/firetower/incidents/tasks/statuspage.py
@@ -1,0 +1,183 @@
+import logging
+from datetime import datetime, timedelta
+
+from django.conf import settings
+from django.utils import timezone
+
+from firetower.incidents.hooks import (
+    ACTIVE_STATUSES,
+    HIGH_SEVERITIES,
+    get_slack_user_id,
+    get_statuspage_followup_reminder_delay_minutes,
+    get_statuspage_initial_reminder_delay_minutes,
+)
+from firetower.incidents.models import (
+    ExternalLinkType,
+    Incident,
+)
+from firetower.incidents.tasks.decorators import datadog_log
+from firetower.integrations.services.slack import SlackService
+
+logger = logging.getLogger(__name__)
+
+MAX_FOLLOWUP_RESCHEDULES = 20
+
+STATUSPAGE_REMINDER_MESSAGE = (
+    ":rotating_light: *Statuspage Reminder* :rotating_light:\n"
+    "This is a *{severity}* incident. The SLO for posting an initial "
+    "Statuspage update is *{slo_minutes} minutes* from declaration. "
+    "The SLO will be violated in *{minutes_remaining} minutes*.\n\n"
+    "No Statuspage update has been posted yet. "
+    "Please run `{slash_command} statuspage` to create a Statuspage incident now."
+    "{ic_mention}"
+)
+
+STATUSPAGE_FOLLOWUP_REMINDER_MESSAGE = (
+    ":rotating_light: *Statuspage Update Reminder* :rotating_light:\n"
+    "This is a *{severity}* incident. The next Statuspage update "
+    "is due in *{minutes_until_due} minutes*.\n\n"
+    "Please run `{slash_command} statuspage` to post a Statuspage update."
+    "{ic_mention}"
+)
+
+
+def _build_ic_mention(incident: Incident) -> str:
+    if not incident.captain:
+        return ""
+    slack_id = get_slack_user_id(incident.captain)
+    if slack_id:
+        return f"\n<@{slack_id}>"
+
+    # If no slack handle, just return empty since we wouldn't be pinging them anyways.
+    return ""
+
+
+@datadog_log
+def send_statuspage_reminder(incident_id: int, scheduled_at: str | None = None) -> None:
+    slo_minutes = get_statuspage_initial_reminder_delay_minutes()
+    if slo_minutes is None:
+        return
+
+    try:
+        incident = Incident.objects.get(pk=incident_id)
+    except Incident.DoesNotExist:
+        logger.warning(f"Incident {incident_id} not found for statuspage reminder")
+        return
+
+    if incident.severity not in HIGH_SEVERITIES:
+        return
+    if incident.status not in ACTIVE_STATUSES:
+        return
+
+    has_statuspage = incident.external_links.filter(
+        type=ExternalLinkType.STATUSPAGE
+    ).exists()
+    if has_statuspage:
+        return
+
+    status_link = incident.external_links.filter(
+        type=ExternalLinkType.SLACK_STATUS
+    ).first()
+    slack_link = (
+        status_link
+        or incident.external_links.filter(type=ExternalLinkType.SLACK).first()
+    )
+    if not slack_link:
+        return
+
+    slack = SlackService()
+    channel_id = slack.parse_channel_id_from_url(slack_link.url)
+    if not channel_id:
+        return
+
+    slash_command = settings.SLACK.get("SLASH_COMMAND", "/inc")
+    reference_time = (
+        datetime.fromisoformat(scheduled_at) if scheduled_at else incident.created_at
+    )
+    slo_deadline = reference_time + timedelta(minutes=slo_minutes)
+    minutes_remaining = max(
+        0, int((slo_deadline - timezone.now()).total_seconds() / 60)
+    )
+    message = STATUSPAGE_REMINDER_MESSAGE.format(
+        severity=incident.severity,
+        slash_command=slash_command,
+        slo_minutes=slo_minutes,
+        minutes_remaining=minutes_remaining,
+        ic_mention=_build_ic_mention(incident),
+    )
+    slack.post_message(channel_id, message)
+
+
+@datadog_log
+def send_statuspage_followup_reminder(
+    incident_id: int,
+    scheduled_at: str | None = None,
+    reschedule_count: int = 0,
+) -> None:
+    followup_minutes = get_statuspage_followup_reminder_delay_minutes()
+    if followup_minutes is None:
+        return
+
+    try:
+        incident = Incident.objects.get(pk=incident_id)
+    except Incident.DoesNotExist:
+        logger.warning(
+            f"Incident {incident_id} not found for statuspage followup reminder"
+        )
+        return
+
+    if incident.severity not in HIGH_SEVERITIES:
+        return
+    if incident.status not in ACTIVE_STATUSES:
+        return
+
+    has_statuspage = incident.external_links.filter(
+        type=ExternalLinkType.STATUSPAGE
+    ).exists()
+    if not has_statuspage:
+        return
+
+    status_link = incident.external_links.filter(
+        type=ExternalLinkType.SLACK_STATUS
+    ).first()
+    slack_link = (
+        status_link
+        or incident.external_links.filter(type=ExternalLinkType.SLACK).first()
+    )
+    if not slack_link:
+        return
+
+    slack = SlackService()
+    channel_id = slack.parse_channel_id_from_url(slack_link.url)
+    if not channel_id:
+        return
+
+    reference_time = (
+        datetime.fromisoformat(scheduled_at) if scheduled_at else timezone.now()
+    )
+    deadline = reference_time + timedelta(minutes=followup_minutes)
+    minutes_until_due = max(0, int((deadline - timezone.now()).total_seconds() / 60))
+
+    slash_command = settings.SLACK.get("SLASH_COMMAND", "/inc")
+    message = STATUSPAGE_FOLLOWUP_REMINDER_MESSAGE.format(
+        severity=incident.severity,
+        slash_command=slash_command,
+        minutes_until_due=minutes_until_due,
+        ic_mention=_build_ic_mention(incident),
+    )
+    try:
+        slack.post_message(channel_id, message)
+    finally:
+        if reschedule_count < MAX_FOLLOWUP_RESCHEDULES:
+            try:
+                from firetower.incidents.hooks import (  # noqa: PLC0415
+                    schedule_statuspage_followup_reminder,
+                )
+
+                schedule_statuspage_followup_reminder(
+                    incident, reschedule_count=reschedule_count + 1
+                )
+            except Exception:
+                logger.exception(
+                    f"Failed to reschedule followup reminder for incident {incident_id}"
+                )

--- a/src/firetower/incidents/tests/test_tasks.py
+++ b/src/firetower/incidents/tests/test_tasks.py
@@ -29,7 +29,7 @@ from firetower.incidents.tasks import (
 
 
 class TestDatadogLogTaskName:
-    @patch("firetower.incidents.tasks.statsd")
+    @patch("firetower.incidents.tasks.decorators.statsd")
     def test_replaces_invalid_chars_with_underscore(self, mock_statsd):
         def f_with_bad_chars() -> None:
             pass
@@ -41,7 +41,7 @@ class TestDatadogLogTaskName:
         expected_tags = ["task:task_with_spaces___symbols_"]
         mock_statsd.increment.assert_any_call("django_q.task.run", 1, expected_tags)
 
-    @patch("firetower.incidents.tasks.statsd")
+    @patch("firetower.incidents.tasks.decorators.statsd")
     def test_preserves_alphanumerics_dash_underscore_dot_slash(self, mock_statsd):
         def f() -> None:
             pass
@@ -53,7 +53,7 @@ class TestDatadogLogTaskName:
         expected_tags = ["task:namespace/sub-task_v1.2"]
         mock_statsd.increment.assert_any_call("django_q.task.run", 1, expected_tags)
 
-    @patch("firetower.incidents.tasks.statsd")
+    @patch("firetower.incidents.tasks.decorators.statsd")
     def test_replaces_consecutive_invalid_chars_individually(self, mock_statsd):
         def f() -> None:
             pass
@@ -67,7 +67,7 @@ class TestDatadogLogTaskName:
 
 
 class TestDatadogLogStatsdIncrements:
-    @patch("firetower.incidents.tasks.statsd")
+    @patch("firetower.incidents.tasks.decorators.statsd")
     def test_increments_run_and_success_on_normal_completion(self, mock_statsd):
         def f() -> None:
             pass
@@ -82,7 +82,7 @@ class TestDatadogLogStatsdIncrements:
             call("django_q.task.success", 1, tags),
         ]
 
-    @patch("firetower.incidents.tasks.statsd")
+    @patch("firetower.incidents.tasks.decorators.statsd")
     def test_increments_run_and_error_when_function_raises(self, mock_statsd):
         def f() -> None:
             raise ValueError("boom")
@@ -98,7 +98,7 @@ class TestDatadogLogStatsdIncrements:
             call("django_q.task.error", 1, tags),
         ]
 
-    @patch("firetower.incidents.tasks.statsd")
+    @patch("firetower.incidents.tasks.decorators.statsd")
     def test_does_not_increment_success_when_function_raises(self, mock_statsd):
         def f() -> None:
             raise RuntimeError("nope")
@@ -115,7 +115,7 @@ class TestDatadogLogStatsdIncrements:
         ]
         assert success_calls == []
 
-    @patch("firetower.incidents.tasks.statsd")
+    @patch("firetower.incidents.tasks.decorators.statsd")
     def test_re_raises_exception_from_wrapped_function(self, mock_statsd):
         def f() -> None:
             raise ValueError("should propagate")
@@ -128,7 +128,7 @@ class TestDatadogLogStatsdIncrements:
 
 
 class TestScheduleDemoPrivateIncident:
-    @patch("firetower.incidents.tasks.statsd")
+    @patch("firetower.incidents.tasks.decorators.statsd")
     @patch("firetower.incidents.tasks.Incident")
     def test_masks_title_for_private_incident(self, mock_incident_cls, mock_statsd):
         mock_incident = MagicMock()
@@ -146,7 +146,7 @@ class TestScheduleDemoPrivateIncident:
         assert "Private Incident" in logged
         assert "Secret outage details" not in logged
 
-    @patch("firetower.incidents.tasks.statsd")
+    @patch("firetower.incidents.tasks.decorators.statsd")
     @patch("firetower.incidents.tasks.Incident")
     def test_shows_title_for_public_incident(self, mock_incident_cls, mock_statsd):
         mock_incident = MagicMock()
@@ -749,14 +749,19 @@ class TestSendActionItemReminder:
 
     @pytest.fixture(autouse=True)
     def mock_sync(self):
-        with patch("firetower.incidents.tasks.sync_action_items_from_linear") as m:
+        with patch(
+            "firetower.incidents.tasks.action_items.sync_action_items_from_linear"
+        ) as m:
             yield m
 
     @pytest.fixture
     def mock_linear(self):
         mock = MagicMock()
         mock.create_comment.return_value = True
-        with patch("firetower.incidents.tasks.LinearService", return_value=mock):
+        with patch(
+            "firetower.incidents.tasks.action_items.LinearService",
+            return_value=mock,
+        ):
             yield mock
 
     def _make_incident(self, days_old: int = 45, **kwargs) -> Incident:
@@ -921,7 +926,9 @@ class TestSendActionItemReminder:
 
         with (
             patch.object(settings, "LINEAR", None),
-            patch("firetower.incidents.tasks.LinearService") as mock_service,
+            patch(
+                "firetower.incidents.tasks.action_items.LinearService"
+            ) as mock_service,
         ):
             send_action_item_reminder()
 

--- a/src/firetower/incidents/tests/test_tasks.py
+++ b/src/firetower/incidents/tests/test_tasks.py
@@ -207,8 +207,11 @@ class TestSendStatuspageReminder:
         mock_slack.parse_channel_id_from_url.return_value = "C12345"
 
         with (
-            patch("firetower.incidents.tasks.SlackService", return_value=mock_slack),
-            patch("firetower.incidents.tasks.timezone") as mock_tz,
+            patch(
+                "firetower.incidents.tasks.statuspage.SlackService",
+                return_value=mock_slack,
+            ),
+            patch("firetower.incidents.tasks.statuspage.timezone") as mock_tz,
         ):
             mock_tz.now.return_value = now
             send_statuspage_reminder(incident.id)
@@ -241,8 +244,11 @@ class TestSendStatuspageReminder:
         mock_slack.parse_channel_id_from_url.return_value = "C99999"
 
         with (
-            patch("firetower.incidents.tasks.SlackService", return_value=mock_slack),
-            patch("firetower.incidents.tasks.timezone") as mock_tz,
+            patch(
+                "firetower.incidents.tasks.statuspage.SlackService",
+                return_value=mock_slack,
+            ),
+            patch("firetower.incidents.tasks.statuspage.timezone") as mock_tz,
         ):
             mock_tz.now.return_value = now
             send_statuspage_reminder(incident.id)
@@ -262,8 +268,11 @@ class TestSendStatuspageReminder:
         mock_slack.parse_channel_id_from_url.return_value = "C12345"
 
         with (
-            patch("firetower.incidents.tasks.SlackService", return_value=mock_slack),
-            patch("firetower.incidents.tasks.timezone") as mock_tz,
+            patch(
+                "firetower.incidents.tasks.statuspage.SlackService",
+                return_value=mock_slack,
+            ),
+            patch("firetower.incidents.tasks.statuspage.timezone") as mock_tz,
         ):
             mock_tz.now.return_value = now
             send_statuspage_reminder(incident.id, scheduled_at=scheduled_at.isoformat())
@@ -286,7 +295,9 @@ class TestSendStatuspageReminder:
         mock_slack = MagicMock()
         mock_slack.parse_channel_id_from_url.return_value = "C12345"
 
-        with patch("firetower.incidents.tasks.SlackService", return_value=mock_slack):
+        with patch(
+            "firetower.incidents.tasks.statuspage.SlackService", return_value=mock_slack
+        ):
             send_statuspage_reminder(incident.id)
 
         mock_slack.post_message.assert_called_once()
@@ -301,7 +312,9 @@ class TestSendStatuspageReminder:
         )
 
         mock_slack = MagicMock()
-        with patch("firetower.incidents.tasks.SlackService", return_value=mock_slack):
+        with patch(
+            "firetower.incidents.tasks.statuspage.SlackService", return_value=mock_slack
+        ):
             send_statuspage_reminder(incident.id)
 
         mock_slack.post_message.assert_not_called()
@@ -311,7 +324,9 @@ class TestSendStatuspageReminder:
         self._make_link(incident, ExternalLinkType.SLACK)
 
         mock_slack = MagicMock()
-        with patch("firetower.incidents.tasks.SlackService", return_value=mock_slack):
+        with patch(
+            "firetower.incidents.tasks.statuspage.SlackService", return_value=mock_slack
+        ):
             send_statuspage_reminder(incident.id)
 
         mock_slack.post_message.assert_not_called()
@@ -323,7 +338,9 @@ class TestSendStatuspageReminder:
         self._make_link(incident, ExternalLinkType.SLACK)
 
         mock_slack = MagicMock()
-        with patch("firetower.incidents.tasks.SlackService", return_value=mock_slack):
+        with patch(
+            "firetower.incidents.tasks.statuspage.SlackService", return_value=mock_slack
+        ):
             send_statuspage_reminder(incident.id)
 
         mock_slack.post_message.assert_not_called()
@@ -335,7 +352,9 @@ class TestSendStatuspageReminder:
         self._make_link(incident, ExternalLinkType.SLACK)
 
         mock_slack = MagicMock()
-        with patch("firetower.incidents.tasks.SlackService", return_value=mock_slack):
+        with patch(
+            "firetower.incidents.tasks.statuspage.SlackService", return_value=mock_slack
+        ):
             send_statuspage_reminder(incident.id)
 
         mock_slack.post_message.assert_not_called()
@@ -349,7 +368,9 @@ class TestSendStatuspageReminder:
         mock_slack = MagicMock()
         mock_slack.parse_channel_id_from_url.return_value = "C12345"
 
-        with patch("firetower.incidents.tasks.SlackService", return_value=mock_slack):
+        with patch(
+            "firetower.incidents.tasks.statuspage.SlackService", return_value=mock_slack
+        ):
             send_statuspage_reminder(incident.id)
 
         mock_slack.post_message.assert_called_once()
@@ -362,7 +383,10 @@ class TestSendStatuspageReminder:
         mock_slack.parse_channel_id_from_url.return_value = "C12345"
 
         with (
-            patch("firetower.incidents.tasks.SlackService", return_value=mock_slack),
+            patch(
+                "firetower.incidents.tasks.statuspage.SlackService",
+                return_value=mock_slack,
+            ),
             patch.object(
                 settings,
                 "STATUSPAGE",
@@ -381,7 +405,9 @@ class TestSendStatuspageReminder:
 
     def test_skips_when_incident_not_found(self):
         mock_slack = MagicMock()
-        with patch("firetower.incidents.tasks.SlackService", return_value=mock_slack):
+        with patch(
+            "firetower.incidents.tasks.statuspage.SlackService", return_value=mock_slack
+        ):
             send_statuspage_reminder(99999)
 
         mock_slack.post_message.assert_not_called()
@@ -390,7 +416,9 @@ class TestSendStatuspageReminder:
         incident = self._make_incident(severity=IncidentSeverity.P0)
 
         mock_slack = MagicMock()
-        with patch("firetower.incidents.tasks.SlackService", return_value=mock_slack):
+        with patch(
+            "firetower.incidents.tasks.statuspage.SlackService", return_value=mock_slack
+        ):
             send_statuspage_reminder(incident.id)
 
         mock_slack.post_message.assert_not_called()
@@ -402,7 +430,9 @@ class TestSendStatuspageReminder:
         mock_slack = MagicMock()
         mock_slack.parse_channel_id_from_url.return_value = None
 
-        with patch("firetower.incidents.tasks.SlackService", return_value=mock_slack):
+        with patch(
+            "firetower.incidents.tasks.statuspage.SlackService", return_value=mock_slack
+        ):
             send_statuspage_reminder(incident.id)
 
         mock_slack.post_message.assert_not_called()
@@ -420,7 +450,9 @@ class TestSendStatuspageReminder:
         mock_slack = MagicMock()
         mock_slack.parse_channel_id_from_url.return_value = "C12345"
 
-        with patch("firetower.incidents.tasks.SlackService", return_value=mock_slack):
+        with patch(
+            "firetower.incidents.tasks.statuspage.SlackService", return_value=mock_slack
+        ):
             send_statuspage_reminder(incident.id)
 
         msg = mock_slack.post_message.call_args[0][1]
@@ -439,7 +471,9 @@ class TestSendStatuspageReminder:
         mock_slack = MagicMock()
         mock_slack.parse_channel_id_from_url.return_value = "C12345"
 
-        with patch("firetower.incidents.tasks.SlackService", return_value=mock_slack):
+        with patch(
+            "firetower.incidents.tasks.statuspage.SlackService", return_value=mock_slack
+        ):
             send_statuspage_reminder(incident.id)
 
         msg = mock_slack.post_message.call_args[0][1]
@@ -502,10 +536,13 @@ class TestSendStatuspageFollowupReminder:
         scheduled_at = now - timedelta(minutes=offset_minutes)
 
         with (
-            patch("firetower.incidents.tasks.SlackService", return_value=mock_slack),
-            patch("firetower.incidents.tasks.timezone") as mock_tz,
             patch(
-                "firetower.incidents.tasks.get_statuspage_followup_reminder_delay_minutes",
+                "firetower.incidents.tasks.statuspage.SlackService",
+                return_value=mock_slack,
+            ),
+            patch("firetower.incidents.tasks.statuspage.timezone") as mock_tz,
+            patch(
+                "firetower.incidents.tasks.statuspage.get_statuspage_followup_reminder_delay_minutes",
                 return_value=self.CONFIGURED_FOLLOWUP_DELAY_MINUTES,
             ),
         ):
@@ -535,9 +572,12 @@ class TestSendStatuspageFollowupReminder:
         mock_slack.parse_channel_id_from_url.return_value = "C12345"
 
         with (
-            patch("firetower.incidents.tasks.SlackService", return_value=mock_slack),
             patch(
-                "firetower.incidents.tasks.get_statuspage_followup_reminder_delay_minutes",
+                "firetower.incidents.tasks.statuspage.SlackService",
+                return_value=mock_slack,
+            ),
+            patch(
+                "firetower.incidents.tasks.statuspage.get_statuspage_followup_reminder_delay_minutes",
                 return_value=self.CONFIGURED_FOLLOWUP_DELAY_MINUTES,
             ),
         ):
@@ -552,7 +592,9 @@ class TestSendStatuspageFollowupReminder:
         self._make_link(incident, ExternalLinkType.SLACK)
 
         mock_slack = MagicMock()
-        with patch("firetower.incidents.tasks.SlackService", return_value=mock_slack):
+        with patch(
+            "firetower.incidents.tasks.statuspage.SlackService", return_value=mock_slack
+        ):
             send_statuspage_followup_reminder(incident.id)
 
         mock_slack.post_message.assert_not_called()
@@ -567,7 +609,9 @@ class TestSendStatuspageFollowupReminder:
         )
 
         mock_slack = MagicMock()
-        with patch("firetower.incidents.tasks.SlackService", return_value=mock_slack):
+        with patch(
+            "firetower.incidents.tasks.statuspage.SlackService", return_value=mock_slack
+        ):
             send_statuspage_followup_reminder(incident.id)
 
         mock_slack.post_message.assert_not_called()
@@ -584,7 +628,9 @@ class TestSendStatuspageFollowupReminder:
         )
 
         mock_slack = MagicMock()
-        with patch("firetower.incidents.tasks.SlackService", return_value=mock_slack):
+        with patch(
+            "firetower.incidents.tasks.statuspage.SlackService", return_value=mock_slack
+        ):
             send_statuspage_followup_reminder(incident.id)
 
         mock_slack.post_message.assert_not_called()
@@ -602,7 +648,10 @@ class TestSendStatuspageFollowupReminder:
         mock_slack.parse_channel_id_from_url.return_value = "C12345"
 
         with (
-            patch("firetower.incidents.tasks.SlackService", return_value=mock_slack),
+            patch(
+                "firetower.incidents.tasks.statuspage.SlackService",
+                return_value=mock_slack,
+            ),
             patch.object(
                 settings,
                 "STATUSPAGE",
@@ -622,7 +671,9 @@ class TestSendStatuspageFollowupReminder:
 
     def test_skips_when_incident_not_found(self):
         mock_slack = MagicMock()
-        with patch("firetower.incidents.tasks.SlackService", return_value=mock_slack):
+        with patch(
+            "firetower.incidents.tasks.statuspage.SlackService", return_value=mock_slack
+        ):
             send_statuspage_followup_reminder(99999)
 
         mock_slack.post_message.assert_not_called()
@@ -636,7 +687,9 @@ class TestSendStatuspageFollowupReminder:
         )
 
         mock_slack = MagicMock()
-        with patch("firetower.incidents.tasks.SlackService", return_value=mock_slack):
+        with patch(
+            "firetower.incidents.tasks.statuspage.SlackService", return_value=mock_slack
+        ):
             send_statuspage_followup_reminder(incident.id)
 
         mock_slack.post_message.assert_not_called()
@@ -656,9 +709,12 @@ class TestSendStatuspageFollowupReminder:
         mock_slack.parse_channel_id_from_url.return_value = "C12345"
 
         with (
-            patch("firetower.incidents.tasks.SlackService", return_value=mock_slack),
             patch(
-                "firetower.incidents.tasks.get_statuspage_followup_reminder_delay_minutes",
+                "firetower.incidents.tasks.statuspage.SlackService",
+                return_value=mock_slack,
+            ),
+            patch(
+                "firetower.incidents.tasks.statuspage.get_statuspage_followup_reminder_delay_minutes",
                 return_value=self.CONFIGURED_FOLLOWUP_DELAY_MINUTES,
             ),
         ):
@@ -685,9 +741,12 @@ class TestSendStatuspageFollowupReminder:
         mock_slack.parse_channel_id_from_url.return_value = "C12345"
 
         with (
-            patch("firetower.incidents.tasks.SlackService", return_value=mock_slack),
             patch(
-                "firetower.incidents.tasks.get_statuspage_followup_reminder_delay_minutes",
+                "firetower.incidents.tasks.statuspage.SlackService",
+                return_value=mock_slack,
+            ),
+            patch(
+                "firetower.incidents.tasks.statuspage.get_statuspage_followup_reminder_delay_minutes",
                 return_value=self.CONFIGURED_FOLLOWUP_DELAY_MINUTES,
             ),
         ):
@@ -715,9 +774,12 @@ class TestSendStatuspageFollowupReminder:
         mock_slack.parse_channel_id_from_url.return_value = "C12345"
 
         with (
-            patch("firetower.incidents.tasks.SlackService", return_value=mock_slack),
             patch(
-                "firetower.incidents.tasks.get_statuspage_followup_reminder_delay_minutes",
+                "firetower.incidents.tasks.statuspage.SlackService",
+                return_value=mock_slack,
+            ),
+            patch(
+                "firetower.incidents.tasks.statuspage.get_statuspage_followup_reminder_delay_minutes",
                 return_value=self.CONFIGURED_FOLLOWUP_DELAY_MINUTES,
             ),
         ):


### PR DESCRIPTION
## Summary
Splits the growing `incidents/tasks.py` into a package, with each task family in its own module.

- `tasks/decorators.py` — shared `datadog_log` decorator
- `tasks/action_items.py` — the tier table, constants, and `send_action_item_reminder`
- `tasks/statuspage.py` — `send_statuspage_reminder` + `send_statuspage_followup_reminder`, their message templates, `_build_ic_mention`, and `MAX_FOLLOWUP_RESCHEDULES`
- `tasks/__init__.py` — keeps `schedule_demo` + `SCHEDULES`, and re-exports the task functions / message constants / `datadog_log` so the existing django-q func strings and migration imports stay valid

## Test plan
- [ ] `pytest src/firetower/incidents/tests/test_tasks.py` passes (55 cases)
- [ ] Confirm `from firetower.incidents.tasks import SCHEDULES` (used by migrations) still resolves
- [ ] Confirm the django-q schedule strings (`firetower.incidents.tasks.{schedule_demo,send_action_item_reminder,send_statuspage_reminder,send_statuspage_followup_reminder}`) resolve at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)