### PR TITLE
fix(statuspage): use US instead of US1 in region hint

### DIFF
--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -139,7 +139,7 @@ def _build_statuspage_modal(
             "hint": {
                 "type": "plain_text",
                 "text": (
-                    "If impact is specific to US1 or US2 mention that in your message "
+                    "If impact is specific to US or US2 mention that in your message "
                     "so customers know whether they are affected."
                 ),
             },


### PR DESCRIPTION
Follows up on #257 — changes "US1" to "US" in the statuspage modal hint, since existing customers know their region as "US" not "US1".

Hint now reads:
> If impact is specific to US or US2 mention that in your message so customers know whether they are affected.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC08RJKP6NR0%3A1781648289.628049%22)