### PR TITLE
feat(slack): add "mitigate" as alias for the mitigated command

### DIFF
--- a/src/firetower/slack_app/bolt.py
+++ b/src/firetower/slack_app/bolt.py
@@ -62,6 +62,7 @@ KNOWN_SUBCOMMANDS = {
     "backfill",
     "mitigated",
     "mit",
+    "mitigate",
     "resolved",
     "fixed",
     "reopen",
@@ -143,7 +144,7 @@ def handle_command(
             handle_backfill_command(ack, body, command, respond)
         elif subcommand in ("help", ""):
             handle_help_command(ack, command, respond)
-        elif subcommand in ("mitigated", "mit"):
+        elif subcommand in ("mitigated", "mit", "mitigate"):
             handle_mitigated_command(ack, body, command, respond)
         elif subcommand in ("resolved", "fixed"):
             handle_resolved_command(ack, body, command, respond)

--- a/src/firetower/slack_app/handlers/help.py
+++ b/src/firetower/slack_app/handlers/help.py
@@ -14,7 +14,7 @@ def handle_help_command(ack: Any, command: dict, respond: Any) -> None:
         f"  `{cmd} captain` - Set incident captain (alias: `{cmd} ic`)\n"
         f"  `{cmd} dumpslack` - Update slack transcript in postmortem doc\n"
         f"  `{cmd} list` - List active and mitigated incidents (alias: `{cmd} ls`)\n"
-        f"  `{cmd} mitigated` - Mark incident as mitigated (alias: `{cmd} mit`)\n"
+        f"  `{cmd} mitigated` - Mark incident as mitigated (aliases: `{cmd} mit`, `{cmd} mitigate`)\n"
         f"  `{cmd} resolved` - Mark incident as resolved (alias: `{cmd} fixed`)\n"
         f"  `{cmd} reopen` - Reopen an incident\n"
         f"  `{cmd} cancel` - Cancel an incident\n"


### PR DESCRIPTION
Adds `mitigate` as a third accepted subcommand alongside `mitigated` and `mit`, so `/ft mitigate` works the same way.

Changes:
- `bolt.py`: add `"mitigate"` to `KNOWN_SUBCOMMANDS` and the dispatch branch
- `handlers/help.py`: update the help text to list all three aliases

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC0BA731G1SA%3A1781291754.040619%22)