### PR TITLE
Enable Sentry span streaming and profiling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "django-q2>=1.7.4",
     "slack-bolt>=1.27.0",
     "slack-sdk>=3.31.0",
-    "sentry-sdk>=2.47.0",
+    "sentry-sdk>=2.62.0",
 ]
 
 [build-system]
@@ -46,7 +46,7 @@ dev = [
 prod = [
     "ddtrace>=3.18.1",
     "granian>=2.6.0",
-    "sentry-sdk[django]>=2.47.0",
+    "sentry-sdk[django]>=2.62.0",
 ]
 
 [tool.pytest.ini_options]

--- a/src/firetower/settings.py
+++ b/src/firetower/settings.py
@@ -59,6 +59,9 @@ if not env_is_dev():
         traces_sample_rate=1.0,
         enable_logs=True,
         trace_propagation_targets=[],
+        _experiments={
+            "trace_lifecycle": "stream",
+        },
     )
 
 

--- a/src/firetower/settings.py
+++ b/src/firetower/settings.py
@@ -57,7 +57,7 @@ if not env_is_dev():
         send_default_pii=False,
         environment=os.environ.get("DJANGO_ENV", "unknown"),
         traces_sample_rate=1.0,
-        profiles_sample_rate=1.0,
+        profiles_sample_rate=0.25,
         enable_logs=True,
         trace_propagation_targets=[],
         _experiments={

--- a/src/firetower/settings.py
+++ b/src/firetower/settings.py
@@ -57,6 +57,7 @@ if not env_is_dev():
         send_default_pii=False,
         environment=os.environ.get("DJANGO_ENV", "unknown"),
         traces_sample_rate=1.0,
+        profiles_sample_rate=1.0,
         enable_logs=True,
         trace_propagation_targets=[],
         _experiments={

--- a/uv.lock
+++ b/uv.lock
@@ -659,7 +659,7 @@ requires-dist = [
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.11" },
     { name = "pyserde", extras = ["toml"], specifier = ">=0.28.0" },
     { name = "requests", specifier = ">=2.32.0" },
-    { name = "sentry-sdk", specifier = ">=2.47.0" },
+    { name = "sentry-sdk", specifier = ">=2.62.0" },
     { name = "slack-bolt", specifier = ">=1.27.0" },
     { name = "slack-sdk", specifier = ">=3.31.0" },
 ]
@@ -681,7 +681,7 @@ dev = [
 prod = [
     { name = "ddtrace", specifier = ">=3.18.1" },
     { name = "granian", specifier = ">=2.6.0" },
-    { name = "sentry-sdk", extras = ["django"], specifier = ">=2.47.0" },
+    { name = "sentry-sdk", extras = ["django"], specifier = ">=2.62.0" },
 ]
 
 [[package]]
@@ -1504,15 +1504,15 @@ wheels = [
 
 [[package]]
 name = "sentry-sdk"
-version = "2.47.0"
+version = "2.64.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4a/2a/d225cbf87b6c8ecce5664db7bcecb82c317e448e3b24a2dcdaacb18ca9a7/sentry_sdk-2.47.0.tar.gz", hash = "sha256:8218891d5e41b4ea8d61d2aed62ed10c80e39d9f2959d6f939efbf056857e050", size = 381895, upload-time = "2025-12-03T14:06:36.846Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/31/b7341f156a5f6f36f0b4845d6f1c28a2ae4799171dba7007f3a1e9b234b4/sentry_sdk-2.64.0.tar.gz", hash = "sha256:68be2c29e14ae310f8a39e1a79916b6d85c6cb41dcce789d14ff05fe293e4c55", size = 921020, upload-time = "2026-06-30T08:13:47.682Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/ac/d6286ea0d49e7b58847faf67b00e56bb4ba3d525281e2ac306e1f1f353da/sentry_sdk-2.47.0-py2.py3-none-any.whl", hash = "sha256:d72f8c61025b7d1d9e52510d03a6247b280094a327dd900d987717a4fce93412", size = 411088, upload-time = "2025-12-03T14:06:35.374Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a8/3fb9a4319efa3b26f5be0e90e6d8918df43fa7c7e977d26390f589501d82/sentry_sdk-2.64.0-py3-none-any.whl", hash = "sha256:715ea91ca860a819e8d8a50a7bde3a80d0df3b4ed7b6660a20fb9a2d084188f1", size = 498901, upload-time = "2026-06-30T08:13:45.566Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- bump the Python Sentry SDK to a span-streaming-compatible version
- enable Sentry span streaming for the Django backend
- enable Sentry profiling for sampled backend traces

## Tests

- `CONFIG_FILE_PATH=../config.ci.toml uv run pytest`
- `CONFIG_FILE_PATH=../config.ci.toml uv run pytest firetower/test_health.py`
- `uv run pre-commit run --all-files`
