### PR TITLE
feat(action-items): Deep-link to Linear create-sub-issue form for action items

### DIFF
--- a/frontend/src/routes/$incidentId/components/ActionItemsList.test.tsx
+++ b/frontend/src/routes/$incidentId/components/ActionItemsList.test.tsx
@@ -1,5 +1,6 @@
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {TooltipProvider} from 'components/Tooltip';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
@@ -150,5 +151,50 @@ describe('ActionItemsList', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Sync action items'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Create action item'})).toBeInTheDocument();
+  });
+
+  it('opens Linear create-sub-issue URL when parent issue ID is available', async () => {
+    mockApiGet.mockResolvedValue([]);
+    const windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+    renderWithProviders(
+      <ActionItemsList
+        incidentId="INC-1"
+        linearUrl="https://linear.app/myworkspace/issue/INC-1"
+        linearParentIssueId="abc-123-def"
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Create action item'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Create in Linear'}));
+
+    expect(windowOpenSpy).toHaveBeenCalledWith(
+      'https://linear.app/myworkspace/new?parentId=abc-123-def',
+      '_blank',
+      'noopener,noreferrer'
+    );
+    windowOpenSpy.mockRestore();
+  });
+
+  it('falls back to parent issue URL when parent issue ID is not available', async () => {
+    mockApiGet.mockResolvedValue([]);
+    const windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+    renderWithProviders(
+      <ActionItemsList
+        incidentId="INC-1"
+        linearUrl="https://linear.app/myworkspace/issue/INC-1"
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Create action item'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Create in Linear'}));
+
+    expect(windowOpenSpy).toHaveBeenCalledWith(
+      'https://linear.app/myworkspace/issue/INC-1',
+      '_blank',
+      'noopener,noreferrer'
+    );
+    windowOpenSpy.mockRestore();
   });
 });

--- a/frontend/src/routes/$incidentId/components/ActionItemsList.tsx
+++ b/frontend/src/routes/$incidentId/components/ActionItemsList.tsx
@@ -62,10 +62,7 @@ function ActionItemCard({item}: {item: ActionItem}) {
   );
 }
 
-function buildLinearCreateUrl(
-  linearUrl: string,
-  parentIssueId: string
-): string | null {
+function buildLinearCreateUrl(linearUrl: string, parentIssueId: string): string | null {
   try {
     const url = new URL(linearUrl);
     const workspace = url.pathname.split('/')[1];

--- a/frontend/src/routes/$incidentId/components/ActionItemsList.tsx
+++ b/frontend/src/routes/$incidentId/components/ActionItemsList.tsx
@@ -62,12 +62,31 @@ function ActionItemCard({item}: {item: ActionItem}) {
   );
 }
 
+function buildLinearCreateUrl(
+  linearUrl: string,
+  parentIssueId: string
+): string | null {
+  try {
+    const url = new URL(linearUrl);
+    const workspace = url.pathname.split('/')[1];
+    if (!workspace) return null;
+    return `https://linear.app/${workspace}/new?parentId=${parentIssueId}`;
+  } catch {
+    return null;
+  }
+}
+
 interface ActionItemsListProps {
   incidentId: string;
   linearUrl?: string;
+  linearParentIssueId?: string | null;
 }
 
-export function ActionItemsList({incidentId, linearUrl}: ActionItemsListProps) {
+export function ActionItemsList({
+  incidentId,
+  linearUrl,
+  linearParentIssueId,
+}: ActionItemsListProps) {
   const queryClient = useQueryClient();
   const syncMutation = useMutation(
     syncActionItemsMutationOptions(queryClient, incidentId)
@@ -127,8 +146,8 @@ export function ActionItemsList({incidentId, linearUrl}: ActionItemsListProps) {
           title="Create Action Item"
           message={
             <>
-              You'll be taken to the parent Linear issue for the incident. Create your
-              action item as a sub-issue or related issue there.
+              You'll be taken to Linear to create a sub-issue under the parent incident
+              issue.
               <br />
               <br />
               Make sure to assign the issue to the appropriate team as issues in the
@@ -154,9 +173,11 @@ export function ActionItemsList({incidentId, linearUrl}: ActionItemsListProps) {
               </ul>
             </>
           }
-          confirmLabel="Open Linear"
+          confirmLabel="Create in Linear"
           onConfirm={() => {
-            window.open(linearUrl, '_blank', 'noopener,noreferrer');
+            const createUrl =
+              linearParentIssueId && buildLinearCreateUrl(linearUrl, linearParentIssueId);
+            window.open(createUrl || linearUrl, '_blank', 'noopener,noreferrer');
             setShowCreateDialog(false);
           }}
           onCancel={() => setShowCreateDialog(false)}

--- a/frontend/src/routes/$incidentId/index.tsx
+++ b/frontend/src/routes/$incidentId/index.tsx
@@ -66,6 +66,7 @@ function Incident() {
           <ActionItemsList
             incidentId={params.incidentId}
             linearUrl={incident.external_links.linear}
+            linearParentIssueId={incident.linear_parent_issue_id}
           />
         </section>
 

--- a/frontend/src/routes/$incidentId/queries/incidentDetailQueryOptions.ts
+++ b/frontend/src/routes/$incidentId/queries/incidentDetailQueryOptions.ts
@@ -39,6 +39,7 @@ const IncidentDetailSchema = z.object({
   impact_type_tags: z.array(z.string()),
   participants: z.array(ParticipantSchema),
   external_links: ExternalLinksSchema,
+  linear_parent_issue_id: z.string().nullable(),
   time_started: z.string().nullable(),
   time_detected: z.string().nullable(),
   time_analyzed: z.string().nullable(),

--- a/src/firetower/incidents/serializers.py
+++ b/src/firetower/incidents/serializers.py
@@ -157,6 +157,7 @@ class IncidentDetailUISerializer(serializers.ModelSerializer):
             "root_cause_tags",
             "impact_type_tags",
             "external_links",
+            "linear_parent_issue_id",
             "created_at",
             "updated_at",
             "time_started",
@@ -168,6 +169,7 @@ class IncidentDetailUISerializer(serializers.ModelSerializer):
         ]
         read_only_fields = [
             "id",
+            "linear_parent_issue_id",
             "created_at",
             "updated_at",
             "time_started",

--- a/src/firetower/incidents/tests/test_serializers.py
+++ b/src/firetower/incidents/tests/test_serializers.py
@@ -148,6 +148,9 @@ class TestIncidentDetailUISerializer:
         assert "linear" not in data["external_links"]  # Not set, so not included
         assert len(data["external_links"]) == 1
 
+        # Check linear_parent_issue_id is exposed (null when not set)
+        assert data["linear_parent_issue_id"] is None
+
 
 @pytest.mark.django_db
 class TestIncidentWriteSerializerHooks:


### PR DESCRIPTION
When creating action items, users were taken to the parent Linear issue and often confused it for the action item itself. Now the "Create Action Item" button opens Linear's create-issue form with the parent pre-set via `?parentId=`, so users land directly on a new sub-issue form.

**Changes:**
- Expose `linear_parent_issue_id` from the incident detail API
- Construct a `https://linear.app/{workspace}/new?parentId={id}` deep-link on the frontend
- Update dialog copy to reflect sub-issue creation and rename button to "Create in Linear"
- Fall back to opening the parent issue URL when the parent ID is unavailable


Agent transcript: https://claudescope.sentry.dev/share/UMKLifuN0pgTBM50ucsv8UeilmQAFlbeetx-XuRibNo