### PR TITLE
feat(linear): distinguish not-found from errors + tight alloc budget (RELENG-912)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -48,6 +48,11 @@ team_id = ""
 project_id = ""
 # When true, claim the Linear issue matching the incident number (e.g. INC-2160) instead of creating a new one.
 sync_identifiers = false
+# Tight timeout (seconds) and retry count for Linear calls on the incident
+# allocation path, which runs while holding a DB lock. Kept lower than the
+# default LinearService budget so a hung Linear can't hold the lock too long.
+alloc_timeout_seconds = 8
+alloc_max_retries = 1
 # SLO deadlines (days from incident creation) for action items by priority tier.
 # High priority covers Linear priorities 1 (Urgent) and 2 (High).
 # Medium priority covers Linear priority 3 (Medium).

--- a/src/firetower/config.py
+++ b/src/firetower/config.py
@@ -77,6 +77,8 @@ class LinearConfig:
     project_id: str = ""
     sync_identifiers: bool = False
     api_key: str = ""
+    alloc_timeout_seconds: int = 8
+    alloc_max_retries: int = 1
     action_item_slo_days_high_priority: int = 14
     action_item_slo_days_medium_priority: int = 30
     action_item_nag_comment_high_priority: str = (

--- a/src/firetower/integrations/services/linear.py
+++ b/src/firetower/integrations/services/linear.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import time
 from datetime import timedelta
 from typing import Any
@@ -32,6 +33,7 @@ TOKEN_REFRESH_BUFFER = timedelta(days=1)
 LINEAR_RETRYABLE_STATUS_CODES = frozenset({502, 503, 504})
 LINEAR_DEFAULT_MAX_RETRIES = 3
 LINEAR_DEFAULT_RETRY_BACKOFF_SECONDS = 1.0
+LINEAR_DEFAULT_TIMEOUT_SECONDS = 30
 
 ISSUE_FIELDS = """
     id
@@ -49,19 +51,63 @@ ISSUE_FIELDS = """
 """
 
 
+class LinearError(Exception):
+    """Raised when a Linear API call fails outright.
+
+    A "failure" means the call could not be completed successfully: a transport
+    error, a non-OK HTTP response, a GraphQL ``errors`` payload, or a missing /
+    invalid access token. It is distinct from a call that *succeeds* but returns
+    an empty or absent result (e.g. an issue that genuinely does not exist),
+    which callers observe as ``None``.
+    """
+
+
+def parse_project_number(identifier: str) -> int | None:
+    """Return the integer N when ``identifier`` is exactly
+    ``f"{settings.PROJECT_KEY}-<digits>"`` (e.g. ``"INC-2353"`` -> ``2353``),
+    otherwise ``None`` (e.g. ``"PRODENG-1404"`` or ``"INC-abc"``).
+    """
+    match = re.fullmatch(rf"{re.escape(settings.PROJECT_KEY)}-(\d+)", identifier)
+    if match is None:
+        return None
+    return int(match.group(1))
+
+
 class LinearService:
-    def __init__(self) -> None:
+    def __init__(
+        self, *, timeout: int | None = None, max_retries: int | None = None
+    ) -> None:
         assert settings.LINEAR is not None
         self.client_id = settings.LINEAR.get("CLIENT_ID")
         self.client_secret = settings.LINEAR.get("CLIENT_SECRET")
         self.api_key = settings.LINEAR.get("API_KEY")
-        self.max_retries: int = max(
-            1, settings.LINEAR.get("MAX_RETRIES", LINEAR_DEFAULT_MAX_RETRIES)
+        configured_max_retries = (
+            max_retries
+            if max_retries is not None
+            else settings.LINEAR.get("MAX_RETRIES", LINEAR_DEFAULT_MAX_RETRIES)
         )
+        self.max_retries: int = max(1, configured_max_retries)
         self.retry_backoff_seconds: float = settings.LINEAR.get(
             "RETRY_BACKOFF_SECONDS", LINEAR_DEFAULT_RETRY_BACKOFF_SECONDS
         )
+        self.timeout: int = (
+            timeout if timeout is not None else LINEAR_DEFAULT_TIMEOUT_SECONDS
+        )
         self._workflow_states_cache: dict[str, str] | None = None
+
+    @classmethod
+    def for_allocation(cls) -> "LinearService":
+        """Construct a service with the tight timeout/retry budget used by the
+        incident allocation path.
+
+        The allocator calls Linear while holding a DB lock, so it uses a bounded
+        timeout and fewer retries than the default budget to ensure a hung or
+        slow Linear can't hold the lock for the full default duration.
+        """
+        return cls(
+            timeout=settings.INCIDENT_ALLOC_LINEAR_TIMEOUT,
+            max_retries=settings.INCIDENT_ALLOC_LINEAR_RETRIES,
+        )
 
     def _request_new_token(self) -> str | None:
         try:
@@ -74,7 +120,7 @@ class LinearService:
                     "scope": "read,write",
                 },
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
-                timeout=30,
+                timeout=self.timeout,
             )
             response.raise_for_status()
             data = response.json()
@@ -125,19 +171,35 @@ class LinearService:
                 "Authorization": auth_value,
                 "Content-Type": "application/json",
             },
-            timeout=30,
+            timeout=self.timeout,
         )
+
+    def _raise_if_requested(self, message: str, *, raise_on_error: bool) -> None:
+        """Raise ``LinearError`` when the caller opted in, otherwise do nothing.
+
+        Lets a failed Linear call fall back to the historical ``None`` return
+        while allowing opt-in callers to distinguish a failure from a genuine
+        empty result.
+        """
+        if raise_on_error:
+            raise LinearError(message)
 
     def _graphql(
         self,
         query: str,
         variables: dict | None = None,
         retryable: bool = True,
+        *,
+        raise_on_error: bool = False,
     ) -> dict | None:
         access_token = self._get_access_token()
         if not access_token:
             logger.warning(
                 "Cannot make Linear API call - no valid access token available"
+            )
+            self._raise_if_requested(
+                "No valid Linear access token available",
+                raise_on_error=raise_on_error,
             )
             return None
 
@@ -153,11 +215,19 @@ class LinearService:
                         logger.error(
                             "Linear API returned 401 with api_key — key is invalid or expired"
                         )
+                        self._raise_if_requested(
+                            "Linear API returned 401 — api_key is invalid or expired",
+                            raise_on_error=raise_on_error,
+                        )
                         return None
 
                     logger.info("Linear token expired, requesting new token")
                     access_token = self._request_new_token()
                     if not access_token:
+                        self._raise_if_requested(
+                            "Linear token refresh failed after 401",
+                            raise_on_error=raise_on_error,
+                        )
                         return None
 
                     response = self._make_graphql_request(
@@ -177,6 +247,10 @@ class LinearService:
                         response.status_code,
                         response.text,
                     )
+                    self._raise_if_requested(
+                        f"Linear API returned HTTP {response.status_code}",
+                        raise_on_error=raise_on_error,
+                    )
                     return None
 
                 data = response.json()
@@ -186,16 +260,39 @@ class LinearService:
                         "Linear GraphQL errors",
                         extra={"errors": data["errors"]},
                     )
+                    self._raise_if_requested(
+                        "Linear GraphQL response contained errors",
+                        raise_on_error=raise_on_error,
+                    )
                     return None
 
-                return data.get("data")
+                result = data.get("data")
+                if result is None:
+                    # A 200 OK carrying a null/absent top-level "data" with no
+                    # "errors" key is an anomalous/failed response, not a genuine
+                    # empty result. Treat it as a failure so raise_on_error
+                    # callers don't mistake it for "not found". Default callers
+                    # still get None (unchanged behavior).
+                    logger.error("Linear API returned no top-level data")
+                    self._raise_if_requested(
+                        "Linear API returned no data",
+                        raise_on_error=raise_on_error,
+                    )
+                    return None
+                return result
             except requests.RequestException:
                 if not is_last_attempt:
                     self._sleep_before_retry(attempt)
                     continue
                 logger.exception("Linear API request failed")
+                self._raise_if_requested(
+                    "Linear API request failed", raise_on_error=raise_on_error
+                )
                 return None
 
+        self._raise_if_requested(
+            "Linear API call failed", raise_on_error=raise_on_error
+        )
         return None
 
     def _sleep_before_retry(self, attempt: int) -> None:
@@ -219,7 +316,18 @@ class LinearService:
             "relation_type": relation_type,
         }
 
-    def get_issue(self, issue_id: str) -> dict[str, Any] | None:
+    def get_issue(
+        self, issue_id: str, *, raise_on_error: bool = False
+    ) -> dict[str, Any] | None:
+        """Fetch a Linear issue by id.
+
+        By default (``raise_on_error=False``) any failure -- including the call
+        failing outright -- is reported as ``None``, matching historical
+        behavior. When ``raise_on_error=True``, ``None`` is returned *only* when
+        the call succeeded and the issue is genuinely absent; a failed call
+        raises :class:`LinearError` so callers can distinguish "not found" from
+        "could not tell".
+        """
         query = f"""
         query($id: String!) {{
             issue(id: $id) {{
@@ -227,7 +335,7 @@ class LinearService:
             }}
         }}
         """
-        data = self._graphql(query, {"id": issue_id})
+        data = self._graphql(query, {"id": issue_id}, raise_on_error=raise_on_error)
         if not data or not data.get("issue"):
             return None
         issue = data["issue"]

--- a/src/firetower/integrations/tests/test_linear_service.py
+++ b/src/firetower/integrations/tests/test_linear_service.py
@@ -8,8 +8,11 @@ from django.utils import timezone
 from firetower.integrations.services.linear import (
     LINEAR_DEFAULT_MAX_RETRIES,
     LINEAR_DEFAULT_RETRY_BACKOFF_SECONDS,
+    LINEAR_DEFAULT_TIMEOUT_SECONDS,
     LINEAR_TOKEN_URL,
+    LinearError,
     LinearService,
+    parse_project_number,
 )
 
 
@@ -439,6 +442,274 @@ class TestGraphql:
 
         assert svc.max_retries == 1
 
+    def test_uses_default_timeout(self, linear_service):
+        assert linear_service.timeout == LINEAR_DEFAULT_TIMEOUT_SECONDS
+
+    def test_raises_linear_error_when_no_access_token(self, linear_service):
+        with patch.object(linear_service, "_get_access_token", return_value=None):
+            with pytest.raises(LinearError):
+                linear_service._graphql("query { viewer { id } }", raise_on_error=True)
+
+    def test_raises_linear_error_on_non_ok_response(self, linear_service):
+        error_response = MagicMock()
+        error_response.status_code = 500
+        error_response.ok = False
+        error_response.text = "Internal Server Error"
+
+        with (
+            patch.object(
+                linear_service, "_get_access_token", return_value="valid-token"
+            ),
+            patch.object(
+                linear_service, "_make_graphql_request", return_value=error_response
+            ),
+        ):
+            with pytest.raises(LinearError):
+                linear_service._graphql("query { viewer { id } }", raise_on_error=True)
+
+    def test_raises_linear_error_on_graphql_errors(self, linear_service):
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "errors": [{"message": "some error"}],
+            "data": None,
+        }
+
+        with (
+            patch.object(
+                linear_service, "_get_access_token", return_value="valid-token"
+            ),
+            patch.object(
+                linear_service, "_make_graphql_request", return_value=mock_response
+            ),
+        ):
+            with pytest.raises(LinearError):
+                linear_service._graphql("query { viewer { id } }", raise_on_error=True)
+
+    def test_raises_linear_error_on_request_exception(self, linear_service):
+        with (
+            patch.object(
+                linear_service, "_get_access_token", return_value="valid-token"
+            ),
+            patch.object(
+                linear_service,
+                "_make_graphql_request",
+                side_effect=requests.ConnectionError("connection reset"),
+            ),
+            patch.object(linear_service, "_sleep_before_retry"),
+        ):
+            with pytest.raises(LinearError):
+                linear_service._graphql("query { viewer { id } }", raise_on_error=True)
+
+    def test_raises_linear_error_on_401_with_api_key(self, linear_service):
+        linear_service.api_key = "lin_api_test"
+        unauthorized_response = MagicMock()
+        unauthorized_response.status_code = 401
+        unauthorized_response.ok = False
+
+        with (
+            patch.object(
+                linear_service, "_get_access_token", return_value="lin_api_test"
+            ),
+            patch.object(
+                linear_service,
+                "_make_graphql_request",
+                return_value=unauthorized_response,
+            ),
+        ):
+            with pytest.raises(LinearError):
+                linear_service._graphql("query { viewer { id } }", raise_on_error=True)
+
+    def test_returns_data_when_result_absent_with_raise_on_error(self, linear_service):
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"data": {"issue": None}}
+
+        with (
+            patch.object(
+                linear_service, "_get_access_token", return_value="valid-token"
+            ),
+            patch.object(
+                linear_service, "_make_graphql_request", return_value=mock_response
+            ),
+        ):
+            result = linear_service._graphql(
+                "query { issue { id } }", raise_on_error=True
+            )
+
+        assert result == {"issue": None}
+
+    def test_raises_linear_error_when_top_level_data_null(self, linear_service):
+        # 200 OK with a null top-level "data" and no "errors" is anomalous, not
+        # a genuine empty result; raise_on_error callers must not mistake it
+        # for "not found".
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"data": None}
+
+        with (
+            patch.object(
+                linear_service, "_get_access_token", return_value="valid-token"
+            ),
+            patch.object(
+                linear_service, "_make_graphql_request", return_value=mock_response
+            ),
+        ):
+            with pytest.raises(LinearError):
+                linear_service._graphql("query { issue { id } }", raise_on_error=True)
+
+    def test_returns_none_when_top_level_data_null_without_raise(self, linear_service):
+        # Default behavior unchanged: null top-level data still returns None.
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"data": None}
+
+        with (
+            patch.object(
+                linear_service, "_get_access_token", return_value="valid-token"
+            ),
+            patch.object(
+                linear_service, "_make_graphql_request", return_value=mock_response
+            ),
+        ):
+            result = linear_service._graphql("query { issue { id } }")
+
+        assert result is None
+
+    def test_raises_linear_error_when_data_key_missing(self, linear_service):
+        # Same anomaly when the "data" key is omitted entirely.
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.status_code = 200
+        mock_response.json.return_value = {}
+
+        with (
+            patch.object(
+                linear_service, "_get_access_token", return_value="valid-token"
+            ),
+            patch.object(
+                linear_service, "_make_graphql_request", return_value=mock_response
+            ),
+        ):
+            with pytest.raises(LinearError):
+                linear_service._graphql("query { issue { id } }", raise_on_error=True)
+
+
+class TestLinearBudget:
+    def test_for_allocation_uses_settings_budget(self):
+        with patch("firetower.integrations.services.linear.settings") as mock_settings:
+            mock_settings.LINEAR = {"CLIENT_ID": "id", "CLIENT_SECRET": "secret"}
+            mock_settings.INCIDENT_ALLOC_LINEAR_TIMEOUT = 8
+            mock_settings.INCIDENT_ALLOC_LINEAR_RETRIES = 1
+            svc = LinearService.for_allocation()
+
+        assert svc.timeout == 8
+        assert svc.max_retries == 1
+
+    def test_constructor_overrides_timeout_and_retries(self):
+        with patch("firetower.integrations.services.linear.settings") as mock_settings:
+            mock_settings.LINEAR = {
+                "CLIENT_ID": "id",
+                "CLIENT_SECRET": "secret",
+                "MAX_RETRIES": 5,
+            }
+            svc = LinearService(timeout=8, max_retries=1)
+
+        assert svc.timeout == 8
+        assert svc.max_retries == 1
+
+    def test_tight_timeout_is_plumbed_into_request(self):
+        with patch("firetower.integrations.services.linear.settings") as mock_settings:
+            mock_settings.LINEAR = {"CLIENT_ID": "id", "CLIENT_SECRET": "secret"}
+            svc = LinearService(timeout=8, max_retries=1)
+
+        with patch("firetower.integrations.services.linear.requests.post") as mock_post:
+            svc._make_graphql_request("query { viewer { id } }", None, "tok")
+
+        _, kwargs = mock_post.call_args
+        assert kwargs["timeout"] == 8
+
+    @patch("firetower.integrations.services.linear.LinearOAuthToken")
+    def test_tight_timeout_is_plumbed_into_token_request(self, mock_token_model):
+        with patch("firetower.integrations.services.linear.settings") as mock_settings:
+            mock_settings.LINEAR = {"CLIENT_ID": "id", "CLIENT_SECRET": "secret"}
+            svc = LinearService(timeout=8, max_retries=1)
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "access_token": "new-access-token",
+            "expires_in": 3600,
+        }
+
+        with patch("firetower.integrations.services.linear.requests.post") as mock_post:
+            mock_post.return_value = mock_response
+            svc._request_new_token()
+
+        _, kwargs = mock_post.call_args
+        assert kwargs["timeout"] == 8
+
+    def test_tight_retries_limit_attempts(self):
+        with patch("firetower.integrations.services.linear.settings") as mock_settings:
+            mock_settings.LINEAR = {"CLIENT_ID": "id", "CLIENT_SECRET": "secret"}
+            svc = LinearService(timeout=8, max_retries=1)
+
+        transient_response = MagicMock()
+        transient_response.status_code = 502
+        transient_response.ok = False
+        transient_response.text = "Bad Gateway"
+
+        with (
+            patch.object(svc, "_get_access_token", return_value="valid-token"),
+            patch.object(
+                svc, "_make_graphql_request", return_value=transient_response
+            ) as mock_request,
+            patch.object(svc, "_sleep_before_retry") as mock_sleep,
+        ):
+            result = svc._graphql("query { viewer { id } }")
+
+        assert result is None
+        assert mock_request.call_count == 1
+        mock_sleep.assert_not_called()
+
+
+class TestParseProjectNumber:
+    @pytest.mark.parametrize(
+        "identifier,expected",
+        [
+            ("INC-2353", 2353),
+            ("INC-1", 1),
+            ("INC-0", 0),
+        ],
+    )
+    def test_matches_project_key(self, identifier, expected):
+        with patch("firetower.integrations.services.linear.settings") as mock_settings:
+            mock_settings.PROJECT_KEY = "INC"
+            assert parse_project_number(identifier) == expected
+
+    @pytest.mark.parametrize(
+        "identifier",
+        [
+            "PRODENG-1404",
+            "INC-abc",
+            "INC-12a",
+            "INC-",
+            "INC",
+            "",
+            "inc-2353",
+            " INC-1",
+            "INC-1 ",
+            "XINC-1",
+        ],
+    )
+    def test_returns_none_for_non_matches(self, identifier):
+        with patch("firetower.integrations.services.linear.settings") as mock_settings:
+            mock_settings.PROJECT_KEY = "INC"
+            assert parse_project_number(identifier) is None
+
 
 class TestParseIssue:
     def test_parses_full_issue(self, linear_service):
@@ -624,3 +895,52 @@ class TestGetIssue:
             result = linear_service.get_issue("nonexistent")
 
         assert result is None
+
+    def test_returns_none_when_issue_null_even_with_raise_on_error(
+        self, linear_service
+    ):
+        mock_response = {"issue": None}
+
+        with patch.object(
+            linear_service, "_graphql", return_value=mock_response
+        ) as mock_gql:
+            result = linear_service.get_issue("nonexistent", raise_on_error=True)
+
+        assert result is None
+        assert mock_gql.call_args.kwargs["raise_on_error"] is True
+
+    def test_raises_linear_error_on_call_failure_when_raise_on_error(
+        self, linear_service
+    ):
+        with patch.object(linear_service, "_graphql", side_effect=LinearError("boom")):
+            with pytest.raises(LinearError):
+                linear_service.get_issue("issue-123", raise_on_error=True)
+
+    def test_returns_none_on_call_failure_when_not_raising(self, linear_service):
+        with patch.object(linear_service, "_graphql", return_value=None) as mock_gql:
+            result = linear_service.get_issue("issue-123")
+
+        assert result is None
+        assert mock_gql.call_args.kwargs["raise_on_error"] is False
+
+    def test_raises_linear_error_when_top_level_data_null_end_to_end(
+        self, linear_service
+    ):
+        # Exercises the real _graphql: a 200 with {"data": null} and no "errors"
+        # must raise for raise_on_error callers rather than return None (which
+        # would be indistinguishable from "issue genuinely absent").
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"data": None}
+
+        with (
+            patch.object(
+                linear_service, "_get_access_token", return_value="valid-token"
+            ),
+            patch.object(
+                linear_service, "_make_graphql_request", return_value=mock_response
+            ),
+        ):
+            with pytest.raises(LinearError):
+                linear_service.get_issue("issue-123", raise_on_error=True)

--- a/src/firetower/settings.py
+++ b/src/firetower/settings.py
@@ -342,6 +342,16 @@ ACTION_ITEM_SYNC_THROTTLE_SECONDS = (
     int(config.linear.action_item_sync_throttle_seconds) if config.linear else 300
 )
 
+# Tight timeout/retry budget for the incident allocation path, which calls
+# Linear while holding a DB lock. Kept lower than the default LinearService
+# budget so a hung Linear can't hold the lock for the full default duration.
+INCIDENT_ALLOC_LINEAR_TIMEOUT = (
+    int(config.linear.alloc_timeout_seconds) if config.linear else 8
+)
+INCIDENT_ALLOC_LINEAR_RETRIES = (
+    int(config.linear.alloc_max_retries) if config.linear else 1
+)
+
 # Django REST Framework Configuration
 REST_FRAMEWORK = {
     # Pagination


### PR DESCRIPTION
Part of **RELENG-909** (adopt-on-create incident-id assignment). This is **PR1a** — foundational, **additive, no behavior change** for existing callers. Unblocks the allocator in PR1b (RELENG-911).

## What

- **`LinearError`** + **`get_issue(..., raise_on_error=False)`**: with `raise_on_error=True`, `get_issue` returns `None` **only** when the call succeeded and the issue is genuinely absent, and raises `LinearError` when the call itself failed. The default (`raise_on_error=False`) preserves today's behavior exactly (`None` on any failure).
- **`LinearService.for_allocation()`** + keyword-only `timeout`/`max_retries` constructor args, driven by new settings **`INCIDENT_ALLOC_LINEAR_TIMEOUT`** (8s) / **`INCIDENT_ALLOC_LINEAR_RETRIES`** (1). A deliberately tight budget for the id-allocation path (which will hold a DB lock across a Linear call in PR1b), so a hung Linear can't hold the lock for the full 30s×retries default.
- **`parse_project_number("INC-2353") -> 2353`** (exact `PROJECT_KEY-<digits>`, else `None`).

## Why

The upcoming allocator (PR1b) calls `get_issue("INC-N")` under the incident counter lock and must distinguish **"the issue doesn't exist → create + adopt a new one"** from **"Linear is down → degrade"**. Today both collapse to `None`, which is the gap this PR closes.
