### PR TITLE
fix(frontend): Wrap long unbroken text in rendered EditableTextField

### DIFF
--- a/frontend/src/components/EditableTextField.test.tsx
+++ b/frontend/src/components/EditableTextField.test.tsx
@@ -13,6 +13,29 @@ describe('EditableTextField', () => {
     expect(display).toBeInTheDocument();
   });
 
+  it('wraps long unbroken content in the rendered display', async () => {
+    const longToken = 'https://example.com/' + 'a'.repeat(200);
+    render(<EditableTextField value={longToken} onSave={async () => {}} />);
+
+    const display = await screen.findByText(longToken);
+    expect(display).toHaveClass('break-words');
+  });
+
+  it('wraps long content in the labeled/multiline display', async () => {
+    const longToken = 'x'.repeat(300);
+    render(
+      <EditableTextField
+        value={longToken}
+        onSave={async () => {}}
+        label="Description"
+        multiline
+      />
+    );
+
+    const display = await screen.findByText(longToken);
+    expect(display).toHaveClass('break-words');
+  });
+
   it('shows trigger button', async () => {
     render(<EditableTextField value="Test" onSave={async () => {}} />);
 

--- a/frontend/src/components/EditableTextField.tsx
+++ b/frontend/src/components/EditableTextField.tsx
@@ -248,6 +248,7 @@ export function EditableTextField({
           {!isEditing && (
             <Component
               className={cn(
+                'break-words',
                 multiline && 'whitespace-pre-wrap',
                 className,
                 !value && placeholder && 'text-content-disabled italic'
@@ -265,6 +266,7 @@ export function EditableTextField({
           <Component
             className={cn(
               fullWidth ? 'flex-1 min-w-0' : 'inline',
+              'break-words',
               multiline && 'whitespace-pre-wrap',
               className,
               !value && placeholder && 'text-content-disabled italic'


### PR DESCRIPTION
The rendered display in \`EditableTextField\` used \`whitespace-pre-wrap\` but no word-breaking, so a long unbroken string (e.g. a URL or token in an incident description) overflowed its container. The \`<textarea>\` soft-wraps by default, which is why the edit field looked fine but the rendered version did not.

## Fix
Add `break-words` (`overflow-wrap: break-word`) to both rendered display paths (labeled/multiline layout used by Description, and the default layout used by Title etc.) so long tokens wrap within the container. Normal text wrapping is unchanged.