### PR TITLE
feat(statuspage): Updates should include the past post message

### DIFF
--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -47,6 +47,7 @@ def _build_statuspage_modal(
 
     is_update = statuspage_incident is not None
     latest_status = "investigating"
+    latest_message = ""
     default_impact = SEVERITY_TO_IMPACT.get(incident_severity, "major")
     affected_components: dict[str, str] = {}
 
@@ -58,6 +59,7 @@ def _build_statuspage_modal(
         )
         if incident_updates:
             latest_status = incident_updates[0].get("status", "investigating")
+            latest_message = incident_updates[0].get("body", "")
             for update in incident_updates:
                 for component in update.get("affected_components") or []:
                     component_id = component.get("code", "")
@@ -119,6 +121,41 @@ def _build_statuspage_modal(
                     },
                 },
                 "label": {"type": "plain_text", "text": "Title"},
+            }
+        )
+
+    if is_update and latest_message:
+        quoted = "\n".join(f">{line}" for line in latest_message.split("\n"))
+        blocks.append(
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*Previous message:*\n{quoted[:2500]}",
+                    }
+                ],
+            }
+        )
+        blocks.append(
+            {
+                "type": "input",
+                "block_id": "reuse_message_block",
+                "optional": True,
+                "element": {
+                    "type": "checkboxes",
+                    "action_id": "reuse_message_checkbox",
+                    "options": [
+                        {
+                            "text": {
+                                "type": "plain_text",
+                                "text": "Reuse previous message",
+                            },
+                            "value": "reuse",
+                        }
+                    ],
+                },
+                "label": {"type": "plain_text", "text": " "},
             }
         )
 
@@ -251,10 +288,14 @@ def _build_statuspage_modal(
                         }
                     )
 
+    metadata = {"channel_id": channel_id}
+    if latest_message:
+        metadata["latest_message"] = latest_message
+
     return {
         "type": "modal",
         "callback_id": "statuspage_modal",
-        "private_metadata": channel_id,
+        "private_metadata": json.dumps(metadata),
         "title": {
             "type": "plain_text",
             "text": "Update Statuspage" if is_update else "New Statuspage Post",
@@ -366,7 +407,14 @@ def handle_statuspage_command(
 
 def _extract_submission_data(view: dict) -> dict[str, Any]:
     values = view.get("state", {}).get("values", {})
-    channel_id = view.get("private_metadata", "")
+    raw_metadata = view.get("private_metadata", "")
+    try:
+        metadata = json.loads(raw_metadata)
+        channel_id = metadata.get("channel_id", "")
+        stored_message = metadata.get("latest_message", "")
+    except (json.JSONDecodeError, AttributeError):
+        channel_id = raw_metadata
+        stored_message = ""
 
     status = (
         values.get("status_block", {})
@@ -376,6 +424,14 @@ def _extract_submission_data(view: dict) -> dict[str, Any]:
     )
     title = values.get("title_block", {}).get("title_input", {}).get("value", "")
     message = values.get("message_block", {}).get("message_input", {}).get("value", "")
+
+    reuse_checked = bool(
+        values.get("reuse_message_block", {})
+        .get("reuse_message_checkbox", {})
+        .get("selected_options")
+    )
+    if reuse_checked and not message:
+        message = stored_message
     impact = (
         values.get("impact_block", {})
         .get("impact_select", {})
@@ -578,18 +634,17 @@ def _process_statuspage_submission(data: dict[str, Any], client: Any) -> bool:
 def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) -> None:
     values = view.get("state", {}).get("values", {})
     errors: dict[str, str] = {}
-    message = values.get("message_block", {}).get("message_input", {}).get("value", "")
-    if not message:
-        errors["message_block"] = "Message is required."
     if "title_block" in values:
         title = values["title_block"].get("title_input", {}).get("value", "")
         if not title:
             errors["title_block"] = "Title is required."
+
+    data = _extract_submission_data(view)
+    if not data["message"]:
+        errors["message_block"] = "Message is required."
     if errors:
         ack(response_action="errors", errors=errors)
         return
-
-    data = _extract_submission_data(view)
 
     if data["status"] == "resolved":
         non_operational = [

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -124,54 +124,24 @@ def _build_statuspage_modal(
             }
         )
 
+    message_element: dict[str, Any] = {
+        "type": "plain_text_input",
+        "action_id": "message_input",
+        "multiline": True,
+    }
     if is_update and latest_message:
-        quoted = "\n".join(f">{line}" for line in latest_message.split("\n"))
-        blocks.append(
-            {
-                "type": "context",
-                "elements": [
-                    {
-                        "type": "mrkdwn",
-                        "text": f"*Previous message:*\n{quoted[:2500]}",
-                    }
-                ],
-            }
-        )
-        blocks.append(
-            {
-                "type": "input",
-                "block_id": "reuse_message_block",
-                "optional": True,
-                "element": {
-                    "type": "checkboxes",
-                    "action_id": "reuse_message_checkbox",
-                    "options": [
-                        {
-                            "text": {
-                                "type": "plain_text",
-                                "text": "Reuse previous message",
-                            },
-                            "value": "reuse",
-                        }
-                    ],
-                },
-                "label": {"type": "plain_text", "text": " "},
-            }
-        )
+        message_element["initial_value"] = latest_message
+    else:
+        message_element["placeholder"] = {
+            "type": "plain_text",
+            "text": DEFAULT_MESSAGES.get(latest_status, ""),
+        }
 
     blocks.append(
         {
             "type": "input",
             "block_id": "message_block",
-            "element": {
-                "type": "plain_text_input",
-                "action_id": "message_input",
-                "multiline": True,
-                "placeholder": {
-                    "type": "plain_text",
-                    "text": DEFAULT_MESSAGES.get(latest_status, ""),
-                },
-            },
+            "element": message_element,
             "label": {"type": "plain_text", "text": "Message"},
             "hint": {
                 "type": "plain_text",
@@ -289,8 +259,6 @@ def _build_statuspage_modal(
                     )
 
     metadata = {"channel_id": channel_id}
-    if latest_message:
-        metadata["latest_message"] = latest_message
 
     return {
         "type": "modal",
@@ -411,10 +379,8 @@ def _extract_submission_data(view: dict) -> dict[str, Any]:
     try:
         metadata = json.loads(raw_metadata)
         channel_id = metadata.get("channel_id", "")
-        stored_message = metadata.get("latest_message", "")
     except (json.JSONDecodeError, AttributeError):
         channel_id = raw_metadata
-        stored_message = ""
 
     status = (
         values.get("status_block", {})
@@ -424,14 +390,6 @@ def _extract_submission_data(view: dict) -> dict[str, Any]:
     )
     title = values.get("title_block", {}).get("title_input", {}).get("value", "")
     message = values.get("message_block", {}).get("message_input", {}).get("value", "")
-
-    reuse_checked = bool(
-        values.get("reuse_message_block", {})
-        .get("reuse_message_checkbox", {})
-        .get("selected_options")
-    )
-    if reuse_checked and not message:
-        message = stored_message
     impact = (
         values.get("impact_block", {})
         .get("impact_select", {})

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -389,7 +389,9 @@ def _extract_submission_data(view: dict) -> dict[str, Any]:
         .get("value", "investigating")
     )
     title = values.get("title_block", {}).get("title_input", {}).get("value", "")
-    message = values.get("message_block", {}).get("message_input", {}).get("value", "")
+    message = (
+        values.get("message_block", {}).get("message_input", {}).get("value") or ""
+    )
     impact = (
         values.get("impact_block", {})
         .get("impact_select", {})
@@ -550,11 +552,12 @@ def _process_statuspage_submission(
                 success_message = f"Statuspage post created: {statuspage_url}"
     except Exception:
         logger.exception("Failed to create/update statuspage incident")
-        client.chat_postEphemeral(
-            channel=channel_id,
-            user=user_id,
-            text="Something went wrong updating Statuspage. Please try again.",
-        )
+        if user_id:
+            client.chat_postEphemeral(
+                channel=channel_id,
+                user=user_id,
+                text="Something went wrong updating Statuspage. Please try again.",
+            )
         return False
 
     notify_channels = {channel_id}

--- a/src/firetower/slack_app/handlers/statuspage.py
+++ b/src/firetower/slack_app/handlers/statuspage.py
@@ -475,7 +475,9 @@ def _build_component_warning_modal(
     }
 
 
-def _process_statuspage_submission(data: dict[str, Any], client: Any) -> bool:
+def _process_statuspage_submission(
+    data: dict[str, Any], client: Any, user_id: str
+) -> bool:
     channel_id = data["channel_id"]
     status = data["status"]
     title = data["title"]
@@ -548,8 +550,9 @@ def _process_statuspage_submission(data: dict[str, Any], client: Any) -> bool:
                 success_message = f"Statuspage post created: {statuspage_url}"
     except Exception:
         logger.exception("Failed to create/update statuspage incident")
-        client.chat_postMessage(
+        client.chat_postEphemeral(
             channel=channel_id,
+            user=user_id,
             text="Something went wrong updating Statuspage. Please try again.",
         )
         return False
@@ -631,7 +634,8 @@ def handle_statuspage_submission(ack: Any, body: dict, view: dict, client: Any) 
             return
 
     ack()
-    _process_statuspage_submission(data, client)
+    user_id = body.get("user", {}).get("id", "")
+    _process_statuspage_submission(data, client, user_id)
 
 
 def handle_component_impact_select(ack: Any, body: dict) -> None:
@@ -640,10 +644,11 @@ def handle_component_impact_select(ack: Any, body: dict) -> None:
 
 def handle_statuspage_reset_and_resolve(ack: Any, body: dict, client: Any) -> None:
     ack()
+    user_id = body.get("user", {}).get("id", "")
     view = body.get("view", {})
     data = json.loads(view.get("private_metadata", "{}"))
     data["components"] = dict.fromkeys(data.get("components", {}), "operational")
-    success = _process_statuspage_submission(data, client)
+    success = _process_statuspage_submission(data, client, user_id)
     from firetower.slack_app.bolt import get_bolt_app  # noqa: PLC0415
 
     if success:
@@ -669,9 +674,10 @@ def handle_statuspage_reset_and_resolve(ack: Any, body: dict, client: Any) -> No
 
 def handle_statuspage_resolve_anyway(ack: Any, body: dict, client: Any) -> None:
     ack()
+    user_id = body.get("user", {}).get("id", "")
     view = body.get("view", {})
     data = json.loads(view.get("private_metadata", "{}"))
-    success = _process_statuspage_submission(data, client)
+    success = _process_statuspage_submission(data, client, user_id)
     from firetower.slack_app.bolt import get_bolt_app  # noqa: PLC0415
 
     if success:

--- a/src/firetower/slack_app/tests/handlers/test_statuspage.py
+++ b/src/firetower/slack_app/tests/handlers/test_statuspage.py
@@ -7,6 +7,7 @@ import requests
 from firetower.incidents.models import ExternalLink, ExternalLinkType
 from firetower.slack_app.handlers.statuspage import (
     _build_statuspage_modal,
+    _extract_submission_data,
     handle_statuspage_command,
     handle_statuspage_reset_and_resolve,
     handle_statuspage_resolve_anyway,
@@ -693,6 +694,52 @@ class TestStatuspageSubmission:
             response_action="errors",
             errors={"title_block": "Title is required."},
         )
+
+    def test_api_error_with_empty_user_id_skips_ephemeral(self, incident):
+        ack = MagicMock()
+        body = {}
+        view = self._make_view()
+        client = MagicMock()
+
+        with patch(
+            "firetower.slack_app.handlers.statuspage.StatuspageService"
+        ) as MockService:
+            instance = MockService.return_value
+            instance.configured = True
+            instance.create_incident.side_effect = requests.RequestException(
+                "API error"
+            )
+
+            handle_statuspage_submission(ack, body, view, client)
+
+        ack.assert_called_once()
+        client.chat_postEphemeral.assert_not_called()
+
+
+class TestExtractSubmissionData:
+    def test_null_message_value_returns_empty_string(self):
+        view = {
+            "state": {
+                "values": {
+                    "status_block": {
+                        "status_select": {
+                            "selected_option": {"value": "investigating"},
+                        }
+                    },
+                    "message_block": {
+                        "message_input": {"value": None},
+                    },
+                    "impact_block": {
+                        "impact_select": {
+                            "selected_option": {"value": "major"},
+                        }
+                    },
+                }
+            },
+            "private_metadata": json.dumps({"channel_id": "C123"}),
+        }
+        data = _extract_submission_data(view)
+        assert data["message"] == ""
 
 
 class TestStatuspageResetAndResolve:

--- a/src/firetower/slack_app/tests/handlers/test_statuspage.py
+++ b/src/firetower/slack_app/tests/handlers/test_statuspage.py
@@ -133,7 +133,7 @@ class TestBuildStatuspageModal:
         )
         assert status_block["element"]["initial_option"]["value"] == "monitoring"
 
-    def test_update_shows_reuse_checkbox_and_previous_message(self):
+    def test_update_prefills_message_from_previous(self):
         sp_incident = {
             "name": "Issue",
             "impact": "major",
@@ -163,32 +163,18 @@ class TestBuildStatuspageModal:
                 statuspage_incident=sp_incident,
             )
 
-        context_blocks = [b for b in modal["blocks"] if b.get("type") == "context"]
-        assert any(
-            "We found the root cause" in el["text"]
-            for b in context_blocks
-            for el in b.get("elements", [])
-        )
-
-        reuse_block = next(
-            (b for b in modal["blocks"] if b.get("block_id") == "reuse_message_block"),
-            None,
-        )
-        assert reuse_block is not None
-        assert reuse_block["optional"] is True
-        checkbox = reuse_block["element"]
-        assert checkbox["type"] == "checkboxes"
-        assert checkbox["options"][0]["value"] == "reuse"
-
         message_block = next(
             b for b in modal["blocks"] if b.get("block_id") == "message_block"
         )
-        assert "initial_value" not in message_block["element"]
+        assert (
+            message_block["element"]["initial_value"]
+            == "We found the root cause in the DB layer."
+        )
 
-        metadata = json.loads(modal["private_metadata"])
-        assert metadata["latest_message"] == "We found the root cause in the DB layer."
+        block_ids = [b.get("block_id") for b in modal["blocks"]]
+        assert "reuse_message_block" not in block_ids
 
-    def test_update_without_body_has_no_reuse_checkbox(self):
+    def test_update_without_body_uses_placeholder(self):
         sp_incident = {
             "name": "Issue",
             "impact": "major",
@@ -211,10 +197,13 @@ class TestBuildStatuspageModal:
                 statuspage_incident=sp_incident,
             )
 
-        block_ids = [b.get("block_id") for b in modal["blocks"]]
-        assert "reuse_message_block" not in block_ids
+        message_block = next(
+            b for b in modal["blocks"] if b.get("block_id") == "message_block"
+        )
+        assert "initial_value" not in message_block["element"]
+        assert "placeholder" in message_block["element"]
 
-    def test_new_post_has_no_reuse_checkbox(self):
+    def test_new_post_uses_placeholder(self):
         with patch(
             "firetower.slack_app.handlers.statuspage.StatuspageService"
         ) as MockService:
@@ -225,12 +214,11 @@ class TestBuildStatuspageModal:
                 incident_severity="P1",
             )
 
-        block_ids = [b.get("block_id") for b in modal["blocks"]]
-        assert "reuse_message_block" not in block_ids
         message_block = next(
             b for b in modal["blocks"] if b.get("block_id") == "message_block"
         )
         assert "initial_value" not in message_block["element"]
+        assert "placeholder" in message_block["element"]
 
     def test_component_fetch_failure_shows_warning(self):
         with patch(
@@ -399,8 +387,6 @@ class TestStatuspageSubmission:
         impact="major",
         channel_id=CHANNEL_ID,
         components=None,
-        reuse_message=False,
-        latest_message="",
     ):
         values: dict = {
             "status_block": {
@@ -420,12 +406,6 @@ class TestStatuspageSubmission:
                 }
             },
         }
-        if reuse_message:
-            values["reuse_message_block"] = {
-                "reuse_message_checkbox": {
-                    "selected_options": [{"value": "reuse"}],
-                }
-            }
         if components:
             for comp_id, comp_status in components.items():
                 values[f"component_{comp_id}"] = {
@@ -434,8 +414,6 @@ class TestStatuspageSubmission:
                     }
                 }
         metadata = {"channel_id": channel_id}
-        if latest_message:
-            metadata["latest_message"] = latest_message
         return {
             "state": {"values": values},
             "private_metadata": json.dumps(metadata),
@@ -593,76 +571,6 @@ class TestStatuspageSubmission:
             errors={"message_block": "Message is required."},
         )
         client.chat_postMessage.assert_not_called()
-
-    def test_reuse_checkbox_uses_stored_message(self, incident):
-        ack = MagicMock()
-        body = {}
-        view = self._make_view(
-            message="",
-            reuse_message=True,
-            latest_message="Previous update text",
-        )
-        client = MagicMock()
-
-        with patch(
-            "firetower.slack_app.handlers.statuspage.StatuspageService"
-        ) as MockService:
-            instance = MockService.return_value
-            instance.configured = True
-            instance.create_incident.return_value = {"id": "sp_reuse"}
-            instance.get_incident_url.return_value = (
-                "https://test.statuspage.io/incidents/sp_reuse"
-            )
-
-            handle_statuspage_submission(ack, body, view, client)
-
-        ack.assert_called_once_with()
-        instance.create_incident.assert_called_once()
-        assert (
-            instance.create_incident.call_args[1]["message"] == "Previous update text"
-        )
-
-    def test_reuse_checkbox_without_stored_message_still_errors(self, incident):
-        ack = MagicMock()
-        body = {}
-        view = self._make_view(
-            message="",
-            reuse_message=True,
-            latest_message="",
-        )
-        client = MagicMock()
-
-        handle_statuspage_submission(ack, body, view, client)
-
-        ack.assert_called_once_with(
-            response_action="errors",
-            errors={"message_block": "Message is required."},
-        )
-
-    def test_typed_message_takes_precedence_over_reuse(self, incident):
-        ack = MagicMock()
-        body = {}
-        view = self._make_view(
-            message="New custom message",
-            reuse_message=True,
-            latest_message="Previous update text",
-        )
-        client = MagicMock()
-
-        with patch(
-            "firetower.slack_app.handlers.statuspage.StatuspageService"
-        ) as MockService:
-            instance = MockService.return_value
-            instance.configured = True
-            instance.create_incident.return_value = {"id": "sp_typed"}
-            instance.get_incident_url.return_value = (
-                "https://test.statuspage.io/incidents/sp_typed"
-            )
-
-            handle_statuspage_submission(ack, body, view, client)
-
-        instance.create_incident.assert_called_once()
-        assert instance.create_incident.call_args[1]["message"] == "New custom message"
 
     def test_unconfigured_service_responds_error(self, incident):
         ack = MagicMock()

--- a/src/firetower/slack_app/tests/handlers/test_statuspage.py
+++ b/src/firetower/slack_app/tests/handlers/test_statuspage.py
@@ -592,7 +592,7 @@ class TestStatuspageSubmission:
 
     def test_api_error_sends_failure_message(self, incident):
         ack = MagicMock()
-        body = {}
+        body = {"user": {"id": "U_SUBMITTER"}}
         view = self._make_view()
         client = MagicMock()
 
@@ -608,7 +608,8 @@ class TestStatuspageSubmission:
             handle_statuspage_submission(ack, body, view, client)
 
         ack.assert_called_once()
-        assert "went wrong" in client.chat_postMessage.call_args[1]["text"]
+        assert "went wrong" in client.chat_postEphemeral.call_args[1]["text"]
+        assert client.chat_postEphemeral.call_args[1]["user"] == "U_SUBMITTER"
         assert not ExternalLink.objects.filter(
             incident=incident, type=ExternalLinkType.STATUSPAGE
         ).exists()
@@ -697,10 +698,11 @@ class TestStatuspageSubmission:
 class TestStatuspageResetAndResolve:
     def _make_body(self, data: dict) -> dict:
         return {
+            "user": {"id": "U_SUBMITTER"},
             "view": {
                 "id": "V_WARNING",
                 "private_metadata": json.dumps(data),
-            }
+            },
         }
 
     def test_sets_all_components_operational_and_processes(self):
@@ -768,10 +770,11 @@ class TestStatuspageResetAndResolve:
 class TestStatuspageResolveAnyway:
     def _make_body(self, data: dict) -> dict:
         return {
+            "user": {"id": "U_SUBMITTER"},
             "view": {
                 "id": "V_WARNING",
                 "private_metadata": json.dumps(data),
-            }
+            },
         }
 
     def test_processes_submission_and_shows_success(self):
@@ -797,7 +800,7 @@ class TestStatuspageResolveAnyway:
             handle_statuspage_resolve_anyway(ack, body, client)
 
         ack.assert_called_once_with()
-        mock_process.assert_called_once_with(data, client)
+        mock_process.assert_called_once_with(data, client, "U_SUBMITTER")
         passed_data = mock_process.call_args[0][0]
         assert passed_data["components"] == {
             "c1": "major_outage",

--- a/src/firetower/slack_app/tests/handlers/test_statuspage.py
+++ b/src/firetower/slack_app/tests/handlers/test_statuspage.py
@@ -133,6 +133,105 @@ class TestBuildStatuspageModal:
         )
         assert status_block["element"]["initial_option"]["value"] == "monitoring"
 
+    def test_update_shows_reuse_checkbox_and_previous_message(self):
+        sp_incident = {
+            "name": "Issue",
+            "impact": "major",
+            "incident_updates": [
+                {
+                    "status": "identified",
+                    "body": "We found the root cause in the DB layer.",
+                    "created_at": "2024-01-02T00:00:00Z",
+                    "affected_components": [],
+                },
+                {
+                    "status": "investigating",
+                    "body": "Looking into reports of elevated errors.",
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "affected_components": [],
+                },
+            ],
+        }
+        with patch(
+            "firetower.slack_app.handlers.statuspage.StatuspageService"
+        ) as MockService:
+            MockService.return_value.configured = False
+            modal = _build_statuspage_modal(
+                channel_id=CHANNEL_ID,
+                incident_title="Test",
+                incident_severity="P1",
+                statuspage_incident=sp_incident,
+            )
+
+        context_blocks = [b for b in modal["blocks"] if b.get("type") == "context"]
+        assert any(
+            "We found the root cause" in el["text"]
+            for b in context_blocks
+            for el in b.get("elements", [])
+        )
+
+        reuse_block = next(
+            (b for b in modal["blocks"] if b.get("block_id") == "reuse_message_block"),
+            None,
+        )
+        assert reuse_block is not None
+        assert reuse_block["optional"] is True
+        checkbox = reuse_block["element"]
+        assert checkbox["type"] == "checkboxes"
+        assert checkbox["options"][0]["value"] == "reuse"
+
+        message_block = next(
+            b for b in modal["blocks"] if b.get("block_id") == "message_block"
+        )
+        assert "initial_value" not in message_block["element"]
+
+        metadata = json.loads(modal["private_metadata"])
+        assert metadata["latest_message"] == "We found the root cause in the DB layer."
+
+    def test_update_without_body_has_no_reuse_checkbox(self):
+        sp_incident = {
+            "name": "Issue",
+            "impact": "major",
+            "incident_updates": [
+                {
+                    "status": "investigating",
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "affected_components": [],
+                },
+            ],
+        }
+        with patch(
+            "firetower.slack_app.handlers.statuspage.StatuspageService"
+        ) as MockService:
+            MockService.return_value.configured = False
+            modal = _build_statuspage_modal(
+                channel_id=CHANNEL_ID,
+                incident_title="Test",
+                incident_severity="P1",
+                statuspage_incident=sp_incident,
+            )
+
+        block_ids = [b.get("block_id") for b in modal["blocks"]]
+        assert "reuse_message_block" not in block_ids
+
+    def test_new_post_has_no_reuse_checkbox(self):
+        with patch(
+            "firetower.slack_app.handlers.statuspage.StatuspageService"
+        ) as MockService:
+            MockService.return_value.configured = False
+            modal = _build_statuspage_modal(
+                channel_id=CHANNEL_ID,
+                incident_title="Test",
+                incident_severity="P1",
+            )
+
+        block_ids = [b.get("block_id") for b in modal["blocks"]]
+        assert "reuse_message_block" not in block_ids
+        message_block = next(
+            b for b in modal["blocks"] if b.get("block_id") == "message_block"
+        )
+        assert "initial_value" not in message_block["element"]
+
     def test_component_fetch_failure_shows_warning(self):
         with patch(
             "firetower.slack_app.handlers.statuspage.StatuspageService"
@@ -300,6 +399,8 @@ class TestStatuspageSubmission:
         impact="major",
         channel_id=CHANNEL_ID,
         components=None,
+        reuse_message=False,
+        latest_message="",
     ):
         values: dict = {
             "status_block": {
@@ -319,6 +420,12 @@ class TestStatuspageSubmission:
                 }
             },
         }
+        if reuse_message:
+            values["reuse_message_block"] = {
+                "reuse_message_checkbox": {
+                    "selected_options": [{"value": "reuse"}],
+                }
+            }
         if components:
             for comp_id, comp_status in components.items():
                 values[f"component_{comp_id}"] = {
@@ -326,9 +433,12 @@ class TestStatuspageSubmission:
                         "selected_option": {"value": comp_status},
                     }
                 }
+        metadata = {"channel_id": channel_id}
+        if latest_message:
+            metadata["latest_message"] = latest_message
         return {
             "state": {"values": values},
-            "private_metadata": channel_id,
+            "private_metadata": json.dumps(metadata),
         }
 
     def test_creates_new_statuspage_incident(self, incident):
@@ -483,6 +593,76 @@ class TestStatuspageSubmission:
             errors={"message_block": "Message is required."},
         )
         client.chat_postMessage.assert_not_called()
+
+    def test_reuse_checkbox_uses_stored_message(self, incident):
+        ack = MagicMock()
+        body = {}
+        view = self._make_view(
+            message="",
+            reuse_message=True,
+            latest_message="Previous update text",
+        )
+        client = MagicMock()
+
+        with patch(
+            "firetower.slack_app.handlers.statuspage.StatuspageService"
+        ) as MockService:
+            instance = MockService.return_value
+            instance.configured = True
+            instance.create_incident.return_value = {"id": "sp_reuse"}
+            instance.get_incident_url.return_value = (
+                "https://test.statuspage.io/incidents/sp_reuse"
+            )
+
+            handle_statuspage_submission(ack, body, view, client)
+
+        ack.assert_called_once_with()
+        instance.create_incident.assert_called_once()
+        assert (
+            instance.create_incident.call_args[1]["message"] == "Previous update text"
+        )
+
+    def test_reuse_checkbox_without_stored_message_still_errors(self, incident):
+        ack = MagicMock()
+        body = {}
+        view = self._make_view(
+            message="",
+            reuse_message=True,
+            latest_message="",
+        )
+        client = MagicMock()
+
+        handle_statuspage_submission(ack, body, view, client)
+
+        ack.assert_called_once_with(
+            response_action="errors",
+            errors={"message_block": "Message is required."},
+        )
+
+    def test_typed_message_takes_precedence_over_reuse(self, incident):
+        ack = MagicMock()
+        body = {}
+        view = self._make_view(
+            message="New custom message",
+            reuse_message=True,
+            latest_message="Previous update text",
+        )
+        client = MagicMock()
+
+        with patch(
+            "firetower.slack_app.handlers.statuspage.StatuspageService"
+        ) as MockService:
+            instance = MockService.return_value
+            instance.configured = True
+            instance.create_incident.return_value = {"id": "sp_typed"}
+            instance.get_incident_url.return_value = (
+                "https://test.statuspage.io/incidents/sp_typed"
+            )
+
+            handle_statuspage_submission(ack, body, view, client)
+
+        instance.create_incident.assert_called_once()
+        assert instance.create_incident.call_args[1]["message"] == "New custom message"
 
     def test_unconfigured_service_responds_error(self, incident):
         ack = MagicMock()


### PR DESCRIPTION
We should pull in the past statuspage post when doing updates so we can repost it or use it as a reference.