### PR TITLE
fix(incidents): Skip status page reminders for private incidents

### DIFF
--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -1101,9 +1101,7 @@ def _schedule_statuspage_reminder(
     reference_time: datetime | None = None,
     allow_update: bool = False,
 ) -> None:
-    if incident.is_private:
-        return
-    if incident.severity not in HIGH_SEVERITIES:
+    if incident.is_private or incident.severity not in HIGH_SEVERITIES:
         return
 
     delay_minutes = get_statuspage_initial_reminder_delay_minutes()
@@ -1132,11 +1130,11 @@ def _schedule_statuspage_reminder(
 def schedule_statuspage_followup_reminder(
     incident: Incident, *, reschedule_count: int = 0
 ) -> None:
-    if incident.is_private:
-        return
-    if incident.severity not in HIGH_SEVERITIES:
-        return
-    if incident.status not in ACTIVE_STATUSES:
+    if (
+        incident.is_private
+        or incident.severity not in HIGH_SEVERITIES
+        or incident.status not in ACTIVE_STATUSES
+    ):
         return
 
     delay_minutes = get_statuspage_followup_reminder_delay_minutes()

--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -1101,6 +1101,8 @@ def _schedule_statuspage_reminder(
     reference_time: datetime | None = None,
     allow_update: bool = False,
 ) -> None:
+    if incident.is_private:
+        return
     if incident.severity not in HIGH_SEVERITIES:
         return
 
@@ -1130,6 +1132,8 @@ def _schedule_statuspage_reminder(
 def schedule_statuspage_followup_reminder(
     incident: Incident, *, reschedule_count: int = 0
 ) -> None:
+    if incident.is_private:
+        return
     if incident.severity not in HIGH_SEVERITIES:
         return
     if incident.status not in ACTIVE_STATUSES:

--- a/src/firetower/incidents/tasks/statuspage.py
+++ b/src/firetower/incidents/tasks/statuspage.py
@@ -64,6 +64,8 @@ def send_statuspage_reminder(incident_id: int, scheduled_at: str | None = None) 
         logger.warning(f"Incident {incident_id} not found for statuspage reminder")
         return
 
+    if incident.is_private:
+        return
     if incident.severity not in HIGH_SEVERITIES:
         return
     if incident.status not in ACTIVE_STATUSES:
@@ -126,6 +128,8 @@ def send_statuspage_followup_reminder(
         )
         return
 
+    if incident.is_private:
+        return
     if incident.severity not in HIGH_SEVERITIES:
         return
     if incident.status not in ACTIVE_STATUSES:

--- a/src/firetower/incidents/tasks/statuspage.py
+++ b/src/firetower/incidents/tasks/statuspage.py
@@ -64,11 +64,11 @@ def send_statuspage_reminder(incident_id: int, scheduled_at: str | None = None) 
         logger.warning(f"Incident {incident_id} not found for statuspage reminder")
         return
 
-    if incident.is_private:
-        return
-    if incident.severity not in HIGH_SEVERITIES:
-        return
-    if incident.status not in ACTIVE_STATUSES:
+    if (
+        incident.is_private
+        or incident.severity not in HIGH_SEVERITIES
+        or incident.status not in ACTIVE_STATUSES
+    ):
         return
 
     has_statuspage = incident.external_links.filter(
@@ -128,11 +128,11 @@ def send_statuspage_followup_reminder(
         )
         return
 
-    if incident.is_private:
-        return
-    if incident.severity not in HIGH_SEVERITIES:
-        return
-    if incident.status not in ACTIVE_STATUSES:
+    if (
+        incident.is_private
+        or incident.severity not in HIGH_SEVERITIES
+        or incident.status not in ACTIVE_STATUSES
+    ):
         return
 
     has_statuspage = incident.external_links.filter(

--- a/src/firetower/incidents/tests/test_hooks.py
+++ b/src/firetower/incidents/tests/test_hooks.py
@@ -2830,6 +2830,14 @@ class TestScheduleStatuspageReminder:
             name=f"statuspage_reminder_{incident.id}"
         ).exists()
 
+    def test_skips_for_private_incident(self):
+        incident = self._make_incident(severity=IncidentSeverity.P0, is_private=True)
+        _schedule_statuspage_reminder(incident)
+
+        assert not Schedule.objects.filter(
+            name=f"statuspage_reminder_{incident.id}"
+        ).exists()
+
     def test_skips_for_p2(self):
         incident = self._make_incident(severity=IncidentSeverity.P2)
         _schedule_statuspage_reminder(incident)
@@ -3031,6 +3039,14 @@ class TestScheduleStatuspageFollowupReminder:
         schedule_statuspage_followup_reminder(incident)
 
         assert Schedule.objects.filter(
+            name=f"statuspage_followup_reminder_{incident.id}"
+        ).exists()
+
+    def test_skips_for_private_incident(self):
+        incident = self._make_incident(severity=IncidentSeverity.P0, is_private=True)
+        schedule_statuspage_followup_reminder(incident)
+
+        assert not Schedule.objects.filter(
             name=f"statuspage_followup_reminder_{incident.id}"
         ).exists()
 

--- a/src/firetower/incidents/tests/test_tasks.py
+++ b/src/firetower/incidents/tests/test_tasks.py
@@ -403,6 +403,18 @@ class TestSendStatuspageReminder:
 
         mock_slack.post_message.assert_not_called()
 
+    def test_skips_for_private_incident(self):
+        incident = self._make_incident(severity=IncidentSeverity.P0, is_private=True)
+        self._make_link(incident, ExternalLinkType.SLACK)
+
+        mock_slack = MagicMock()
+        with patch(
+            "firetower.incidents.tasks.statuspage.SlackService", return_value=mock_slack
+        ):
+            send_statuspage_reminder(incident.id)
+
+        mock_slack.post_message.assert_not_called()
+
     def test_skips_when_incident_not_found(self):
         mock_slack = MagicMock()
         with patch(
@@ -664,6 +676,23 @@ class TestSendStatuspageFollowupReminder:
                     "WARNING_BUFFER_MINUTES": 0,
                 },
             ),
+        ):
+            send_statuspage_followup_reminder(incident.id)
+
+        mock_slack.post_message.assert_not_called()
+
+    def test_skips_for_private_incident(self):
+        incident = self._make_incident(severity=IncidentSeverity.P0, is_private=True)
+        self._make_link(incident, ExternalLinkType.SLACK)
+        self._make_link(
+            incident,
+            ExternalLinkType.STATUSPAGE,
+            url="https://manage.statuspage.io/incidents/abc123",
+        )
+
+        mock_slack = MagicMock()
+        with patch(
+            "firetower.incidents.tasks.statuspage.SlackService", return_value=mock_slack
         ):
             send_statuspage_followup_reminder(incident.id)
 


### PR DESCRIPTION
Private incidents were still receiving status page reminders (both initial and followup), even though other hooks (status channel creation, Datadog notebook, troubleshooting doc, feed messages) already skip for private incidents.

Added `is_private` guards at both layers:
- **Scheduling** (`_schedule_statuspage_reminder`, `schedule_statuspage_followup_reminder` in hooks.py) -- prevents creating unnecessary scheduled tasks
- **Execution** (`send_statuspage_reminder`, `send_statuspage_followup_reminder` in tasks/statuspage.py) -- safety net if the incident becomes private after the task was already scheduled

Resolves RELENG-830


Agent transcript: https://claudescope.sentry.dev/share/vsMuJLM5ppTXgISgZvcrX-asK7LqdnVPfJy8vveyvpg