### PR TITLE
ref(cn): replace classnames with cnfast clsx

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
     "@tanstack/react-router": "^1.141.1",
     "@tanstack/zod-adapter": "^1.141.1",
     "class-variance-authority": "^0.7.1",
-    "classnames": "^2.5.1",
+    "cnfast": "^0.0.8",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.560.0",
     "react": "^19.2.2",

--- a/frontend/src/utils/cn.ts
+++ b/frontend/src/utils/cn.ts
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import {clsx, type ClassValue} from 'cnfast';
 import {extendTailwindMerge} from 'tailwind-merge';
 
 // Create custom Tailwind Merge instance with design token class groups
@@ -164,6 +164,6 @@ const twMerge = extendTailwindMerge({
 
 // Combines the features of classnames and tailwind-merge into one, easy-to-use
 // utility. Drop in replacement for both classnames and tailwind-merge.
-export function cn(...inputs: classNames.ArgumentArray) {
-  return twMerge(classNames(inputs));
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
 }


### PR DESCRIPTION
Replaces `classnames` with `cnfast` in `utils/cn.ts`, preserving the `extendTailwindMerge` config and all component call sites.

**Changes:**
- `cn.ts`: `import classNames from 'classnames'` → `import {clsx, type ClassValue} from 'cnfast'`
- Function signature: `classNames.ArgumentArray` → `ClassValue[]` (cnfast's clsx equivalent)
- `package.json`: remove `classnames`, add `cnfast`; `tailwind-merge` stays for `extendTailwindMerge`

**What's unchanged:**
- All 27 component imports (`from 'utils/cn'`) — untouched
- The full `extendTailwindMerge` design token class group config (bg-color, text-color, font-size, border-color, rounded, spacing, etc.)
- `cn.test.ts` — all existing tests should pass

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AD0ASJ2VKP1U%3A1781100908.501389%22)