### PR TITLE
fix: Make Linear parent status one-way and sync assignee on captain change

### DIFF
--- a/src/firetower/config.py
+++ b/src/firetower/config.py
@@ -100,12 +100,6 @@ class LinearConfig:
         "{% else %}all {{ total_action_items }} action "
         "item{% if total_action_items != 1 %}s{% endif %} are complete.{% endif %}"
     )
-    parent_status_comment_started: str = (
-        "Firetower set this issue to **Started**. "
-        "Incident {{ incident.incident_number }} is {{ incident.status }}. "
-        "{{ completed_action_items }} of {{ total_action_items }} action "
-        "item{% if total_action_items != 1 %}s{% endif %} complete."
-    )
 
 
 @deserialize

--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -1002,7 +1002,7 @@ LINEAR_PARENT_DESCRIPTION = (
     "Child issues or other relations (related, blocking, etc.) will all work. "
     "Do not update title, status or captain here, use Firetower for that.\n\n"
     "Firetower will mark this ticket completed once the incident is resolved and "
-    "all action items are done. It will not reopen it after that. "
+    "all action items are done."
     "If you have questions, please reach out to #team-sre."
 )
 

--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -982,12 +982,27 @@ def _sync_linear_title(incident: Incident) -> None:
         )
 
 
+def _sync_linear_assignee(incident: Incident) -> None:
+    if not settings.LINEAR or not incident.linear_parent_issue_id:
+        return
+    try:
+        linear_service = _get_linear_service()
+        captain_linear_id = _resolve_linear_user_id(incident.captain, linear_service)
+        linear_service.update_issue(
+            incident.linear_parent_issue_id, assignee_id=captain_linear_id
+        )
+    except Exception:
+        logger.exception(
+            f"Failed to update Linear issue assignee for incident {incident.id}"
+        )
+
+
 LINEAR_PARENT_DESCRIPTION = (
     "Relate action items to this ticket to have them tracked by Firetower. "
     "Child issues or other relations (related, blocking, etc.) will all work. "
     "Do not update title, status or captain here, use Firetower for that.\n\n"
-    "Firetower will reopen this ticket if the incident is reopened, or if "
-    "there are still unfinished action items. "
+    "Firetower will mark this ticket completed once the incident is resolved and "
+    "all action items are done. It will not reopen it after that. "
     "If you have questions, please reach out to #team-sre."
 )
 
@@ -1651,3 +1666,7 @@ def on_incident_updated(
     # Title or visibility change: sync linear
     if old_title is not None or visibility_changed:
         _sync_linear_title(incident)
+
+    # Captain change: sync linear assignee
+    if captain_changed:
+        _sync_linear_assignee(incident)

--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -1002,7 +1002,7 @@ LINEAR_PARENT_DESCRIPTION = (
     "Child issues or other relations (related, blocking, etc.) will all work. "
     "Do not update title, status or captain here, use Firetower for that.\n\n"
     "Firetower will mark this ticket completed once the incident is resolved and "
-    "all action items are done."
+    "all action items are done. "
     "If you have questions, please reach out to #team-sre."
 )
 

--- a/src/firetower/incidents/services.py
+++ b/src/firetower/incidents/services.py
@@ -246,22 +246,23 @@ def _update_parent_issue_status(
         not statuses or all(s in COMPLETED_STATUSES for s in statuses)
     )
 
+    if not all_complete:
+        return
+
     states = linear_service.get_workflow_states(team_id)
     if not states:
         return
 
-    target_state = "completed" if all_complete else "started"
-
     parent_issue = linear_service.get_issue(incident.linear_parent_issue_id)
-    if not parent_issue or parent_issue.get("state_type") == target_state:
+    if not parent_issue or parent_issue.get("state_type") == "completed":
         return
 
-    state_id = states.get(target_state)
+    state_id = states.get("completed")
     if state_id and linear_service.update_issue(
         incident.linear_parent_issue_id, state_id=state_id
     ):
         _comment_parent_issue_status_change(
-            incident, linear_service, target_state, statuses
+            incident, linear_service, "completed", statuses
         )
 
 

--- a/src/firetower/incidents/services.py
+++ b/src/firetower/incidents/services.py
@@ -189,21 +189,15 @@ COMPLETED_STATUSES = {ActionItemStatus.DONE, ActionItemStatus.CANCELED}
 _PARENT_STATUS_TEMPLATE_ENV = Environment(autoescape=False)
 
 
-def _comment_parent_issue_status_change(
+def _comment_parent_issue_completed(
     incident: Incident,
     linear_service: LinearService,
-    target_state: str,
     statuses: list[str],
 ) -> None:
     if not settings.LINEAR or not incident.linear_parent_issue_id:
         return
 
-    template_key = (
-        "PARENT_STATUS_COMMENT_COMPLETED"
-        if target_state == "completed"
-        else "PARENT_STATUS_COMMENT_STARTED"
-    )
-    template_source = settings.LINEAR.get(template_key, "")
+    template_source = settings.LINEAR.get("PARENT_STATUS_COMMENT_COMPLETED", "")
     if not template_source or not template_source.strip():
         return
 
@@ -215,7 +209,7 @@ def _comment_parent_issue_status_change(
             incident=incident,
             total_action_items=len(statuses),
             completed_action_items=completed_action_items,
-            target_state=target_state,
+            target_state="completed",
         )
     except TemplateError:
         logger.exception(
@@ -261,20 +255,7 @@ def _update_parent_issue_status(
     if state_id and linear_service.update_issue(
         incident.linear_parent_issue_id, state_id=state_id
     ):
-        _comment_parent_issue_status_change(
-            incident, linear_service, "completed", statuses
-        )
-
-
-def _sync_parent_assignee(incident: Incident, linear_service: LinearService) -> None:
-    if not incident.linear_parent_issue_id:
-        return
-    from firetower.incidents.hooks import _resolve_linear_user_id  # noqa: PLC0415
-
-    captain_linear_id = _resolve_linear_user_id(incident.captain, linear_service)
-    linear_service.update_issue(
-        incident.linear_parent_issue_id, assignee_id=captain_linear_id
-    )
+        _comment_parent_issue_completed(incident, linear_service, statuses)
 
 
 def sync_action_items_from_linear(
@@ -406,13 +387,6 @@ def sync_action_items_from_linear(
     except Exception:
         logger.exception(
             f"Failed to update Linear parent issue status for incident {incident.id}"
-        )
-
-    try:
-        _sync_parent_assignee(incident, linear_service)
-    except Exception:
-        logger.exception(
-            f"Failed to sync Linear parent assignee for incident {incident.id}"
         )
 
     logger.info(

--- a/src/firetower/incidents/services.py
+++ b/src/firetower/incidents/services.py
@@ -209,7 +209,6 @@ def _comment_parent_issue_completed(
             incident=incident,
             total_action_items=len(statuses),
             completed_action_items=completed_action_items,
-            target_state="completed",
         )
     except TemplateError:
         logger.exception(

--- a/src/firetower/incidents/tests/test_action_items.py
+++ b/src/firetower/incidents/tests/test_action_items.py
@@ -435,7 +435,7 @@ class TestSyncActionItemsFromLinear:
                 "parent-issue-id", state_id="state-done"
             )
 
-    def test_sets_parent_to_started_when_incomplete_items(self, settings):
+    def test_does_not_change_parent_state_when_incomplete_items(self, settings):
         settings.LINEAR = {"TEAM_ID": "team-1"}
         incident = self._make_incident()
 
@@ -460,9 +460,8 @@ class TestSyncActionItemsFromLinear:
 
             sync_action_items_from_linear(incident, force=True)
 
-            mock_service.update_issue.assert_any_call(
-                "parent-issue-id", state_id="state-started"
-            )
+            for call in mock_service.update_issue.call_args_list:
+                assert "state_id" not in call.kwargs
 
     def test_completes_parent_when_no_action_items(self, settings):
         settings.LINEAR = {"TEAM_ID": "team-1"}

--- a/src/firetower/incidents/tests/test_action_items.py
+++ b/src/firetower/incidents/tests/test_action_items.py
@@ -437,14 +437,14 @@ class TestSyncActionItemsFromLinear:
 
     def test_does_not_change_parent_state_when_incomplete_items(self, settings):
         settings.LINEAR = {"TEAM_ID": "team-1"}
-        incident = self._make_incident()
+        incident = self._make_incident(status=IncidentStatus.DONE)
 
         children = [
             _make_linear_issue(
                 id="id-1", identifier="ENG-1", title="T1", status="Done"
             ),
             _make_linear_issue(
-                id="id-2", identifier="ENG-2", title="T2", status="Todo"
+                id="id-2", identifier="ENG-2", title="T2", status="In Progress"
             ),
         ]
 

--- a/src/firetower/incidents/tests/test_action_items.py
+++ b/src/firetower/incidents/tests/test_action_items.py
@@ -483,7 +483,7 @@ class TestSyncActionItemsFromLinear:
                 "parent-issue-id", state_id="state-done"
             )
 
-    def test_syncs_captain_as_parent_assignee(self, settings):
+    def test_does_not_push_parent_assignee_on_sync(self, settings):
         settings.LINEAR = {"TEAM_ID": "team-1"}
         captain = User.objects.create_user(
             username="captain@example.com",
@@ -505,26 +505,8 @@ class TestSyncActionItemsFromLinear:
 
             sync_action_items_from_linear(incident, force=True)
 
-            mock_service.update_issue.assert_any_call(
-                "parent-issue-id", assignee_id="linear-captain-id"
-            )
-
-    def test_unassigns_parent_when_no_captain(self, settings):
-        settings.LINEAR = {"TEAM_ID": "team-1"}
-        incident = self._make_incident(captain=None)
-
-        with patch("firetower.incidents.services._get_linear_service") as mock_get:
-            mock_service = mock_get.return_value
-            mock_service.get_child_issues.return_value = []
-            mock_service.get_related_issues.return_value = []
-            mock_service.get_workflow_states.return_value = None
-            mock_service.update_issue.return_value = True
-
-            sync_action_items_from_linear(incident, force=True)
-
-            mock_service.update_issue.assert_any_call(
-                "parent-issue-id", assignee_id=None
-            )
+            for call in mock_service.update_issue.call_args_list:
+                assert "assignee_id" not in call.kwargs
 
 
 @pytest.mark.django_db

--- a/src/firetower/incidents/tests/test_hooks.py
+++ b/src/firetower/incidents/tests/test_hooks.py
@@ -3522,6 +3522,24 @@ class TestOnIncidentUpdated:
 
     @patch("firetower.incidents.hooks._get_linear_service")
     @patch("firetower.incidents.hooks._slack_service")
+    def test_unassigns_linear_parent_when_no_captain(
+        self, mock_slack, mock_get_linear, settings
+    ):
+        settings.LINEAR = {"TEAM_ID": "team-1"}
+        mock_slack.parse_channel_id_from_url.return_value = None
+        mock_service = mock_get_linear.return_value
+        mock_service.update_issue.return_value = True
+
+        incident = self._make_incident(
+            captain=None, linear_parent_issue_id="linear-issue-id"
+        )
+
+        on_incident_updated(incident, captain_changed=True)
+
+        mock_service.update_issue.assert_any_call("linear-issue-id", assignee_id=None)
+
+    @patch("firetower.incidents.hooks._get_linear_service")
+    @patch("firetower.incidents.hooks._slack_service")
     def test_does_not_sync_linear_assignee_without_captain_change(
         self, mock_slack, mock_get_linear, settings
     ):

--- a/src/firetower/incidents/tests/test_hooks.py
+++ b/src/firetower/incidents/tests/test_hooks.py
@@ -3491,3 +3491,48 @@ class TestOnIncidentUpdated:
         messages = [c[0][1] for c in mock_slack.post_message.call_args_list]
         assert any("- Status:" in m for m in messages)
         assert any("private" in m for m in messages)
+
+    @patch("firetower.incidents.hooks._get_linear_service")
+    @patch("firetower.incidents.hooks._slack_service")
+    def test_syncs_linear_assignee_on_captain_change(
+        self, mock_slack, mock_get_linear, settings
+    ):
+        settings.LINEAR = {"TEAM_ID": "team-1"}
+        mock_slack.parse_channel_id_from_url.return_value = None
+        mock_service = mock_get_linear.return_value
+        mock_service.update_issue.return_value = True
+
+        captain = User.objects.create_user(
+            username="cap@example.com", email="cap@example.com"
+        )
+        ExternalProfile.objects.create(
+            user=captain,
+            type=ExternalProfileType.LINEAR,
+            external_id="linear-captain-id",
+        )
+        incident = self._make_incident(
+            captain=captain, linear_parent_issue_id="linear-issue-id"
+        )
+
+        on_incident_updated(incident, captain_changed=True)
+
+        mock_service.update_issue.assert_any_call(
+            "linear-issue-id", assignee_id="linear-captain-id"
+        )
+
+    @patch("firetower.incidents.hooks._get_linear_service")
+    @patch("firetower.incidents.hooks._slack_service")
+    def test_does_not_sync_linear_assignee_without_captain_change(
+        self, mock_slack, mock_get_linear, settings
+    ):
+        settings.LINEAR = {"TEAM_ID": "team-1"}
+        mock_slack.parse_channel_id_from_url.return_value = None
+
+        incident = self._make_incident(
+            status=IncidentStatus.MITIGATED,
+            linear_parent_issue_id="linear-issue-id",
+        )
+
+        on_incident_updated(incident, old_status=IncidentStatus.ACTIVE)
+
+        mock_get_linear.return_value.update_issue.assert_not_called()

--- a/src/firetower/incidents/tests/test_services.py
+++ b/src/firetower/incidents/tests/test_services.py
@@ -444,31 +444,55 @@ class TestUpdateParentIssueStatus:
             "PARENT_STATUS_COMMENT_STARTED": "started comment",
         }
 
-    def test_active_incident_no_action_items_sets_started(self):
-        incident = self._make_incident(status=IncidentStatus.ACTIVE)
-        svc = self._make_linear_service()
-
-        _update_parent_issue_status(incident, svc)
-
-        svc.update_issue.assert_called_once_with("lin-123", state_id="state-started")
-        svc.create_comment.assert_called_once()
-
-    def test_active_incident_all_items_done_sets_started(self):
-        incident = self._make_incident(status=IncidentStatus.ACTIVE)
-        ActionItem.objects.create(
+    def _add_item(self, incident, status, suffix="1"):
+        return ActionItem.objects.create(
             incident=incident,
-            linear_issue_id="li-1",
-            linear_identifier="INC-1",
-            title="Item 1",
-            status=ActionItemStatus.DONE,
-            url="https://linear.app/issue/1",
+            linear_issue_id=f"li-{suffix}",
+            linear_identifier=f"INC-{suffix}",
+            title=f"Item {suffix}",
+            status=status,
+            url=f"https://linear.app/issue/{suffix}",
         )
+
+    def test_active_incident_no_action_items_does_nothing(self):
+        incident = self._make_incident(status=IncidentStatus.ACTIVE)
         svc = self._make_linear_service()
 
         _update_parent_issue_status(incident, svc)
 
-        svc.update_issue.assert_called_once_with("lin-123", state_id="state-started")
-        svc.create_comment.assert_called_once()
+        svc.update_issue.assert_not_called()
+        svc.create_comment.assert_not_called()
+
+    def test_active_incident_all_items_done_does_nothing(self):
+        incident = self._make_incident(status=IncidentStatus.ACTIVE)
+        self._add_item(incident, ActionItemStatus.DONE)
+        svc = self._make_linear_service()
+
+        _update_parent_issue_status(incident, svc)
+
+        svc.update_issue.assert_not_called()
+        svc.create_comment.assert_not_called()
+
+    def test_mitigated_incident_all_items_done_does_nothing(self):
+        incident = self._make_incident(status=IncidentStatus.MITIGATED)
+        self._add_item(incident, ActionItemStatus.DONE)
+        svc = self._make_linear_service()
+
+        _update_parent_issue_status(incident, svc)
+
+        svc.update_issue.assert_not_called()
+        svc.create_comment.assert_not_called()
+
+    def test_done_incident_incomplete_items_does_nothing(self):
+        incident = self._make_incident(status=IncidentStatus.DONE)
+        self._add_item(incident, ActionItemStatus.DONE, "1")
+        self._add_item(incident, ActionItemStatus.IN_PROGRESS, "2")
+        svc = self._make_linear_service()
+
+        _update_parent_issue_status(incident, svc)
+
+        svc.update_issue.assert_not_called()
+        svc.create_comment.assert_not_called()
 
     def test_done_incident_no_action_items_sets_completed(self):
         incident = self._make_incident(status=IncidentStatus.DONE)
@@ -481,22 +505,8 @@ class TestUpdateParentIssueStatus:
 
     def test_done_incident_all_items_done_sets_completed(self):
         incident = self._make_incident(status=IncidentStatus.DONE)
-        ActionItem.objects.create(
-            incident=incident,
-            linear_issue_id="li-1",
-            linear_identifier="INC-1",
-            title="Item 1",
-            status=ActionItemStatus.DONE,
-            url="https://linear.app/issue/1",
-        )
-        ActionItem.objects.create(
-            incident=incident,
-            linear_issue_id="li-2",
-            linear_identifier="INC-2",
-            title="Item 2",
-            status=ActionItemStatus.CANCELED,
-            url="https://linear.app/issue/2",
-        )
+        self._add_item(incident, ActionItemStatus.DONE, "1")
+        self._add_item(incident, ActionItemStatus.CANCELED, "2")
         svc = self._make_linear_service()
 
         _update_parent_issue_status(incident, svc)
@@ -504,46 +514,14 @@ class TestUpdateParentIssueStatus:
         svc.update_issue.assert_called_once_with("lin-123", state_id="state-completed")
         svc.create_comment.assert_called_once()
 
-    def test_done_incident_incomplete_items_sets_started(self):
-        incident = self._make_incident(status=IncidentStatus.DONE)
-        ActionItem.objects.create(
-            incident=incident,
-            linear_issue_id="li-1",
-            linear_identifier="INC-1",
-            title="Item 1",
-            status=ActionItemStatus.DONE,
-            url="https://linear.app/issue/1",
-        )
-        ActionItem.objects.create(
-            incident=incident,
-            linear_issue_id="li-2",
-            linear_identifier="INC-2",
-            title="Item 2",
-            status=ActionItemStatus.IN_PROGRESS,
-            url="https://linear.app/issue/2",
-        )
+    def test_canceled_incident_all_items_done_sets_completed(self):
+        incident = self._make_incident(status=IncidentStatus.CANCELED)
+        self._add_item(incident, ActionItemStatus.DONE)
         svc = self._make_linear_service()
 
         _update_parent_issue_status(incident, svc)
 
-        svc.update_issue.assert_called_once_with("lin-123", state_id="state-started")
-        svc.create_comment.assert_called_once()
-
-    def test_mitigated_incident_all_items_done_sets_started(self):
-        incident = self._make_incident(status=IncidentStatus.MITIGATED)
-        ActionItem.objects.create(
-            incident=incident,
-            linear_issue_id="li-1",
-            linear_identifier="INC-1",
-            title="Item 1",
-            status=ActionItemStatus.DONE,
-            url="https://linear.app/issue/1",
-        )
-        svc = self._make_linear_service()
-
-        _update_parent_issue_status(incident, svc)
-
-        svc.update_issue.assert_called_once_with("lin-123", state_id="state-started")
+        svc.update_issue.assert_called_once_with("lin-123", state_id="state-completed")
         svc.create_comment.assert_called_once()
 
     def test_update_issue_failure_skips_comment(self):
@@ -556,9 +534,9 @@ class TestUpdateParentIssueStatus:
         svc.update_issue.assert_called_once_with("lin-123", state_id="state-completed")
         svc.create_comment.assert_not_called()
 
-    def test_skips_update_when_already_in_target_state(self):
-        incident = self._make_incident(status=IncidentStatus.ACTIVE)
-        svc = self._make_linear_service(current_state_type="started")
+    def test_skips_update_when_already_completed(self):
+        incident = self._make_incident(status=IncidentStatus.DONE)
+        svc = self._make_linear_service(current_state_type="completed")
 
         _update_parent_issue_status(incident, svc)
 
@@ -575,9 +553,20 @@ class TestUpdateParentIssueStatus:
         svc.create_comment.assert_called_once()
 
     def test_skips_update_when_get_issue_fails(self):
-        incident = self._make_incident(status=IncidentStatus.ACTIVE)
+        incident = self._make_incident(status=IncidentStatus.DONE)
         svc = self._make_linear_service()
         svc.get_issue.return_value = None
+
+        _update_parent_issue_status(incident, svc)
+
+        svc.update_issue.assert_not_called()
+        svc.create_comment.assert_not_called()
+
+    def test_never_reopens_when_item_reopens_after_completion(self):
+        incident = self._make_incident(status=IncidentStatus.DONE)
+        self._add_item(incident, ActionItemStatus.DONE, "1")
+        self._add_item(incident, ActionItemStatus.IN_PROGRESS, "2")
+        svc = self._make_linear_service(current_state_type="completed")
 
         _update_parent_issue_status(incident, svc)
 

--- a/src/firetower/incidents/tests/test_services.py
+++ b/src/firetower/incidents/tests/test_services.py
@@ -16,7 +16,7 @@ from firetower.incidents.models import (
     IncidentStatus,
 )
 from firetower.incidents.services import (
-    _comment_parent_issue_status_change,
+    _comment_parent_issue_completed,
     _update_parent_issue_status,
     sync_incident_participants_from_slack,
 )
@@ -441,7 +441,6 @@ class TestUpdateParentIssueStatus:
             "TEAM_ID": "team-1",
             "API_KEY": "key",
             "PARENT_STATUS_COMMENT_COMPLETED": "completed comment",
-            "PARENT_STATUS_COMMENT_STARTED": "started comment",
         }
 
     def _add_item(self, incident, status, suffix="1"):
@@ -575,8 +574,8 @@ class TestUpdateParentIssueStatus:
 
 
 @pytest.mark.django_db
-class TestCommentParentIssueStatusChange:
-    def _make_incident(self, status=IncidentStatus.ACTIVE):
+class TestCommentParentIssueCompleted:
+    def _make_incident(self, status=IncidentStatus.DONE):
         return Incident.objects.create(
             title="Test Incident",
             status=status,
@@ -594,46 +593,24 @@ class TestCommentParentIssueStatusChange:
                 "Incident {{ incident.incident_number }} is {{ incident.status }}. "
                 "{{ completed_action_items }}/{{ total_action_items }} done."
             ),
-            "PARENT_STATUS_COMMENT_STARTED": (
-                "Set to Started. "
-                "Incident {{ incident.incident_number }} is {{ incident.status }}. "
-                "{{ completed_action_items }}/{{ total_action_items }} done."
-            ),
         }
 
     def test_posts_completed_comment(self):
         incident = self._make_incident(status=IncidentStatus.DONE)
         svc = MagicMock()
 
-        _comment_parent_issue_status_change(
-            incident, svc, "completed", ["Done", "Done"]
-        )
+        _comment_parent_issue_completed(incident, svc, ["Done", "Done"])
 
         svc.create_comment.assert_called_once_with(
             "lin-123",
             f"Set to Completed. Incident {incident.incident_number} is Done. 2/2 done.",
         )
 
-    def test_posts_started_comment_with_mixed_statuses(self):
-        incident = self._make_incident(status=IncidentStatus.ACTIVE)
-        svc = MagicMock()
-
-        _comment_parent_issue_status_change(
-            incident, svc, "started", ["Done", "In Progress", "Todo"]
-        )
-
-        svc.create_comment.assert_called_once_with(
-            "lin-123",
-            f"Set to Started. Incident {incident.incident_number} is Active. 1/3 done.",
-        )
-
     def test_counts_canceled_as_completed(self):
         incident = self._make_incident(status=IncidentStatus.DONE)
         svc = MagicMock()
 
-        _comment_parent_issue_status_change(
-            incident, svc, "completed", ["Done", "Canceled"]
-        )
+        _comment_parent_issue_completed(incident, svc, ["Done", "Canceled"])
 
         svc.create_comment.assert_called_once_with(
             "lin-123",
@@ -645,16 +622,16 @@ class TestCommentParentIssueStatusChange:
         incident = self._make_incident(status=IncidentStatus.DONE)
         svc = MagicMock()
 
-        _comment_parent_issue_status_change(incident, svc, "completed", ["Done"])
+        _comment_parent_issue_completed(incident, svc, ["Done"])
 
         svc.create_comment.assert_not_called()
 
     def test_whitespace_only_template_skips_comment(self, settings):
-        settings.LINEAR["PARENT_STATUS_COMMENT_STARTED"] = "   "
-        incident = self._make_incident(status=IncidentStatus.ACTIVE)
+        settings.LINEAR["PARENT_STATUS_COMMENT_COMPLETED"] = "   "
+        incident = self._make_incident(status=IncidentStatus.DONE)
         svc = MagicMock()
 
-        _comment_parent_issue_status_change(incident, svc, "started", ["Todo"])
+        _comment_parent_issue_completed(incident, svc, ["Done"])
 
         svc.create_comment.assert_not_called()
 
@@ -662,7 +639,7 @@ class TestCommentParentIssueStatusChange:
         incident = self._make_incident(status=IncidentStatus.DONE)
         svc = MagicMock()
 
-        _comment_parent_issue_status_change(incident, svc, "completed", [])
+        _comment_parent_issue_completed(incident, svc, [])
 
         svc.create_comment.assert_called_once_with(
             "lin-123",
@@ -674,7 +651,7 @@ class TestCommentParentIssueStatusChange:
         svc = MagicMock()
         svc.create_comment.return_value = False
 
-        _comment_parent_issue_status_change(incident, svc, "completed", ["Done"])
+        _comment_parent_issue_completed(incident, svc, ["Done"])
 
         svc.create_comment.assert_called_once()
 
@@ -683,7 +660,7 @@ class TestCommentParentIssueStatusChange:
         svc = MagicMock()
         svc.create_comment.side_effect = Exception("API error")
 
-        _comment_parent_issue_status_change(incident, svc, "completed", ["Done"])
+        _comment_parent_issue_completed(incident, svc, ["Done"])
 
         svc.create_comment.assert_called_once()
 
@@ -692,6 +669,6 @@ class TestCommentParentIssueStatusChange:
         incident = self._make_incident(status=IncidentStatus.DONE)
         svc = MagicMock()
 
-        _comment_parent_issue_status_change(incident, svc, "completed", ["Done"])
+        _comment_parent_issue_completed(incident, svc, ["Done"])
 
         svc.create_comment.assert_not_called()

--- a/src/firetower/settings.py
+++ b/src/firetower/settings.py
@@ -328,7 +328,6 @@ LINEAR: dict | None = (
         "ACTION_ITEM_NAG_COMMENT_HIGH_PRIORITY": config.linear.action_item_nag_comment_high_priority,
         "ACTION_ITEM_NAG_COMMENT_MEDIUM_PRIORITY": config.linear.action_item_nag_comment_medium_priority,
         "PARENT_STATUS_COMMENT_COMPLETED": config.linear.parent_status_comment_completed,
-        "PARENT_STATUS_COMMENT_STARTED": config.linear.parent_status_comment_started,
     }
     if config.linear
     else None


### PR DESCRIPTION
Removes the automatic re-opening of the Linear parent issue based on action item status, which was confusing for people. Firetower now only ever advances the parent forward to Completed, once, when the incident is resolved and all action items are done, and never moves it back. Includes related cleanup:

- Fixes the parent issue description, which previously promised Firetower would reopen the ticket.
- Drops the dead started status-change comment template and its now-unused config key.
- Syncs the incident captain to the Linear assignee only when the captain actually changes, instead of overwriting a manually-set assignee on every action item sync.