### PR TITLE
feat(statuspage): add region hint to statuspage modal message field

### DIFF
--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -139,8 +139,8 @@ def _build_statuspage_modal(
             "hint": {
                 "type": "plain_text",
                 "text": (
-                    "If impact is region-specific, mention US1, US2, or 'all US' "
-                    "in your message so customers know which region is affected."
+                    "If impact is specific to US1 or US2 mention that in your message "
+                    "so customers know whether they are affected."
                 ),
             },
         }

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -136,6 +136,13 @@ def _build_statuspage_modal(
                 },
             },
             "label": {"type": "plain_text", "text": "Message"},
+            "hint": {
+                "type": "plain_text",
+                "text": (
+                    "If impact is region-specific, mention US1, US2, or 'all US' "
+                    "in your message so customers know which region is affected."
+                ),
+            },
         }
     )
 


### PR DESCRIPTION
## What

Adds a Block Kit `hint` below the Message input in the statuspage modal (both new post and update flows) reminding ICs to specify which US region is affected.

The hint reads:
> If impact is region-specific, mention US1, US2, or 'all US' in your message so customers know which region is affected.

## Why

With US2 coming online, a single "US" statuspage update is ambiguous — customers on US1 vs US2 need to know if they're actually affected. This is a low-friction nudge at the exact moment ICs are writing the public-facing message.

Context: discussed in #team-sre as part of US2 region launch prep.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC08RJKP6NR0%3A1781648289.628049%22)