### PR TITLE
feat(statuspage): Add user attribution to status page update notifications

### DIFF
--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -461,7 +461,9 @@ def _build_component_warning_modal(
     }
 
 
-def _process_statuspage_submission(data: dict[str, Any], client: Any) -> bool:
+def _process_statuspage_submission(
+    data: dict[str, Any], client: Any, user_id: str = ""
+) -> bool:
     channel_id = data["channel_id"]
     status = data["status"]
     title = data["title"]
@@ -519,7 +521,10 @@ def _process_statuspage_submission(data: dict[str, Any], client: Any) -> bool:
                     components=components or None,
                 )
                 statuspage_url = service.get_incident_url(result["id"])
-                success_message = f"Statuspage has been updated: {statuspage_url}"
+                attribution = f"<@{user_id}> " if user_id else ""
+                success_message = (
+                    f"{attribution}updated the statuspage: {statuspage_url}"
+                )
             else:
                 result = service.create_incident(
                     title=title,
@@ -531,7 +536,10 @@ def _process_statuspage_submission(data: dict[str, Any], client: Any) -> bool:
                 statuspage_url = service.get_incident_url(result["id"])
                 statuspage_link.url = statuspage_url
                 statuspage_link.save(update_fields=["url"])
-                success_message = f"Statuspage post created: {statuspage_url}"
+                attribution = f"<@{user_id}> " if user_id else ""
+                success_message = (
+                    f"{attribution}created a statuspage post: {statuspage_url}"
+                )
     except Exception:
         logger.exception("Failed to create/update statuspage incident")
         client.chat_postMessage(
@@ -618,7 +626,8 @@ def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) 
             return
 
     ack()
-    _process_statuspage_submission(data, client)
+    submitter_id = body.get("user", {}).get("id", "")
+    _process_statuspage_submission(data, client, user_id=submitter_id)
 
 
 def handle_component_impact_select(ack: Any, body: dict) -> None:
@@ -630,7 +639,8 @@ def handle_statuspage_reset_and_resolve(ack: Any, body: dict, client: Any) -> No
     view = body.get("view", {})
     data = json.loads(view.get("private_metadata", "{}"))
     data["components"] = dict.fromkeys(data.get("components", {}), "operational")
-    success = _process_statuspage_submission(data, client)
+    submitter_id = body.get("user", {}).get("id", "")
+    success = _process_statuspage_submission(data, client, user_id=submitter_id)
     from firetower.slack_app.bolt import get_bolt_app  # noqa: PLC0415
 
     if success:
@@ -658,7 +668,8 @@ def handle_statuspage_resolve_anyway(ack: Any, body: dict, client: Any) -> None:
     ack()
     view = body.get("view", {})
     data = json.loads(view.get("private_metadata", "{}"))
-    success = _process_statuspage_submission(data, client)
+    submitter_id = body.get("user", {}).get("id", "")
+    success = _process_statuspage_submission(data, client, user_id=submitter_id)
     from firetower.slack_app.bolt import get_bolt_app  # noqa: PLC0415
 
     if success:

--- a/src/firetower/slack_app/tests/handlers/test_statuspage.py
+++ b/src/firetower/slack_app/tests/handlers/test_statuspage.py
@@ -333,7 +333,7 @@ class TestStatuspageSubmission:
 
     def test_creates_new_statuspage_incident(self, incident):
         ack = MagicMock()
-        body = {}
+        body = {"user": {"id": "U_SUBMITTER"}}
         view = self._make_view()
         client = MagicMock()
 
@@ -363,11 +363,13 @@ class TestStatuspageSubmission:
         )
         assert link.url == "https://test.statuspage.io/incidents/new_sp_123"
 
-        assert "created" in client.chat_postMessage.call_args[1]["text"]
+        msg = client.chat_postMessage.call_args[1]["text"]
+        assert "created" in msg
+        assert "<@U_SUBMITTER>" in msg
 
     def test_posts_to_both_incident_and_status_channels(self, incident):
         ack = MagicMock()
-        body = {}
+        body = {"user": {"id": "U_SUBMITTER"}}
         view = self._make_view()
         client = MagicMock()
 
@@ -390,7 +392,7 @@ class TestStatuspageSubmission:
 
     def test_posts_to_both_channels_when_invoked_from_status_channel(self, incident):
         ack = MagicMock()
-        body = {}
+        body = {"user": {"id": "U_SUBMITTER"}}
         view = self._make_view(channel_id=STATUS_CHANNEL_ID)
         client = MagicMock()
 
@@ -413,7 +415,7 @@ class TestStatuspageSubmission:
 
     def test_creates_with_components(self, incident):
         ack = MagicMock()
-        body = {}
+        body = {"user": {"id": "U_SUBMITTER"}}
         view = self._make_view(components={"comp1": "major_outage"})
         client = MagicMock()
 
@@ -445,7 +447,7 @@ class TestStatuspageSubmission:
         )
 
         ack = MagicMock()
-        body = {}
+        body = {"user": {"id": "U_SUBMITTER"}}
         view = self._make_view(status="identified", message="Found the cause")
         client = MagicMock()
 
@@ -468,11 +470,13 @@ class TestStatuspageSubmission:
             message="Found the cause",
             components=None,
         )
-        assert "updated" in client.chat_postMessage.call_args[1]["text"]
+        msg = client.chat_postMessage.call_args[1]["text"]
+        assert "updated" in msg
+        assert "<@U_SUBMITTER>" in msg
 
     def test_empty_message_returns_error(self, incident):
         ack = MagicMock()
-        body = {}
+        body = {"user": {"id": "U_SUBMITTER"}}
         view = self._make_view(message="")
         client = MagicMock()
 
@@ -486,7 +490,7 @@ class TestStatuspageSubmission:
 
     def test_unconfigured_service_responds_error(self, incident):
         ack = MagicMock()
-        body = {}
+        body = {"user": {"id": "U_SUBMITTER"}}
         view = self._make_view()
         client = MagicMock()
 
@@ -504,7 +508,7 @@ class TestStatuspageSubmission:
 
     def test_api_error_sends_failure_message(self, incident):
         ack = MagicMock()
-        body = {}
+        body = {"user": {"id": "U_SUBMITTER"}}
         view = self._make_view()
         client = MagicMock()
 
@@ -527,7 +531,7 @@ class TestStatuspageSubmission:
 
     def test_no_incident_for_channel(self, db):
         ack = MagicMock()
-        body = {}
+        body = {"user": {"id": "U_SUBMITTER"}}
         view = self._make_view(channel_id="C_NONEXISTENT")
         client = MagicMock()
 
@@ -547,7 +551,7 @@ class TestStatuspageSubmission:
         self, incident
     ):
         ack = MagicMock()
-        body = {}
+        body = {"user": {"id": "U_SUBMITTER"}}
         view = self._make_view(
             status="resolved",
             components={"c1": "major_outage"},
@@ -594,7 +598,7 @@ class TestStatuspageSubmission:
 
     def test_rejects_empty_title(self, incident):
         ack = MagicMock()
-        body = {}
+        body = {"user": {"id": "U_SUBMITTER"}}
         view = self._make_view(title="")
         client = MagicMock()
 
@@ -607,12 +611,13 @@ class TestStatuspageSubmission:
 
 
 class TestStatuspageResetAndResolve:
-    def _make_body(self, data: dict) -> dict:
+    def _make_body(self, data: dict, user_id: str = "U_SUBMITTER") -> dict:
         return {
+            "user": {"id": user_id},
             "view": {
                 "id": "V_WARNING",
                 "private_metadata": json.dumps(data),
-            }
+            },
         }
 
     def test_sets_all_components_operational_and_processes(self):
@@ -641,6 +646,7 @@ class TestStatuspageResetAndResolve:
         mock_process.assert_called_once()
         passed_data = mock_process.call_args[0][0]
         assert passed_data["components"] == {"c1": "operational", "c2": "operational"}
+        assert mock_process.call_args[1]["user_id"] == "U_SUBMITTER"
         mock_app.return_value.client.views_update.assert_called_once()
         update_kwargs = mock_app.return_value.client.views_update.call_args[1]
         assert update_kwargs["view_id"] == "V_WARNING"
@@ -678,12 +684,13 @@ class TestStatuspageResetAndResolve:
 
 
 class TestStatuspageResolveAnyway:
-    def _make_body(self, data: dict) -> dict:
+    def _make_body(self, data: dict, user_id: str = "U_SUBMITTER") -> dict:
         return {
+            "user": {"id": user_id},
             "view": {
                 "id": "V_WARNING",
                 "private_metadata": json.dumps(data),
-            }
+            },
         }
 
     def test_processes_submission_and_shows_success(self):
@@ -709,7 +716,7 @@ class TestStatuspageResolveAnyway:
             handle_statuspage_resolve_anyway(ack, body, client)
 
         ack.assert_called_once_with()
-        mock_process.assert_called_once_with(data, client)
+        mock_process.assert_called_once_with(data, client, user_id="U_SUBMITTER")
         passed_data = mock_process.call_args[0][0]
         assert passed_data["components"] == {
             "c1": "major_outage",


### PR DESCRIPTION
## Summary
- When a status page update is posted to incident Slack channels, the notification now includes a mention of the user who submitted it (e.g. `<@U123> updated the statuspage: <url>`)
- Threads the Slack user ID from the modal submission `body` through all three call sites (`handle_statuspage_submission`, `handle_statuspage_reset_and_resolve`, `handle_statuspage_resolve_anyway`) into `_process_statuspage_submission`
- Gracefully degrades to no attribution if user ID is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Agent transcript: https://claudescope.sentry.dev/share/la2aaiksPbcGAOLaJxxhGUe4saWuj5yr-7ymdoDpenI