### PR TITLE
ci: Split deploy-db-migration into per-env jobs so the inactive env shows skipped

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,45 +50,50 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  deploy-db-migration:
+  deploy-db-migration-test:
     needs: [build]
+    if: ${{ inputs.environment == 'test' }}
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - env_name: test
-            cloud_run_job: firetower-test-db-migration
-          - env_name: prod
-            cloud_run_job: firetower-prod-db-migration
     steps:
       - name: Checkout code
-        if: >-
-          (matrix.env_name == 'test' && inputs.environment == 'test') ||
-          (matrix.env_name == 'prod' && github.ref == 'refs/heads/main' && ((!inputs.environment) || inputs.environment == 'prod'))
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Authenticate with GCP
-        if: >-
-          (matrix.env_name == 'test' && inputs.environment == 'test') ||
-          (matrix.env_name == 'prod' && github.ref == 'refs/heads/main' && ((!inputs.environment) || inputs.environment == 'prod'))
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           project_id: ${{ secrets.GCP_PROJECT_SLUG }}
           workload_identity_provider: projects/${{ secrets.GCP_PROJECT_NUM }}/locations/global/workloadIdentityPools/github/providers/github-prvdr
-      - name: Run migration (${{ matrix.env_name }})
-        if: >-
-          (matrix.env_name == 'test' && inputs.environment == 'test') ||
-          (matrix.env_name == 'prod' && github.ref == 'refs/heads/main' && ((!inputs.environment) || inputs.environment == 'prod'))
+      - name: Run migration (test)
         uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3
         with:
-          job: ${{ matrix.cloud_run_job }}
+          job: firetower-test-db-migration
+          project_id: ${{ secrets.GCP_PROJECT_SLUG }}
+          region: us-west1
+          image: ${{ env.BACKEND_IMAGE_REF }}
+          wait: true
+
+  deploy-db-migration-prod:
+    needs: [build]
+    if: ${{ github.ref == 'refs/heads/main' && ((!inputs.environment) || inputs.environment == 'prod') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - name: Authenticate with GCP
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_SLUG }}
+          workload_identity_provider: projects/${{ secrets.GCP_PROJECT_NUM }}/locations/global/workloadIdentityPools/github/providers/github-prvdr
+      - name: Run migration (prod)
+        uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3
+        with:
+          job: firetower-prod-db-migration
           project_id: ${{ secrets.GCP_PROJECT_SLUG }}
           region: us-west1
           image: ${{ env.BACKEND_IMAGE_REF }}
           wait: true
 
   deploy-test:
-    needs: [deploy-db-migration]
+    needs: [deploy-db-migration-test]
     if: ${{ inputs.environment == 'test' }}
     runs-on: ubuntu-latest
     strategy:
@@ -129,7 +134,7 @@ jobs:
             --container firetower-backend --image "${{ env.BACKEND_IMAGE_REF }}"
 
   deploy-prod:
-    needs: [deploy-db-migration]
+    needs: [deploy-db-migration-prod]
     if: ${{ github.ref == 'refs/heads/main' && ((!inputs.environment) || inputs.environment == 'prod') }}
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Splits the single matrix-based deploy-db-migration job into separate deploy-db-migration-test and deploy-db-migration-prod jobs, each gated by a job-level if: that mirrors the existing deploy-test/deploy-prod conditions, and rewires the deploy jobs' needs: to the matching per-env migration. This is a behavioral no-op: the same migrations and deploys run against the same environments under the same trigger conditions. The only change is that the non-targeted environment's migration job now reports as skipped instead of a misleading green success (where the job ran but every step was individually if-skipped), which previously read like the inactive env had migrated when it had not.

Tested [here](https://github.com/getsentry/firetower/actions/runs/26982170059) looking good.