### PR TITLE
fix(slack): Handle archived channels gracefully instead of logging errors

### DIFF
--- a/src/firetower/integrations/services/slack.py
+++ b/src/firetower/integrations/services/slack.py
@@ -318,6 +318,11 @@ class SlackService:
                             f"Error posting message after joining channel: {retry_error}",
                             extra={"channel_id": channel_id},
                         )
+                else:
+                    logger.error(
+                        f"Failed to join channel {channel_id} for message retry",
+                        extra={"channel_id": channel_id},
+                    )
             else:
                 logger.error(
                     f"Error posting message: {e}", extra={"channel_id": channel_id}
@@ -373,6 +378,11 @@ class SlackService:
                             f"Error adding bookmark after joining channel: {retry_error}",
                             extra={"channel_id": channel_id},
                         )
+                else:
+                    logger.error(
+                        f"Failed to join channel {channel_id} for bookmark retry",
+                        extra={"channel_id": channel_id},
+                    )
             else:
                 logger.error(
                     f"Error adding bookmark: {e}", extra={"channel_id": channel_id}

--- a/src/firetower/integrations/services/slack.py
+++ b/src/firetower/integrations/services/slack.py
@@ -205,10 +205,13 @@ class SlackService:
             self.client.conversations_rename(channel=channel_id, name=name)
             return True
         except SlackApiError as e:
-            logger.error(
-                f"Error renaming channel: {e}",
-                extra={"channel_id": channel_id, "new_name": name},
-            )
+            if e.response.get("error") == "is_archived":
+                logger.warning(f"Cannot rename archived channel {channel_id}, skipping")
+            else:
+                logger.error(
+                    f"Error renaming channel: {e}",
+                    extra={"channel_id": channel_id, "new_name": name},
+                )
             return False
 
     def set_channel_topic(self, channel_id: str, topic: str) -> bool:
@@ -221,10 +224,15 @@ class SlackService:
             self.client.conversations_setTopic(channel=channel_id, topic=topic)
             return True
         except SlackApiError as e:
-            logger.error(
-                f"Error setting channel topic: {e}",
-                extra={"channel_id": channel_id},
-            )
+            if e.response.get("error") == "is_archived":
+                logger.warning(
+                    f"Cannot set topic on archived channel {channel_id}, skipping"
+                )
+            else:
+                logger.error(
+                    f"Error setting channel topic: {e}",
+                    extra={"channel_id": channel_id},
+                )
             return False
 
     def set_all_channel_topics(
@@ -250,10 +258,15 @@ class SlackService:
             if e.response.get("error") == "already_in_channel":
                 logger.info(f"Users already in channel {channel_id}")
                 return True
-            logger.error(
-                f"Error inviting to channel: {e}",
-                extra={"channel_id": channel_id},
-            )
+            if e.response.get("error") == "is_archived":
+                logger.warning(
+                    f"Cannot invite to archived channel {channel_id}, skipping"
+                )
+            else:
+                logger.error(
+                    f"Error inviting to channel: {e}",
+                    extra={"channel_id": channel_id},
+                )
             return False
 
     def join_channel(self, channel_id: str) -> bool:
@@ -266,9 +279,12 @@ class SlackService:
             self.client.conversations_join(channel=channel_id)
             return True
         except SlackApiError as e:
-            logger.error(
-                f"Error joining channel: {e}", extra={"channel_id": channel_id}
-            )
+            if e.response.get("error") == "is_archived":
+                logger.warning(f"Cannot join archived channel {channel_id}, skipping")
+            else:
+                logger.error(
+                    f"Error joining channel: {e}", extra={"channel_id": channel_id}
+                )
             return False
 
     def post_message(
@@ -285,7 +301,11 @@ class SlackService:
             )
             return response.get("ts")
         except SlackApiError as e:
-            if e.response.get("error") == "not_in_channel":
+            if e.response.get("error") == "is_archived":
+                logger.warning(
+                    f"Cannot post to archived channel {channel_id}, skipping"
+                )
+            elif e.response.get("error") == "not_in_channel":
                 logger.info(f"Not in channel {channel_id}, joining and retrying post")
                 if self.join_channel(channel_id):
                     try:
@@ -298,10 +318,10 @@ class SlackService:
                             f"Error posting message after joining channel: {retry_error}",
                             extra={"channel_id": channel_id},
                         )
-                        return None
-            logger.error(
-                f"Error posting message: {e}", extra={"channel_id": channel_id}
-            )
+            else:
+                logger.error(
+                    f"Error posting message: {e}", extra={"channel_id": channel_id}
+                )
             return None
 
     def pin_message(self, channel_id: str, message_ts: str) -> bool:
@@ -314,9 +334,12 @@ class SlackService:
             self.client.pins_add(channel=channel_id, timestamp=message_ts)
             return True
         except SlackApiError as e:
-            logger.error(
-                f"Error pinning message: {e}", extra={"channel_id": channel_id}
-            )
+            if e.response.get("error") == "is_archived":
+                logger.warning(f"Cannot pin in archived channel {channel_id}, skipping")
+            else:
+                logger.error(
+                    f"Error pinning message: {e}", extra={"channel_id": channel_id}
+                )
             return False
 
     def add_bookmark(self, channel_id: str, title: str, link: str) -> bool:
@@ -331,7 +354,11 @@ class SlackService:
             )
             return True
         except SlackApiError as e:
-            if e.response.get("error") == "not_in_channel":
+            if e.response.get("error") == "is_archived":
+                logger.warning(
+                    f"Cannot bookmark in archived channel {channel_id}, skipping"
+                )
+            elif e.response.get("error") == "not_in_channel":
                 logger.info(
                     f"Not in channel {channel_id}, joining and retrying bookmark"
                 )
@@ -346,10 +373,10 @@ class SlackService:
                             f"Error adding bookmark after joining channel: {retry_error}",
                             extra={"channel_id": channel_id},
                         )
-                        return False
-            logger.error(
-                f"Error adding bookmark: {e}", extra={"channel_id": channel_id}
-            )
+            else:
+                logger.error(
+                    f"Error adding bookmark: {e}", extra={"channel_id": channel_id}
+                )
             return False
 
     def build_channel_url(self, channel_id: str) -> str:
@@ -367,6 +394,7 @@ class SlackService:
                 "id": channel.get("id", ""),
                 "name": channel.get("name", ""),
                 "is_private": channel.get("is_private", False),
+                "is_archived": channel.get("is_archived", False),
             }
         except SlackApiError as e:
             logger.error(

--- a/src/firetower/integrations/tests/test_slack.py
+++ b/src/firetower/integrations/tests/test_slack.py
@@ -333,7 +333,12 @@ class TestSlackService:
         mock_client.conversations_join.side_effect = SlackApiError(
             "channel_not_found", join_error_response
         )
-        assert service.post_message("C12345", "hello") is None
+        with patch("firetower.integrations.services.slack.logger") as mock_logger:
+            assert service.post_message("C12345", "hello") is None
+            mock_logger.error.assert_any_call(
+                "Failed to join channel C12345 for message retry",
+                extra={"channel_id": "C12345"},
+            )
         mock_client.conversations_join.assert_called_once_with(channel="C12345")
         assert mock_client.chat_postMessage.call_count == 1
 
@@ -397,7 +402,14 @@ class TestSlackService:
         mock_client.conversations_join.side_effect = SlackApiError(
             "channel_not_found", join_error_response
         )
-        assert service.add_bookmark("C12345", "title", "https://example.com") is False
+        with patch("firetower.integrations.services.slack.logger") as mock_logger:
+            assert (
+                service.add_bookmark("C12345", "title", "https://example.com") is False
+            )
+            mock_logger.error.assert_any_call(
+                "Failed to join channel C12345 for bookmark retry",
+                extra={"channel_id": "C12345"},
+            )
         mock_client.conversations_join.assert_called_once_with(channel="C12345")
         assert mock_client.bookmarks_add.call_count == 1
 

--- a/src/firetower/integrations/tests/test_slack.py
+++ b/src/firetower/integrations/tests/test_slack.py
@@ -591,6 +591,46 @@ class TestSlackService:
         mock_client.pins_add.side_effect = SlackApiError("error", mock_response)
         assert service.pin_message("C12345", "1234567890.123456") is False
 
+    def _make_archived_error(self):
+        mock_response = MagicMock()
+        mock_response.get.return_value = "is_archived"
+        return SlackApiError("is_archived", mock_response)
+
+    def test_join_channel_archived(self):
+        service, mock_client = self._make_service()
+        mock_client.conversations_join.side_effect = self._make_archived_error()
+        assert service.join_channel("C12345") is False
+
+    def test_post_message_archived(self):
+        service, mock_client = self._make_service()
+        mock_client.chat_postMessage.side_effect = self._make_archived_error()
+        assert service.post_message("C12345", "hello") is None
+
+    def test_pin_message_archived(self):
+        service, mock_client = self._make_service()
+        mock_client.pins_add.side_effect = self._make_archived_error()
+        assert service.pin_message("C12345", "1234567890.123456") is False
+
+    def test_add_bookmark_archived(self):
+        service, mock_client = self._make_service()
+        mock_client.bookmarks_add.side_effect = self._make_archived_error()
+        assert service.add_bookmark("C12345", "title", "https://example.com") is False
+
+    def test_invite_to_channel_archived(self):
+        service, mock_client = self._make_service()
+        mock_client.conversations_invite.side_effect = self._make_archived_error()
+        assert service.invite_to_channel("C12345", ["U111"]) is False
+
+    def test_rename_channel_archived(self):
+        service, mock_client = self._make_service()
+        mock_client.conversations_rename.side_effect = self._make_archived_error()
+        assert service.rename_channel("C12345", "new-name") is False
+
+    def test_set_channel_topic_archived(self):
+        service, mock_client = self._make_service()
+        mock_client.conversations_setTopic.side_effect = self._make_archived_error()
+        assert service.set_channel_topic("C12345", "topic") is False
+
 
 class TestIsSlackGuest:
     def test_returns_true_for_restricted_user(self):

--- a/src/firetower/slack_app/handlers/backfill_incident.py
+++ b/src/firetower/slack_app/handlers/backfill_incident.py
@@ -48,6 +48,15 @@ def _build_backfill_modal(channel_id: str, user_id: str = "") -> dict:
 def _setup_channel_for_incident(
     incident: Any, channel_id: str, notify_user_id: str, client: Any
 ) -> None:
+    channel_info = _slack_service.get_channel_info(channel_id)
+    if channel_info and channel_info.get("is_archived"):
+        logger.warning(
+            "Skipping setup for archived channel %s on incident %s",
+            channel_id,
+            incident.id,
+        )
+        return
+
     joined = _slack_service.join_channel(channel_id)
     if not joined:
         base_url = settings.FIRETOWER_BASE_URL
@@ -70,7 +79,6 @@ def _setup_channel_for_incident(
         return
 
     expected_name = build_channel_name(incident)
-    channel_info = _slack_service.get_channel_info(channel_id)
     if channel_info and channel_info["name"] != expected_name:
         renamed = _slack_service.rename_channel(channel_id, expected_name)
         if not renamed:

--- a/src/firetower/slack_app/handlers/backfill_incident.py
+++ b/src/firetower/slack_app/handlers/backfill_incident.py
@@ -78,6 +78,9 @@ def _setup_channel_for_incident(
             )
         return
 
+    if not channel_info:
+        channel_info = _slack_service.get_channel_info(channel_id)
+
     expected_name = build_channel_name(incident)
     if channel_info and channel_info["name"] != expected_name:
         renamed = _slack_service.rename_channel(channel_id, expected_name)

--- a/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
+++ b/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
@@ -497,6 +497,7 @@ class TestBackfillSubmission:
         )
         mock_slack_svc.get_channel_info.side_effect = [
             None,
+            None,
             {
                 "id": "C_TEST",
                 "name": "wrong-name",
@@ -515,7 +516,7 @@ class TestBackfillSubmission:
         incident = Incident.objects.get(title="Test Backfill")
         expected_name = incident.incident_number.lower()
         mock_slack_svc.rename_channel.assert_called_once_with("C_TEST", expected_name)
-        assert mock_slack_svc.get_channel_info.call_count == 2
+        assert mock_slack_svc.get_channel_info.call_count == 3
 
     def test_empty_title_returns_modal_error(self):
         ack = MagicMock()

--- a/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
+++ b/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
@@ -480,6 +480,43 @@ class TestBackfillSubmission:
         incident = Incident.objects.get(title="Test Backfill")
         assert incident.is_private is True
 
+    @patch(
+        "firetower.slack_app.handlers.backfill_incident.sync_incident_participants_from_slack"
+    )
+    @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
+    @patch(
+        "firetower.slack_app.handlers.backfill_incident.get_or_create_user_from_slack_id"
+    )
+    @patch("firetower.incidents.serializers.on_incident_created")
+    def test_retries_channel_info_after_join_when_initial_fetch_failed(
+        self, mock_hook, mock_get_user, mock_slack_svc, mock_sync
+    ):
+        mock_get_user.return_value = self.user
+        mock_slack_svc.build_channel_url.return_value = (
+            "https://T0000.slack.com/archives/C_TEST"
+        )
+        mock_slack_svc.get_channel_info.side_effect = [
+            None,
+            {
+                "id": "C_TEST",
+                "name": "wrong-name",
+                "is_private": False,
+            },
+        ]
+        mock_slack_svc.join_channel.return_value = True
+        mock_slack_svc.rename_channel.return_value = True
+
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_TEST"}}
+
+        handle_backfill_submission(ack, body, self._build_view(), client)
+
+        incident = Incident.objects.get(title="Test Backfill")
+        expected_name = incident.incident_number.lower()
+        mock_slack_svc.rename_channel.assert_called_once_with("C_TEST", expected_name)
+        assert mock_slack_svc.get_channel_info.call_count == 2
+
     def test_empty_title_returns_modal_error(self):
         ack = MagicMock()
         client = MagicMock()

--- a/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
+++ b/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
@@ -306,6 +306,39 @@ class TestBackfillSubmission:
         assert "could not join" in msg
         assert "/ft backfill" in msg
 
+    @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
+    @patch(
+        "firetower.slack_app.handlers.backfill_incident.get_or_create_user_from_slack_id"
+    )
+    @patch("firetower.incidents.serializers.on_incident_created")
+    def test_skips_setup_for_archived_channel(
+        self, mock_hook, mock_get_user, mock_slack_svc
+    ):
+        mock_get_user.return_value = self.user
+        mock_slack_svc.build_channel_url.return_value = (
+            "https://T0000.slack.com/archives/C_TEST"
+        )
+        mock_slack_svc.get_channel_info.return_value = {
+            "id": "C_TEST",
+            "name": f"{settings.PROJECT_KEY.lower()}-2050",
+            "is_private": False,
+            "is_archived": True,
+        }
+
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_TEST"}}
+
+        handle_backfill_submission(ack, body, self._build_view(), client)
+
+        incident = Incident.objects.get(title="Test Backfill")
+        assert incident is not None
+
+        mock_slack_svc.join_channel.assert_not_called()
+        mock_slack_svc.set_channel_topic.assert_not_called()
+        mock_slack_svc.add_bookmark.assert_not_called()
+        client.chat_postMessage.assert_not_called()
+
     @patch(
         "firetower.slack_app.handlers.backfill_incident.sync_incident_participants_from_slack"
     )


### PR DESCRIPTION
Catch the Slack API 'is_archived' error in all channel-mutating methods (join, post, pin, bookmark, invite, rename, set topic) and log a warning instead of an error. Also add an upfront archived-channel check in the backfill handler to skip setup entirely and avoid sending a misleading DM about inviting the bot.

Fixes FIRETOWER-BACKEND-4D
Co-Authored-By: Claude <noreply@anthropic.com>

Agent transcript: https://claudescope.sentry.dev/share/iSJ8GLrggJu2yvWAMY0Qg8VvHJ9AgfdC3lL8L3cly6A