### PR TITLE
feat(users): pin active user to top of user lists

### DIFF
--- a/frontend/src/routes/$incidentId/components/ParticipantsList.tsx
+++ b/frontend/src/routes/$incidentId/components/ParticipantsList.tsx
@@ -1,5 +1,5 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import {useMutation, useQueryClient} from '@tanstack/react-query';
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
 import {cva} from 'class-variance-authority';
 import {Avatar} from 'components/Avatar';
 import {Button} from 'components/Button';
@@ -7,6 +7,7 @@ import {Card} from 'components/Card';
 import {Pencil, X} from 'lucide-react';
 import {cn} from 'utils/cn';
 
+import {currentUserQueryOptions} from '../../queries/currentUserQueryOptions';
 import type {IncidentDetail} from '../queries/incidentDetailQueryOptions';
 import {updateIncidentFieldMutationOptions} from '../queries/updateIncidentFieldMutationOptions';
 
@@ -82,6 +83,7 @@ interface ParticipantDropdownProps {
   value: string;
   onChange: (value: string) => void;
   containerRef?: React.RefObject<HTMLDivElement | null>;
+  currentUserEmail?: string;
 }
 
 function ParticipantDropdown({
@@ -89,6 +91,7 @@ function ParticipantDropdown({
   value,
   onChange,
   containerRef,
+  currentUserEmail,
 }: ParticipantDropdownProps) {
   const [searchValue, setSearchValue] = useState('');
   const [focusedIndex, setFocusedIndex] = useState(-1);
@@ -98,11 +101,16 @@ function ParticipantDropdown({
 
   const selectedParticipant = participants.find(p => p.email === value);
 
-  const filteredParticipants = useMemo(
-    () =>
-      participants.filter(p => p.name.toLowerCase().includes(searchValue.toLowerCase())),
-    [participants, searchValue]
-  );
+  const filteredParticipants = useMemo(() => {
+    const filtered = participants.filter(p =>
+      p.name.toLowerCase().includes(searchValue.toLowerCase())
+    );
+    return filtered.sort((a, b) => {
+      if (currentUserEmail && a.email === currentUserEmail) return -1;
+      if (currentUserEmail && b.email === currentUserEmail) return 1;
+      return 0;
+    });
+  }, [participants, searchValue, currentUserEmail]);
 
   const handleSelect = useCallback(
     (participant: Participant) => {
@@ -230,6 +238,7 @@ interface ParticipantsListProps {
 
 export function ParticipantsList({incidentId, participants}: ParticipantsListProps) {
   const queryClient = useQueryClient();
+  const {data: currentUser} = useQuery(currentUserQueryOptions());
   const updateIncidentField = useMutation(
     updateIncidentFieldMutationOptions(queryClient)
   );
@@ -312,6 +321,7 @@ export function ParticipantsList({incidentId, participants}: ParticipantsListPro
               value={selectedParticipantEmail}
               onChange={handleRoleChange}
               containerRef={containerRef}
+              currentUserEmail={currentUser?.email}
             />
           </div>
           <div className="gap-space-xs flex items-center">

--- a/frontend/src/routes/components/filters/UserFilter.tsx
+++ b/frontend/src/routes/components/filters/UserFilter.tsx
@@ -1,10 +1,11 @@
 import {useEffect, useRef, useState} from 'react';
-import {useInfiniteQuery} from '@tanstack/react-query';
+import {useInfiniteQuery, useQuery} from '@tanstack/react-query';
 import {Button} from 'components/Button';
 import {Tag} from 'components/Tag';
 import {Pencil, XIcon} from 'lucide-react';
 import {cn} from 'utils/cn';
 
+import {currentUserQueryOptions} from '../../queries/currentUserQueryOptions';
 import {usersInfiniteQueryOptions} from '../../queries/usersQueryOptions';
 import {type ArrayFilterKey} from '../useActiveFilters';
 
@@ -130,6 +131,8 @@ export function UserFilter({label, filterKey}: UserFilterProps) {
     onOpen: () => setDebouncedSearch(''),
   });
 
+  const {data: currentUser} = useQuery(currentUserQueryOptions());
+
   const {
     data: users = [],
     fetchNextPage,
@@ -140,7 +143,13 @@ export function UserFilter({label, filterKey}: UserFilterProps) {
     enabled: isEditing,
   });
 
-  const available = users.filter(u => !selected.includes(u.email));
+  const available = users
+    .filter(u => !selected.includes(u.email))
+    .sort((a, b) => {
+      if (currentUser && a.email === currentUser.email) return -1;
+      if (currentUser && b.email === currentUser.email) return 1;
+      return 0;
+    });
 
   useEffect(() => {
     const timer = setTimeout(() => setDebouncedSearch(inputValue), 300);

--- a/frontend/src/routes/components/filters/UserFilter.tsx
+++ b/frontend/src/routes/components/filters/UserFilter.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef, useState} from 'react';
+import {useEffect, useMemo, useRef, useState} from 'react';
 import {useInfiniteQuery, useQuery} from '@tanstack/react-query';
 import {Button} from 'components/Button';
 import {Tag} from 'components/Tag';
@@ -143,13 +143,25 @@ export function UserFilter({label, filterKey}: UserFilterProps) {
     enabled: isEditing,
   });
 
-  const available = users
-    .filter(u => !selected.includes(u.email))
-    .sort((a, b) => {
-      if (currentUser && a.email === currentUser.email) return -1;
-      if (currentUser && b.email === currentUser.email) return 1;
-      return 0;
-    });
+  const available = useMemo(() => {
+    const notSelected = users.filter(u => !selected.includes(u.email));
+
+    if (!currentUser || selected.includes(currentUser.email)) {
+      return notSelected;
+    }
+
+    const matchesSearch =
+      !debouncedSearch ||
+      currentUser.name.toLowerCase().includes(debouncedSearch.toLowerCase()) ||
+      currentUser.email.toLowerCase().includes(debouncedSearch.toLowerCase());
+
+    if (!matchesSearch) return notSelected;
+
+    // Always prepend the active user regardless of pagination position,
+    // removing any duplicate that may have loaded from the paginated list.
+    const rest = notSelected.filter(u => u.email !== currentUser.email);
+    return [currentUser, ...rest];
+  }, [users, selected, currentUser, debouncedSearch]);
 
   useEffect(() => {
     const timer = setTimeout(() => setDebouncedSearch(inputValue), 300);

--- a/frontend/src/routes/index.test.tsx
+++ b/frontend/src/routes/index.test.tsx
@@ -50,6 +50,7 @@ const mockIncidents: PaginatedIncidents = {
 };
 
 const mockCurrentUser: CurrentUser = {
+  email: 'test.user@example.com',
   name: 'Test User',
   avatar_url: null,
 };

--- a/frontend/src/routes/queries/currentUserQueryOptions.ts
+++ b/frontend/src/routes/queries/currentUserQueryOptions.ts
@@ -3,6 +3,7 @@ import {Api} from 'api';
 import {z} from 'zod';
 
 const CurrentUserSchema = z.object({
+  email: z.string(),
   name: z.string(),
   avatar_url: z.string().nullable(),
 });

--- a/src/firetower/auth/serializers.py
+++ b/src/firetower/auth/serializers.py
@@ -14,7 +14,7 @@ class UserSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
-        fields = ["name", "avatar_url"]
+        fields = ["email", "name", "avatar_url"]
         read_only_fields: list[str] = []
 
     def get_name(self, obj: User) -> str:

--- a/src/firetower/auth/tests/test_views.py
+++ b/src/firetower/auth/tests/test_views.py
@@ -27,6 +27,7 @@ class TestCurrentUserView:
         response = self.client.get("/api/ui/users/me/")
 
         assert response.status_code == 200
+        assert response.data["email"] == "john@example.com"
         assert response.data["name"] == "John Doe"
         assert response.data["avatar_url"] == "https://example.com/avatar.jpg"
 
@@ -45,6 +46,7 @@ class TestCurrentUserView:
         response = self.client.get("/api/ui/users/me/")
 
         assert response.status_code == 200
+        assert response.data["email"] == "jane@example.com"
         assert response.data["name"] == "Jane Smith"
         assert response.data["avatar_url"] is None
 
@@ -60,6 +62,7 @@ class TestCurrentUserView:
         response = self.client.get("/api/ui/users/me/")
 
         assert response.status_code == 200
+        assert response.data["email"] == "test@example.com"
         assert response.data["name"] == "test@example.com"
 
     @override_settings(IAP_ENABLED=True)


### PR DESCRIPTION
Pins the authenticated user to the top of user dropdowns across the app so you don't have to hunt for yourself.

**What changed:**

- `UserSerializer` now includes `email` in its response so `/ui/users/me/` returns the current user's email alongside name and avatar
- `CurrentUserSchema` (frontend) updated to include `email`
- `UserFilter` — sorts the active user to position 0 in the available-users list (used by list filters, participants filters, etc.)
- `ParticipantDropdown` — accepts a `currentUserEmail` prop and sorts the active user to the top of the filtered participants list (used when assigning Captain/Reporter roles)

**Verified:**

- `pnpm run type-check` passes clean
- All 171 frontend tests pass
- Backend view tests updated to assert `email` is present in `/ui/users/me/` responses

Refs RELENG-905

<!-- junior-session-footer:start -->

--

[View Junior Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AC0590GND78Q%3A1783018870.345999/?project=4510944073809921)

<!-- junior-session-footer:end -->