### PR TITLE
fix: Reject bot users when assigning incident captain

### DIFF
--- a/src/firetower/slack_app/handlers/captain.py
+++ b/src/firetower/slack_app/handlers/captain.py
@@ -93,10 +93,23 @@ def handle_captain_submission(ack: Any, body: dict, view: dict, client: Any) -> 
         )
         return
 
+    submitter_slack_id = body["user"]["id"]
     slack_user_info = SlackService().get_user_info(captain_slack_id)
-    if slack_user_info and slack_user_info.get("is_bot"):
-        client.chat_postMessage(
+    if not slack_user_info:
+        logger.error(
+            "Could not fetch Slack info for selected captain %s", captain_slack_id
+        )
+        client.chat_postEphemeral(
             channel=channel_id,
+            user=submitter_slack_id,
+            text="Could not verify the selected user with Slack; "
+            "captain was not changed.",
+        )
+        return
+    if slack_user_info.get("is_bot"):
+        client.chat_postEphemeral(
+            channel=channel_id,
+            user=submitter_slack_id,
             text="Captain cannot be a bot user.",
         )
         return

--- a/src/firetower/slack_app/handlers/captain.py
+++ b/src/firetower/slack_app/handlers/captain.py
@@ -4,6 +4,7 @@ from typing import Any
 from firetower.auth.models import ExternalProfileType
 from firetower.auth.services import get_or_create_user_from_slack_id
 from firetower.incidents.serializers import IncidentWriteSerializer
+from firetower.integrations.services import SlackService
 from firetower.slack_app.handlers.utils import get_incident_from_channel
 
 logger = logging.getLogger(__name__)
@@ -89,6 +90,14 @@ def handle_captain_submission(ack: Any, body: dict, view: dict, client: Any) -> 
         client.chat_postMessage(
             channel=channel_id,
             text=f"*{incident.incident_number}* captain was not changed.",
+        )
+        return
+
+    slack_user_info = SlackService().get_user_info(captain_slack_id)
+    if slack_user_info and slack_user_info.get("is_bot"):
+        client.chat_postMessage(
+            channel=channel_id,
+            text="Captain cannot be a bot user.",
         )
         return
 

--- a/src/firetower/slack_app/handlers/captain.py
+++ b/src/firetower/slack_app/handlers/captain.py
@@ -110,7 +110,7 @@ def handle_captain_submission(ack: Any, body: dict, view: dict, client: Any) -> 
         client.chat_postEphemeral(
             channel=channel_id,
             user=submitter_slack_id,
-            text="Captain cannot be a bot user.",
+            text="Captain cannot be a bot user, please try again.",
         )
         return
 

--- a/src/firetower/slack_app/tests/handlers/test_captain.py
+++ b/src/firetower/slack_app/tests/handlers/test_captain.py
@@ -114,6 +114,28 @@ class TestCaptainSubmission:
         ack.assert_called_once()
         assert "Failed to resolve" in client.chat_postMessage.call_args[1]["text"]
 
+    @patch("firetower.slack_app.handlers.captain.SlackService")
+    @patch("firetower.slack_app.handlers.captain.get_or_create_user_from_slack_id")
+    def test_rejects_bot_user(self, mock_get_user, mock_slack_service, incident):
+        mock_slack_service.return_value.get_user_info.return_value = {"is_bot": True}
+        ack = MagicMock()
+        body = {"user": {"id": "U_SUBMITTER"}}
+        view = {
+            "state": {
+                "values": {
+                    "captain_block": {"captain_select": {"selected_user": "U_BOT"}}
+                }
+            },
+            "private_metadata": CHANNEL_ID,
+        }
+        client = MagicMock()
+
+        handle_captain_submission(ack, body, view, client)
+
+        ack.assert_called_once()
+        assert "bot user" in client.chat_postMessage.call_args[1]["text"]
+        mock_get_user.assert_not_called()
+
     def test_no_captain_selected(self, incident):
         ack = MagicMock()
         body = {"user": {"id": "U_SUBMITTER"}}

--- a/src/firetower/slack_app/tests/handlers/test_captain.py
+++ b/src/firetower/slack_app/tests/handlers/test_captain.py
@@ -71,9 +71,13 @@ class TestCaptainCommand:
 
 @pytest.mark.django_db
 class TestCaptainSubmission:
+    @patch("firetower.slack_app.handlers.captain.SlackService")
     @patch("firetower.incidents.serializers.on_incident_updated")
     @patch("firetower.slack_app.handlers.captain.get_or_create_user_from_slack_id")
-    def test_sets_captain(self, mock_get_user, mock_hook, user, incident):
+    def test_sets_captain(
+        self, mock_get_user, mock_hook, mock_slack_service, user, incident
+    ):
+        mock_slack_service.return_value.get_user_info.return_value = {"is_bot": False}
         mock_get_user.return_value = user
         ack = MagicMock()
         body = {"user": {"id": "U_SUBMITTER"}}
@@ -94,8 +98,10 @@ class TestCaptainSubmission:
         assert incident.captain == user
         client.chat_postMessage.assert_not_called()
 
+    @patch("firetower.slack_app.handlers.captain.SlackService")
     @patch("firetower.slack_app.handlers.captain.get_or_create_user_from_slack_id")
-    def test_user_not_found(self, mock_get_user, incident):
+    def test_user_not_found(self, mock_get_user, mock_slack_service, incident):
+        mock_slack_service.return_value.get_user_info.return_value = {"is_bot": False}
         mock_get_user.return_value = None
         ack = MagicMock()
         body = {"user": {"id": "U_SUBMITTER"}}
@@ -133,7 +139,30 @@ class TestCaptainSubmission:
         handle_captain_submission(ack, body, view, client)
 
         ack.assert_called_once()
-        assert "bot user" in client.chat_postMessage.call_args[1]["text"]
+        assert "bot user" in client.chat_postEphemeral.call_args[1]["text"]
+        assert client.chat_postEphemeral.call_args[1]["user"] == "U_SUBMITTER"
+        mock_get_user.assert_not_called()
+
+    @patch("firetower.slack_app.handlers.captain.SlackService")
+    @patch("firetower.slack_app.handlers.captain.get_or_create_user_from_slack_id")
+    def test_slack_lookup_failure(self, mock_get_user, mock_slack_service, incident):
+        mock_slack_service.return_value.get_user_info.return_value = None
+        ack = MagicMock()
+        body = {"user": {"id": "U_SUBMITTER"}}
+        view = {
+            "state": {
+                "values": {
+                    "captain_block": {"captain_select": {"selected_user": "U_X"}}
+                }
+            },
+            "private_metadata": CHANNEL_ID,
+        }
+        client = MagicMock()
+
+        handle_captain_submission(ack, body, view, client)
+
+        ack.assert_called_once()
+        assert "Could not verify" in client.chat_postEphemeral.call_args[1]["text"]
         mock_get_user.assert_not_called()
 
     def test_no_captain_selected(self, incident):


### PR DESCRIPTION
Assigning a bot user as incident captain crashed with a raw serializer error (\`This field may not be blank.\`) because bots have no email and resolve to an inactive user with a blank email.

Now detects the bot via Slack's \`is_bot\` flag and posts a clear **"Captain cannot be a bot user."** message before reaching the serializer.

Fixes FIRETOWER-BACKEND-71