### PR TITLE
doc(linear): Add team-sre contact to Linear description template

### DIFF
--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -969,7 +969,8 @@ LINEAR_PARENT_DESCRIPTION = (
     "Child issues or other relations (related, blocking, etc.) will all work. "
     "Do not update title, status or captain here, use Firetower for that.\n\n"
     "Firetower will reopen this ticket if the incident is reopened, or if "
-    "there are still unfinished action items."
+    "there are still unfinished action items. "
+    "If you have questions, please reach out to #team-sre."
 )
 
 


### PR DESCRIPTION
Appends a contact line to the Linear ticket description so users know where to ask questions about Firetower automation.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC08RJKP6NR0%3A1780992576.590079%22)