### PR TITLE
feat(incidents): Auto-resolve PagerDuty pages when P0/P1 incidents are mitigated or resolved

### DIFF
--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -215,6 +215,14 @@ def resolve_pages_for_incident(incident: Incident) -> None:
     never paged (or was already resolved) is a harmless 202 no-op, so we resolve
     every configured policy unconditionally.
 
+    Intentionally NOT gated on is_private or severity, unlike the trigger path
+    (page_for_channel). An incident can be paged while it is public and P0/P1
+    and then have its visibility or severity changed before it is mitigated;
+    gating resolve on the *current* is_private/severity would leave those
+    already-fired pages open. Resolving unconditionally costs at most a couple
+    of dead 202 no-op calls for incidents that never paged, which we accept in
+    exchange for never missing a real page.
+
     Known gap: pages fired on the degraded fallback path use the Slack channel
     name as the dedup prefix (not the incident number), so they are not matched
     here. Those are cleaned up manually.
@@ -1659,6 +1667,9 @@ def on_incident_updated(
 
     # Status change into a mitigated/terminal state: resolve any PD pages we sent.
     # Best-effort so a PagerDuty hiccup never breaks the incident update.
+    # resolve_pages_for_incident is intentionally severity- and visibility-
+    # agnostic (see its docstring): severity/visibility can change after the
+    # page fired, so gating on current values could strand an open page.
     if (
         old_status is not None
         and old_status in ACTIVE_STATUSES

--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -40,6 +40,14 @@ def _get_linear_service() -> LinearService:
 
 HIGH_SEVERITIES = {IncidentSeverity.P0, IncidentSeverity.P1}
 ACTIVE_STATUSES = {IncidentStatus.ACTIVE, IncidentStatus.MITIGATED}
+# Statuses that mean the incident has been responded to/mitigated, at which
+# point any PagerDuty pages Firetower triggered should be auto-resolved.
+PAGE_RESOLVE_STATUSES = {
+    IncidentStatus.MITIGATED,
+    IncidentStatus.DONE,
+    IncidentStatus.POSTMORTEM,
+    IncidentStatus.CANCELED,
+}
 
 DEFAULT_STATUSPAGE_WARNING_BUFFER_MINUTES = 0
 
@@ -196,6 +204,52 @@ def _page_if_needed(
         is_private=incident.is_private,
         skip_paging=skip_paging,
     )
+
+
+def resolve_pages_for_incident(incident: Incident) -> None:
+    """Resolve any PagerDuty pages Firetower triggered for this incident.
+
+    The dedup key is deterministically rebuilt from incident_number + policy
+    name, matching what page_for_channel sent at trigger time on the normal
+    path, so no PD lookup or stored alert id is needed. Resolving a policy that
+    never paged (or was already resolved) is a harmless 202 no-op, so we resolve
+    every configured policy unconditionally.
+
+    Known gap: pages fired on the degraded fallback path use the Slack channel
+    name as the dedup prefix (not the incident number), so they are not matched
+    here. Those are cleaned up manually.
+    """
+    pd_config = settings.PAGERDUTY
+    if not pd_config:
+        return
+
+    escalation_policies = pd_config.get("ESCALATION_POLICIES", {})
+
+    pd_service = None
+
+    for policy_name in PAGING_POLICIES:
+        policy = escalation_policies.get(policy_name)
+        if not policy:
+            continue
+
+        integration_key = policy.get("integration_key")
+        if not integration_key:
+            continue
+
+        if pd_service is None:
+            try:
+                pd_service = PagerDutyService()
+            except Exception:
+                logger.exception("Failed to initialize PagerDutyService for resolve")
+                return
+
+        dedup_key = f"firetower-{incident.incident_number}-{policy_name}"
+        try:
+            pd_service.resolve_incident(dedup_key, integration_key)
+        except Exception:
+            logger.exception(
+                f"Failed to resolve {policy_name} page for {incident.incident_number}"
+            )
 
 
 def build_channel_name(incident: Incident) -> str:
@@ -1601,6 +1655,20 @@ def on_incident_updated(
         except Exception:
             logger.exception(
                 f"Failed to trigger slack dump in on_incident_updated for incident {incident.id}"
+            )
+
+    # Status change into a mitigated/terminal state: resolve any PD pages we sent.
+    # Best-effort so a PagerDuty hiccup never breaks the incident update.
+    if (
+        old_status is not None
+        and old_status in ACTIVE_STATUSES
+        and incident.status in PAGE_RESOLVE_STATUSES
+    ):
+        try:
+            resolve_pages_for_incident(incident)
+        except Exception:
+            logger.exception(
+                f"Failed to resolve pages in on_incident_updated for incident {incident.id}"
             )
 
     # Severity escalation: page, invite oncall, create status channel, schedule reminders

--- a/src/firetower/incidents/tests/test_hooks.py
+++ b/src/firetower/incidents/tests/test_hooks.py
@@ -3589,9 +3589,7 @@ class TestOnIncidentUpdated:
 
     @patch("firetower.incidents.hooks.resolve_pages_for_incident")
     @patch("firetower.incidents.hooks._slack_service")
-    def test_resolves_pages_on_active_to_mitigated(
-        self, mock_slack, mock_resolve
-    ):
+    def test_resolves_pages_on_active_to_mitigated(self, mock_slack, mock_resolve):
         mock_slack.parse_channel_id_from_url.return_value = "C12345"
 
         incident = self._make_incident(status=IncidentStatus.MITIGATED)
@@ -3615,9 +3613,7 @@ class TestOnIncidentUpdated:
 
     @patch("firetower.incidents.hooks.resolve_pages_for_incident")
     @patch("firetower.incidents.hooks._slack_service")
-    def test_does_not_resolve_pages_on_no_status_change(
-        self, mock_slack, mock_resolve
-    ):
+    def test_does_not_resolve_pages_on_no_status_change(self, mock_slack, mock_resolve):
         mock_slack.parse_channel_id_from_url.return_value = "C12345"
 
         incident = self._make_incident(status=IncidentStatus.ACTIVE)

--- a/src/firetower/incidents/tests/test_hooks.py
+++ b/src/firetower/incidents/tests/test_hooks.py
@@ -29,6 +29,7 @@ from firetower.incidents.hooks import (
     on_title_changed,
     on_visibility_changed,
     page_for_channel,
+    resolve_pages_for_incident,
     schedule_statuspage_followup_reminder,
 )
 from firetower.incidents.models import (
@@ -797,6 +798,102 @@ MOCK_PD_CONFIG = {
         },
     },
 }
+
+
+@pytest.mark.django_db
+class TestResolvePagesForIncident:
+    @patch("firetower.incidents.hooks.PagerDutyService")
+    def test_resolves_both_policies(self, mock_pd_cls, settings):
+        settings.PAGERDUTY = MOCK_PD_CONFIG
+        mock_pd = mock_pd_cls.return_value
+
+        incident = Incident.objects.create(
+            title="Major outage",
+            severity=IncidentSeverity.P0,
+        )
+
+        resolve_pages_for_incident(incident)
+
+        assert mock_pd.resolve_incident.call_count == 2
+        imoc_call, pe_call = mock_pd.resolve_incident.call_args_list
+        assert imoc_call == (
+            (f"firetower-{incident.incident_number}-IMOC", "imoc-integration-key"),
+        )
+        assert pe_call == (
+            (
+                f"firetower-{incident.incident_number}-PROD_ENG",
+                "prod-eng-integration-key",
+            ),
+        )
+
+    @patch("firetower.incidents.hooks.PagerDutyService")
+    def test_resolves_regardless_of_severity(self, mock_pd_cls, settings):
+        # We do not know which policies actually paged, so resolve is
+        # unconditional and relies on PD treating unknown keys as a no-op.
+        settings.PAGERDUTY = MOCK_PD_CONFIG
+        mock_pd = mock_pd_cls.return_value
+
+        incident = Incident.objects.create(
+            title="Minor blip",
+            severity=IncidentSeverity.P3,
+        )
+
+        resolve_pages_for_incident(incident)
+
+        assert mock_pd.resolve_incident.call_count == 2
+
+    @patch("firetower.incidents.hooks.PagerDutyService")
+    def test_noop_when_pagerduty_unconfigured(self, mock_pd_cls, settings):
+        settings.PAGERDUTY = None
+
+        incident = Incident.objects.create(
+            title="Outage",
+            severity=IncidentSeverity.P0,
+        )
+
+        resolve_pages_for_incident(incident)
+
+        mock_pd_cls.assert_not_called()
+
+    @patch("firetower.incidents.hooks.PagerDutyService")
+    def test_skips_policies_without_integration_key(self, mock_pd_cls, settings):
+        settings.PAGERDUTY = {
+            "API_TOKEN": "test-token",
+            "ESCALATION_POLICIES": {
+                "IMOC": {"id": "PIMOC01", "integration_key": "imoc-integration-key"},
+                "PROD_ENG": {"id": "PPE001"},
+            },
+        }
+        mock_pd = mock_pd_cls.return_value
+
+        incident = Incident.objects.create(
+            title="Outage",
+            severity=IncidentSeverity.P0,
+        )
+
+        resolve_pages_for_incident(incident)
+
+        assert mock_pd.resolve_incident.call_count == 1
+        (call,) = mock_pd.resolve_incident.call_args_list
+        assert call == (
+            (f"firetower-{incident.incident_number}-IMOC", "imoc-integration-key"),
+        )
+
+    @patch("firetower.incidents.hooks.PagerDutyService")
+    def test_pd_failure_does_not_raise(self, mock_pd_cls, settings):
+        settings.PAGERDUTY = MOCK_PD_CONFIG
+        mock_pd = mock_pd_cls.return_value
+        mock_pd.resolve_incident.side_effect = Exception("boom")
+
+        incident = Incident.objects.create(
+            title="Outage",
+            severity=IncidentSeverity.P0,
+        )
+
+        # Should swallow per-policy errors and keep going.
+        resolve_pages_for_incident(incident)
+
+        assert mock_pd.resolve_incident.call_count == 2
 
 
 @pytest.mark.django_db
@@ -3489,6 +3586,86 @@ class TestOnIncidentUpdated:
         on_incident_updated(incident, old_status=IncidentStatus.MITIGATED)
 
         mock_dump_async.assert_called_once_with(mock_client, "C12345", incident)
+
+    @patch("firetower.incidents.hooks.resolve_pages_for_incident")
+    @patch("firetower.incidents.hooks._slack_service")
+    def test_resolves_pages_on_active_to_mitigated(
+        self, mock_slack, mock_resolve
+    ):
+        mock_slack.parse_channel_id_from_url.return_value = "C12345"
+
+        incident = self._make_incident(status=IncidentStatus.MITIGATED)
+        self._link_slack(incident)
+
+        on_incident_updated(incident, old_status=IncidentStatus.ACTIVE)
+
+        mock_resolve.assert_called_once_with(incident)
+
+    @patch("firetower.incidents.hooks.resolve_pages_for_incident")
+    @patch("firetower.incidents.hooks._slack_service")
+    def test_resolves_pages_on_active_to_canceled(self, mock_slack, mock_resolve):
+        mock_slack.parse_channel_id_from_url.return_value = "C12345"
+
+        incident = self._make_incident(status=IncidentStatus.CANCELED)
+        self._link_slack(incident)
+
+        on_incident_updated(incident, old_status=IncidentStatus.ACTIVE)
+
+        mock_resolve.assert_called_once_with(incident)
+
+    @patch("firetower.incidents.hooks.resolve_pages_for_incident")
+    @patch("firetower.incidents.hooks._slack_service")
+    def test_does_not_resolve_pages_on_no_status_change(
+        self, mock_slack, mock_resolve
+    ):
+        mock_slack.parse_channel_id_from_url.return_value = "C12345"
+
+        incident = self._make_incident(status=IncidentStatus.ACTIVE)
+        self._link_slack(incident)
+
+        on_incident_updated(incident, old_title="Old title")
+
+        mock_resolve.assert_not_called()
+
+    @patch("firetower.incidents.hooks.resolve_pages_for_incident")
+    @patch("firetower.incidents.hooks._slack_service")
+    def test_does_not_resolve_pages_on_reopen(self, mock_slack, mock_resolve):
+        mock_slack.parse_channel_id_from_url.return_value = "C12345"
+
+        incident = self._make_incident(status=IncidentStatus.ACTIVE)
+        self._link_slack(incident)
+
+        on_incident_updated(incident, old_status=IncidentStatus.MITIGATED)
+
+        mock_resolve.assert_not_called()
+
+    @patch("firetower.incidents.hooks.resolve_pages_for_incident")
+    @patch("firetower.incidents.hooks._slack_service")
+    def test_does_not_resolve_pages_from_terminal_status(
+        self, mock_slack, mock_resolve
+    ):
+        # Postmortem is not an active status, so a later transition to Done
+        # should not re-resolve (pages were already resolved at mitigation).
+        mock_slack.parse_channel_id_from_url.return_value = "C12345"
+
+        incident = self._make_incident(status=IncidentStatus.DONE)
+        self._link_slack(incident)
+
+        on_incident_updated(incident, old_status=IncidentStatus.POSTMORTEM)
+
+        mock_resolve.assert_not_called()
+
+    @patch("firetower.incidents.hooks.PagerDutyService")
+    @patch("firetower.incidents.hooks._slack_service")
+    def test_resolve_failure_does_not_break_update(self, mock_slack, mock_pd_cls):
+        mock_slack.parse_channel_id_from_url.return_value = "C12345"
+        mock_pd_cls.side_effect = Exception("pd down")
+
+        incident = self._make_incident(status=IncidentStatus.MITIGATED)
+        self._link_slack(incident)
+
+        # Must not raise even if PagerDuty resolve blows up.
+        on_incident_updated(incident, old_status=IncidentStatus.ACTIVE)
 
     @patch("firetower.incidents.hooks.schedule_statuspage_followup_reminder")
     @patch("firetower.incidents.hooks._schedule_statuspage_reminder")

--- a/src/firetower/incidents/tests/test_hooks.py
+++ b/src/firetower/incidents/tests/test_hooks.py
@@ -3655,6 +3655,22 @@ class TestOnIncidentUpdated:
 
         mock_resolve.assert_not_called()
 
+    @patch("firetower.incidents.hooks.resolve_pages_for_incident")
+    @patch("firetower.incidents.hooks._slack_service")
+    def test_re_resolves_pages_on_mitigated_to_postmortem(
+        self, mock_slack, mock_resolve
+    ):
+        # Mitigated is still an active status, so a transition to a terminal
+        # state re-resolves. This is a harmless idempotent 202 no-op.
+        mock_slack.parse_channel_id_from_url.return_value = "C12345"
+
+        incident = self._make_incident(status=IncidentStatus.POSTMORTEM)
+        self._link_slack(incident)
+
+        on_incident_updated(incident, old_status=IncidentStatus.MITIGATED)
+
+        mock_resolve.assert_called_once_with(incident)
+
     @patch("firetower.incidents.hooks.PagerDutyService")
     @patch("firetower.incidents.hooks._slack_service")
     def test_resolve_failure_does_not_break_update(self, mock_slack, mock_pd_cls):

--- a/src/firetower/integrations/services/pagerduty.py
+++ b/src/firetower/integrations/services/pagerduty.py
@@ -52,6 +52,34 @@ class PagerDutyService:
             )
             return False
 
+    def resolve_incident(self, dedup_key: str, integration_key: str) -> bool:
+        """Resolve a PagerDuty alert by re-sending its (routing_key, dedup_key).
+
+        PagerDuty groups Events API v2 alerts by (routing_key, dedup_key), so a
+        resolve for an unknown or already-resolved key is a harmless 202 no-op.
+        This lets us resolve without any REST lookup or stored PD alert id.
+        """
+        payload: dict = {
+            "routing_key": integration_key,
+            "event_action": "resolve",
+            "dedup_key": dedup_key,
+        }
+
+        try:
+            resp = requests.post(EVENTS_API_URL, json=payload, timeout=10)
+            resp.raise_for_status()
+            logger.info(
+                "Resolved PagerDuty incident",
+                extra={"dedup_key": dedup_key},
+            )
+            return True
+        except requests.RequestException:
+            logger.exception(
+                "Failed to resolve PagerDuty incident",
+                extra={"dedup_key": dedup_key},
+            )
+            return False
+
     def get_oncall_users(self, escalation_policy_id: str) -> list[dict]:
         headers = {
             "Authorization": f"Token token={self.api_token}",

--- a/src/firetower/integrations/tests/test_pagerduty.py
+++ b/src/firetower/integrations/tests/test_pagerduty.py
@@ -64,6 +64,31 @@ class TestTriggerIncident:
         assert result is False
 
 
+class TestResolveIncident:
+    @patch("firetower.integrations.services.pagerduty.requests.post")
+    def test_resolve_success(self, mock_post, pd_service):
+        mock_post.return_value = MagicMock(status_code=202)
+
+        result = pd_service.resolve_incident("dedup-123", "int-key")
+
+        assert result is True
+        mock_post.assert_called_once()
+        mock_post.return_value.raise_for_status.assert_called_once()
+        call_kwargs = mock_post.call_args
+        assert call_kwargs.kwargs["json"]["routing_key"] == "int-key"
+        assert call_kwargs.kwargs["json"]["dedup_key"] == "dedup-123"
+        assert call_kwargs.kwargs["json"]["event_action"] == "resolve"
+        assert "payload" not in call_kwargs.kwargs["json"]
+
+    @patch("firetower.integrations.services.pagerduty.requests.post")
+    def test_resolve_failure(self, mock_post, pd_service):
+        mock_post.side_effect = requests.RequestException("connection error")
+
+        result = pd_service.resolve_incident("dedup-123", "int-key")
+
+        assert result is False
+
+
 class TestGetOncallUsers:
     @patch("firetower.integrations.services.pagerduty.requests.get")
     def test_returns_users_with_escalation_level(self, mock_get, pd_service):


### PR DESCRIPTION
Closes RELENG-915.

When an incident transitions from an active state (Active/Mitigated) to a mitigated/terminal state (Mitigated/Done/Postmortem/Canceled), Firetower now auto-resolves the PagerDuty pages it triggered, so they don't linger open.

**How:** Reconstructs each page's dedup key (\`firetower-{incident_number}-{policy}\`) and re-sends it to the PD Events API with \`event_action=resolve\`. No PD lookup or stored alert id needed; resolving an unknown/already-resolved key is an idempotent 202 no-op, so we resolve every configured policy unconditionally (and stay severity/visibility-agnostic since those can change after a page fires).

**Known gap:** pages fired on the degraded fallback path are keyed on the Slack channel name, not the incident number, so they aren't matched here. Rare, and cleaned up manually.

No schema changes. Adds \`PagerDutyService.resolve_incident\` + \`hooks.resolve_pages_for_incident\`, wired into \`on_incident_updated\`, with tests.