### PR TITLE
feat(linear): Post comment on parent issue when state changes

### DIFF
--- a/src/firetower/config.py
+++ b/src/firetower/config.py
@@ -93,6 +93,17 @@ class LinearConfig:
         "days from incident creation. Please prioritize this work or close "
         "out the issue if it is no longer relevant."
     )
+    parent_status_comment_completed: str = (
+        "Firetower set this issue to **Completed**. "
+        "Incident {{ incident.incident_number }} is {{ incident.status }} "
+        "and {% if total_action_items == 0 %}there are no action items."
+        "{% else %}all {{ total_action_items }} action item(s) are complete.{% endif %}"
+    )
+    parent_status_comment_started: str = (
+        "Firetower set this issue to **Started**. "
+        "Incident {{ incident.incident_number }} is {{ incident.status }}. "
+        "{{ completed_action_items }} of {{ total_action_items }} action item(s) complete."
+    )
 
 
 @deserialize

--- a/src/firetower/config.py
+++ b/src/firetower/config.py
@@ -80,15 +80,15 @@ class LinearConfig:
     action_item_slo_days_high_priority: int = 14
     action_item_slo_days_medium_priority: int = 30
     action_item_nag_comment_high_priority: str = (
-        "{% if days_past_due > 0 %}This action item is **{{ days_past_due }} day(s) "
-        "past due**. {% endif %}"
+        "{% if days_past_due > 0 %}This action item is **{{ days_past_due }} "
+        "day{% if days_past_due != 1 %}s{% endif %} past due**. {% endif %}"
         "The SLO for completing P0/P1 incident action items is {{ slo_days }} "
         "days from incident creation. Please prioritize this work or close "
         "out the issue if it is no longer relevant."
     )
     action_item_nag_comment_medium_priority: str = (
-        "{% if days_past_due > 0 %}This action item is **{{ days_past_due }} day(s) "
-        "past due**. {% endif %}"
+        "{% if days_past_due > 0 %}This action item is **{{ days_past_due }} "
+        "day{% if days_past_due != 1 %}s{% endif %} past due**. {% endif %}"
         "The SLO for completing P2 incident action items is {{ slo_days }} "
         "days from incident creation. Please prioritize this work or close "
         "out the issue if it is no longer relevant."
@@ -97,12 +97,14 @@ class LinearConfig:
         "Firetower set this issue to **Completed**. "
         "Incident {{ incident.incident_number }} is {{ incident.status }} "
         "and {% if total_action_items == 0 %}there are no action items."
-        "{% else %}all {{ total_action_items }} action item(s) are complete.{% endif %}"
+        "{% else %}all {{ total_action_items }} action "
+        "item{% if total_action_items != 1 %}s{% endif %} are complete.{% endif %}"
     )
     parent_status_comment_started: str = (
         "Firetower set this issue to **Started**. "
         "Incident {{ incident.incident_number }} is {{ incident.status }}. "
-        "{{ completed_action_items }} of {{ total_action_items }} action item(s) complete."
+        "{{ completed_action_items }} of {{ total_action_items }} action "
+        "item{% if total_action_items != 1 %}s{% endif %} complete."
     )
 
 

--- a/src/firetower/incidents/services.py
+++ b/src/firetower/incidents/services.py
@@ -251,6 +251,11 @@ def _update_parent_issue_status(
         return
 
     target_state = "completed" if all_complete else "started"
+
+    parent_issue = linear_service.get_issue(incident.linear_parent_issue_id)
+    if parent_issue and parent_issue.get("state_type") == target_state:
+        return
+
     state_id = states.get(target_state)
     if state_id and linear_service.update_issue(
         incident.linear_parent_issue_id, state_id=state_id

--- a/src/firetower/incidents/services.py
+++ b/src/firetower/incidents/services.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import transaction
 from django.utils import timezone
+from jinja2 import Environment, TemplateError
 
 from firetower.auth.models import ExternalProfile, ExternalProfileType
 from firetower.auth.services import (
@@ -185,6 +186,50 @@ def _resolve_assignees(
 
 COMPLETED_STATUSES = {ActionItemStatus.DONE, ActionItemStatus.CANCELED}
 
+_PARENT_STATUS_TEMPLATE_ENV = Environment(autoescape=False)
+
+
+def _comment_parent_issue_status_change(
+    incident: Incident,
+    linear_service: LinearService,
+    target_state: str,
+    statuses: list[str],
+) -> None:
+    if not settings.LINEAR or not incident.linear_parent_issue_id:
+        return
+
+    template_key = (
+        "PARENT_STATUS_COMMENT_COMPLETED"
+        if target_state == "completed"
+        else "PARENT_STATUS_COMMENT_STARTED"
+    )
+    template_source = settings.LINEAR.get(template_key, "")
+    if not template_source or not template_source.strip():
+        return
+
+    completed_action_items = sum(
+        1 for s in statuses if s in {ActionItemStatus.DONE, ActionItemStatus.CANCELED}
+    )
+    try:
+        comment = _PARENT_STATUS_TEMPLATE_ENV.from_string(template_source).render(
+            incident=incident,
+            total_action_items=len(statuses),
+            completed_action_items=completed_action_items,
+            target_state=target_state,
+        )
+    except TemplateError:
+        logger.exception(
+            f"Failed to render parent status comment template for incident {incident.id}"
+        )
+        return
+
+    try:
+        linear_service.create_comment(incident.linear_parent_issue_id, comment)
+    except Exception:
+        logger.exception(
+            f"Failed to post parent status comment for incident {incident.id}"
+        )
+
 
 def _update_parent_issue_status(
     incident: Incident, linear_service: LinearService
@@ -207,8 +252,12 @@ def _update_parent_issue_status(
 
     target_state = "completed" if all_complete else "started"
     state_id = states.get(target_state)
-    if state_id:
-        linear_service.update_issue(incident.linear_parent_issue_id, state_id=state_id)
+    if state_id and linear_service.update_issue(
+        incident.linear_parent_issue_id, state_id=state_id
+    ):
+        _comment_parent_issue_status_change(
+            incident, linear_service, target_state, statuses
+        )
 
 
 def _sync_parent_assignee(incident: Incident, linear_service: LinearService) -> None:

--- a/src/firetower/incidents/services.py
+++ b/src/firetower/incidents/services.py
@@ -253,7 +253,7 @@ def _update_parent_issue_status(
     target_state = "completed" if all_complete else "started"
 
     parent_issue = linear_service.get_issue(incident.linear_parent_issue_id)
-    if parent_issue and parent_issue.get("state_type") == target_state:
+    if not parent_issue or parent_issue.get("state_type") == target_state:
         return
 
     state_id = states.get(target_state)

--- a/src/firetower/incidents/tests/test_services.py
+++ b/src/firetower/incidents/tests/test_services.py
@@ -425,13 +425,14 @@ class TestUpdateParentIssueStatus:
             linear_parent_issue_id="lin-123",
         )
 
-    def _make_linear_service(self):
+    def _make_linear_service(self, current_state_type="unstarted"):
         svc = MagicMock()
         svc.get_workflow_states.return_value = {
             "started": "state-started",
             "completed": "state-completed",
         }
         svc.update_issue.return_value = True
+        svc.get_issue.return_value = {"state_type": current_state_type}
         return svc
 
     @pytest.fixture(autouse=True)
@@ -554,6 +555,34 @@ class TestUpdateParentIssueStatus:
 
         svc.update_issue.assert_called_once_with("lin-123", state_id="state-completed")
         svc.create_comment.assert_not_called()
+
+    def test_skips_update_when_already_in_target_state(self):
+        incident = self._make_incident(status=IncidentStatus.ACTIVE)
+        svc = self._make_linear_service(current_state_type="started")
+
+        _update_parent_issue_status(incident, svc)
+
+        svc.update_issue.assert_not_called()
+        svc.create_comment.assert_not_called()
+
+    def test_updates_when_in_different_state(self):
+        incident = self._make_incident(status=IncidentStatus.DONE)
+        svc = self._make_linear_service(current_state_type="started")
+
+        _update_parent_issue_status(incident, svc)
+
+        svc.update_issue.assert_called_once_with("lin-123", state_id="state-completed")
+        svc.create_comment.assert_called_once()
+
+    def test_updates_when_get_issue_fails(self):
+        incident = self._make_incident(status=IncidentStatus.ACTIVE)
+        svc = self._make_linear_service()
+        svc.get_issue.return_value = None
+
+        _update_parent_issue_status(incident, svc)
+
+        svc.update_issue.assert_called_once_with("lin-123", state_id="state-started")
+        svc.create_comment.assert_called_once()
 
 
 @pytest.mark.django_db

--- a/src/firetower/incidents/tests/test_services.py
+++ b/src/firetower/incidents/tests/test_services.py
@@ -16,6 +16,7 @@ from firetower.incidents.models import (
     IncidentStatus,
 )
 from firetower.incidents.services import (
+    _comment_parent_issue_status_change,
     _update_parent_issue_status,
     sync_incident_participants_from_slack,
 )
@@ -531,3 +532,126 @@ class TestUpdateParentIssueStatus:
         _update_parent_issue_status(incident, svc)
 
         svc.update_issue.assert_called_once_with("lin-123", state_id="state-started")
+
+
+@pytest.mark.django_db
+class TestCommentParentIssueStatusChange:
+    def _make_incident(self, status=IncidentStatus.ACTIVE):
+        return Incident.objects.create(
+            title="Test Incident",
+            status=status,
+            severity=IncidentSeverity.P1,
+            linear_parent_issue_id="lin-123",
+        )
+
+    @pytest.fixture(autouse=True)
+    def _linear_settings(self, settings):
+        settings.LINEAR = {
+            "TEAM_ID": "team-1",
+            "API_KEY": "key",
+            "PARENT_STATUS_COMMENT_COMPLETED": (
+                "Set to Completed. "
+                "Incident {{ incident.incident_number }} is {{ incident.status }}. "
+                "{{ completed_action_items }}/{{ total_action_items }} done."
+            ),
+            "PARENT_STATUS_COMMENT_STARTED": (
+                "Set to Started. "
+                "Incident {{ incident.incident_number }} is {{ incident.status }}. "
+                "{{ completed_action_items }}/{{ total_action_items }} done."
+            ),
+        }
+
+    def test_posts_completed_comment(self):
+        incident = self._make_incident(status=IncidentStatus.DONE)
+        svc = MagicMock()
+
+        _comment_parent_issue_status_change(
+            incident, svc, "completed", ["Done", "Done"]
+        )
+
+        svc.create_comment.assert_called_once_with(
+            "lin-123",
+            f"Set to Completed. Incident {incident.incident_number} is Done. 2/2 done.",
+        )
+
+    def test_posts_started_comment_with_mixed_statuses(self):
+        incident = self._make_incident(status=IncidentStatus.ACTIVE)
+        svc = MagicMock()
+
+        _comment_parent_issue_status_change(
+            incident, svc, "started", ["Done", "In Progress", "Todo"]
+        )
+
+        svc.create_comment.assert_called_once_with(
+            "lin-123",
+            f"Set to Started. Incident {incident.incident_number} is Active. 1/3 done.",
+        )
+
+    def test_counts_canceled_as_completed(self):
+        incident = self._make_incident(status=IncidentStatus.DONE)
+        svc = MagicMock()
+
+        _comment_parent_issue_status_change(
+            incident, svc, "completed", ["Done", "Canceled"]
+        )
+
+        svc.create_comment.assert_called_once_with(
+            "lin-123",
+            f"Set to Completed. Incident {incident.incident_number} is Done. 2/2 done.",
+        )
+
+    def test_empty_template_skips_comment(self, settings):
+        settings.LINEAR["PARENT_STATUS_COMMENT_COMPLETED"] = ""
+        incident = self._make_incident(status=IncidentStatus.DONE)
+        svc = MagicMock()
+
+        _comment_parent_issue_status_change(incident, svc, "completed", ["Done"])
+
+        svc.create_comment.assert_not_called()
+
+    def test_whitespace_only_template_skips_comment(self, settings):
+        settings.LINEAR["PARENT_STATUS_COMMENT_STARTED"] = "   "
+        incident = self._make_incident(status=IncidentStatus.ACTIVE)
+        svc = MagicMock()
+
+        _comment_parent_issue_status_change(incident, svc, "started", ["Todo"])
+
+        svc.create_comment.assert_not_called()
+
+    def test_no_action_items(self):
+        incident = self._make_incident(status=IncidentStatus.DONE)
+        svc = MagicMock()
+
+        _comment_parent_issue_status_change(incident, svc, "completed", [])
+
+        svc.create_comment.assert_called_once_with(
+            "lin-123",
+            f"Set to Completed. Incident {incident.incident_number} is Done. 0/0 done.",
+        )
+
+    def test_create_comment_failure_logs_and_continues(self):
+        incident = self._make_incident(status=IncidentStatus.DONE)
+        svc = MagicMock()
+        svc.create_comment.return_value = False
+
+        _comment_parent_issue_status_change(incident, svc, "completed", ["Done"])
+
+        svc.create_comment.assert_called_once()
+
+    def test_create_comment_exception_logs_and_continues(self):
+        incident = self._make_incident(status=IncidentStatus.DONE)
+        svc = MagicMock()
+        svc.create_comment.side_effect = Exception("API error")
+
+        _comment_parent_issue_status_change(incident, svc, "completed", ["Done"])
+
+        svc.create_comment.assert_called_once()
+
+    def test_template_render_error_logs_and_continues(self, settings):
+        settings.LINEAR["PARENT_STATUS_COMMENT_COMPLETED"] = "{{ unterminated"
+        incident = self._make_incident(status=IncidentStatus.DONE)
+        svc = MagicMock()
+
+        _comment_parent_issue_status_change(incident, svc, "completed", ["Done"])
+
+        svc.create_comment.assert_not_called()

--- a/src/firetower/incidents/tests/test_services.py
+++ b/src/firetower/incidents/tests/test_services.py
@@ -574,15 +574,15 @@ class TestUpdateParentIssueStatus:
         svc.update_issue.assert_called_once_with("lin-123", state_id="state-completed")
         svc.create_comment.assert_called_once()
 
-    def test_updates_when_get_issue_fails(self):
+    def test_skips_update_when_get_issue_fails(self):
         incident = self._make_incident(status=IncidentStatus.ACTIVE)
         svc = self._make_linear_service()
         svc.get_issue.return_value = None
 
         _update_parent_issue_status(incident, svc)
 
-        svc.update_issue.assert_called_once_with("lin-123", state_id="state-started")
-        svc.create_comment.assert_called_once()
+        svc.update_issue.assert_not_called()
+        svc.create_comment.assert_not_called()
 
 
 @pytest.mark.django_db

--- a/src/firetower/incidents/tests/test_services.py
+++ b/src/firetower/incidents/tests/test_services.py
@@ -431,11 +431,17 @@ class TestUpdateParentIssueStatus:
             "started": "state-started",
             "completed": "state-completed",
         }
+        svc.update_issue.return_value = True
         return svc
 
     @pytest.fixture(autouse=True)
     def _linear_settings(self, settings):
-        settings.LINEAR = {"TEAM_ID": "team-1", "API_KEY": "key"}
+        settings.LINEAR = {
+            "TEAM_ID": "team-1",
+            "API_KEY": "key",
+            "PARENT_STATUS_COMMENT_COMPLETED": "completed comment",
+            "PARENT_STATUS_COMMENT_STARTED": "started comment",
+        }
 
     def test_active_incident_no_action_items_sets_started(self):
         incident = self._make_incident(status=IncidentStatus.ACTIVE)
@@ -444,6 +450,7 @@ class TestUpdateParentIssueStatus:
         _update_parent_issue_status(incident, svc)
 
         svc.update_issue.assert_called_once_with("lin-123", state_id="state-started")
+        svc.create_comment.assert_called_once()
 
     def test_active_incident_all_items_done_sets_started(self):
         incident = self._make_incident(status=IncidentStatus.ACTIVE)
@@ -460,6 +467,7 @@ class TestUpdateParentIssueStatus:
         _update_parent_issue_status(incident, svc)
 
         svc.update_issue.assert_called_once_with("lin-123", state_id="state-started")
+        svc.create_comment.assert_called_once()
 
     def test_done_incident_no_action_items_sets_completed(self):
         incident = self._make_incident(status=IncidentStatus.DONE)
@@ -468,6 +476,7 @@ class TestUpdateParentIssueStatus:
         _update_parent_issue_status(incident, svc)
 
         svc.update_issue.assert_called_once_with("lin-123", state_id="state-completed")
+        svc.create_comment.assert_called_once()
 
     def test_done_incident_all_items_done_sets_completed(self):
         incident = self._make_incident(status=IncidentStatus.DONE)
@@ -492,6 +501,7 @@ class TestUpdateParentIssueStatus:
         _update_parent_issue_status(incident, svc)
 
         svc.update_issue.assert_called_once_with("lin-123", state_id="state-completed")
+        svc.create_comment.assert_called_once()
 
     def test_done_incident_incomplete_items_sets_started(self):
         incident = self._make_incident(status=IncidentStatus.DONE)
@@ -516,6 +526,7 @@ class TestUpdateParentIssueStatus:
         _update_parent_issue_status(incident, svc)
 
         svc.update_issue.assert_called_once_with("lin-123", state_id="state-started")
+        svc.create_comment.assert_called_once()
 
     def test_mitigated_incident_all_items_done_sets_started(self):
         incident = self._make_incident(status=IncidentStatus.MITIGATED)
@@ -532,6 +543,17 @@ class TestUpdateParentIssueStatus:
         _update_parent_issue_status(incident, svc)
 
         svc.update_issue.assert_called_once_with("lin-123", state_id="state-started")
+        svc.create_comment.assert_called_once()
+
+    def test_update_issue_failure_skips_comment(self):
+        incident = self._make_incident(status=IncidentStatus.DONE)
+        svc = self._make_linear_service()
+        svc.update_issue.return_value = False
+
+        _update_parent_issue_status(incident, svc)
+
+        svc.update_issue.assert_called_once_with("lin-123", state_id="state-completed")
+        svc.create_comment.assert_not_called()
 
 
 @pytest.mark.django_db

--- a/src/firetower/integrations/services/linear.py
+++ b/src/firetower/integrations/services/linear.py
@@ -201,6 +201,7 @@ class LinearService:
             "identifier": issue["identifier"],
             "title": issue["title"],
             "url": issue["url"],
+            "state_type": (issue.get("state") or {}).get("type", ""),
         }
 
     def get_user_by_email(self, email: str) -> dict[str, str] | None:

--- a/src/firetower/integrations/tests/test_linear_service.py
+++ b/src/firetower/integrations/tests/test_linear_service.py
@@ -436,3 +436,62 @@ class TestGetUserByEmail:
             result = linear_service.get_user_by_email("alice@example.com")
 
         assert result is None
+
+
+class TestGetIssue:
+    def test_returns_issue_with_state_type(self, linear_service):
+        mock_response = {
+            "issue": {
+                "id": "issue-123",
+                "identifier": "LIN-42",
+                "title": "Fix the thing",
+                "url": "https://linear.app/team/issue/LIN-42",
+                "priority": 1,
+                "state": {"type": "started"},
+                "assignee": {"id": "user-1", "email": "alice@example.com"},
+            }
+        }
+
+        with patch.object(linear_service, "_graphql", return_value=mock_response):
+            result = linear_service.get_issue("issue-123")
+
+        assert result == {
+            "id": "issue-123",
+            "identifier": "LIN-42",
+            "title": "Fix the thing",
+            "url": "https://linear.app/team/issue/LIN-42",
+            "state_type": "started",
+        }
+
+    def test_returns_empty_state_type_when_state_is_null(self, linear_service):
+        mock_response = {
+            "issue": {
+                "id": "issue-123",
+                "identifier": "LIN-42",
+                "title": "Fix the thing",
+                "url": "https://linear.app/team/issue/LIN-42",
+                "priority": 1,
+                "state": None,
+                "assignee": None,
+            }
+        }
+
+        with patch.object(linear_service, "_graphql", return_value=mock_response):
+            result = linear_service.get_issue("issue-123")
+
+        assert result is not None
+        assert result["state_type"] == ""
+
+    def test_returns_none_on_api_failure(self, linear_service):
+        with patch.object(linear_service, "_graphql", return_value=None):
+            result = linear_service.get_issue("issue-123")
+
+        assert result is None
+
+    def test_returns_none_when_issue_not_found(self, linear_service):
+        mock_response = {"issue": None}
+
+        with patch.object(linear_service, "_graphql", return_value=mock_response):
+            result = linear_service.get_issue("nonexistent")
+
+        assert result is None

--- a/src/firetower/settings.py
+++ b/src/firetower/settings.py
@@ -327,6 +327,8 @@ LINEAR: dict | None = (
         "ACTION_ITEM_SLO_DAYS_MEDIUM_PRIORITY": config.linear.action_item_slo_days_medium_priority,
         "ACTION_ITEM_NAG_COMMENT_HIGH_PRIORITY": config.linear.action_item_nag_comment_high_priority,
         "ACTION_ITEM_NAG_COMMENT_MEDIUM_PRIORITY": config.linear.action_item_nag_comment_medium_priority,
+        "PARENT_STATUS_COMMENT_COMPLETED": config.linear.parent_status_comment_completed,
+        "PARENT_STATUS_COMMENT_STARTED": config.linear.parent_status_comment_started,
     }
     if config.linear
     else None


### PR DESCRIPTION
When Firetower changes the parent Linear ticket's workflow state (via `_update_parent_issue_status()`), it now posts a comment explaining why the transition happened -- e.g., "Firetower set this issue to **Completed**. Incident INC-2001 is Done and all 3 action item(s) are complete."

This gives visibility into automated state changes directly in Linear, so people looking at the ticket understand why it moved without needing to check Firetower.

Comments are only posted after a successful `update_issue()` call. Template rendering errors and API failures are logged but do not block the state change.


Agent transcript: https://claudescope.sentry.dev/share/pzP9lcJ0H-hmoz7k_UeCk-Poj0JBO-AJkfGFWzMo0b0