### PR TITLE
fix(incidents): Skip paging and on-call invites for private incidents

### DIFF
--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -114,6 +114,9 @@ def page_for_channel(
     """
     paged: set[str] = set()
 
+    if is_private:
+        return paged
+
     if severity not in HIGH_SEVERITIES:
         return paged
 
@@ -125,12 +128,7 @@ def page_for_channel(
 
     pd_service = None
 
-    policies_to_page = (
-        {"IMOC": PAGING_POLICIES["IMOC"]} if is_private else PAGING_POLICIES
-    )
-    title = "Private Incident" if is_private else title
-
-    for policy_name, policy_info in policies_to_page.items():
+    for policy_name, policy_info in PAGING_POLICIES.items():
         policy = escalation_policies.get(policy_name)
         if not policy:
             logger.info(f"No {policy_name} escalation policy configured, skipping page")
@@ -296,6 +294,9 @@ def _invite_oncall_to_channel(
     paged_policies: set[str] | None = None,
 ) -> None:
     """Invite on-call users to a channel. No DB access."""
+    if is_private:
+        return
+
     if severity not in HIGH_SEVERITIES:
         return
 
@@ -314,13 +315,7 @@ def _invite_oncall_to_channel(
     role_entries: list[tuple[int, int, str]] = []
     users_to_invite: list[tuple[str, str]] = []
 
-    policies_to_invite = (
-        {"IMOC": PAGING_POLICIES["IMOC"]} if is_private else PAGING_POLICIES
-    )
-
-    for policy_index, (policy_name, policy_info) in enumerate(
-        policies_to_invite.items()
-    ):
+    for policy_index, (policy_name, policy_info) in enumerate(PAGING_POLICIES.items()):
         policy_label = policy_info.label
         max_level = policy_info.max_level
         policy = escalation_policies.get(policy_name)

--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -114,10 +114,7 @@ def page_for_channel(
     """
     paged: set[str] = set()
 
-    if is_private:
-        return paged
-
-    if severity not in HIGH_SEVERITIES:
+    if is_private or severity not in HIGH_SEVERITIES:
         return paged
 
     pd_config = settings.PAGERDUTY
@@ -294,10 +291,7 @@ def _invite_oncall_to_channel(
     paged_policies: set[str] | None = None,
 ) -> None:
     """Invite on-call users to a channel. No DB access."""
-    if is_private:
-        return
-
-    if severity not in HIGH_SEVERITIES:
+    if is_private or severity not in HIGH_SEVERITIES:
         return
 
     pd_config = settings.PAGERDUTY

--- a/src/firetower/incidents/tests/test_hooks.py
+++ b/src/firetower/incidents/tests/test_hooks.py
@@ -940,11 +940,9 @@ class TestPageIfNeeded:
         assert "PROD_ENG" in mock_pd.trigger_incident.call_args[0][1]
 
     @patch("firetower.incidents.hooks.PagerDutyService")
-    def test_private_incident_pages_only_imoc(self, mock_pd_cls, settings):
+    def test_private_incident_does_not_page(self, mock_pd_cls, settings):
         settings.PAGERDUTY = MOCK_PD_CONFIG
         settings.FIRETOWER_BASE_URL = "https://firetower.example.com"
-        mock_pd = mock_pd_cls.return_value
-        mock_pd.trigger_incident.return_value = True
 
         incident = Incident.objects.create(
             title="Sensitive issue",
@@ -952,15 +950,10 @@ class TestPageIfNeeded:
             is_private=True,
         )
 
-        _page_if_needed(incident)
+        result = _page_if_needed(incident)
 
-        mock_pd.trigger_incident.assert_called_once()
-        summary = mock_pd.trigger_incident.call_args[0][0]
-        dedup_key = mock_pd.trigger_incident.call_args[0][1]
-        assert "IMOC" in dedup_key
-        assert "PROD_ENG" not in dedup_key
-        assert "Private Incident" in summary
-        assert "Sensitive issue" not in summary
+        mock_pd_cls.assert_not_called()
+        assert result == set()
 
     @patch("firetower.incidents.hooks.PagerDutyService")
     def test_pages_only_configured_policies(self, mock_pd_cls, settings):
@@ -1302,15 +1295,10 @@ class TestInviteOncallUsers:
 
     @patch("firetower.incidents.hooks._slack_service")
     @patch("firetower.incidents.hooks.PagerDutyService")
-    def test_private_incident_invites_only_imoc(
+    def test_private_incident_skips_oncall_invite(
         self, mock_pd_cls, mock_slack, settings
     ):
         settings.PAGERDUTY = MOCK_PD_CONFIG
-        mock_pd = mock_pd_cls.return_value
-        mock_pd.get_oncall_users.return_value = [
-            {"email": "imoc@example.com", "escalation_level": 1},
-        ]
-        mock_slack.get_user_profile_by_email.return_value = {"slack_user_id": "U_IMOC"}
 
         incident = Incident.objects.create(
             title="Sensitive issue",
@@ -1320,11 +1308,9 @@ class TestInviteOncallUsers:
 
         _invite_oncall_users(incident, "C99999")
 
-        mock_pd.get_oncall_users.assert_called_once_with("PIMOC01")
-        mock_slack.invite_to_channel.assert_called_once_with("C99999", ["U_IMOC"])
-        message = mock_slack.post_message.call_args[0][1]
-        assert "On-Call Incident Manager: <@U_IMOC>" in message
-        assert "Prod Eng" not in message
+        mock_pd_cls.assert_not_called()
+        mock_slack.invite_to_channel.assert_not_called()
+        mock_slack.post_message.assert_not_called()
 
     @patch("firetower.incidents.hooks._slack_service")
     @patch("firetower.incidents.hooks.PagerDutyService")


### PR DESCRIPTION
Private incidents previously paged IMOC and invited IMOC on-call users to the Slack channel. This changes both `page_for_channel` and `_invite_oncall_to_channel` to return early when `is_private=True`, so private incidents trigger no PagerDuty pages and no on-call user invitations at all.

The rationale is that private incidents should be fully contained -- only the creator and explicitly added participants should be aware of them.

This also simplifies the code by removing the conditional policy filtering (`policies_to_page`/`policies_to_invite` dicts) and the "Private Incident" title masking, since neither function proceeds past the early return for private incidents.
0

Resolves RELENG-829

Agent transcript: https://claudescope.sentry.dev/share/qsIWVQpzXBWCvgFuxekwvsr7zSfwgYS5xraF9KBrBZk