### PR TITLE
feat(config): Add salt_keys for encryption key rotation

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -3,6 +3,11 @@ log_level = "INFO"
 django_secret_key = "django-insecure-gmj)qc*_dk&^i1=z7oy(ew7%5*fz^yowp8=4=0882_d=i3hl69"
 # Salt for django-fernet-encrypted-fields. In prod, use a unique value: python -c "import secrets; print(secrets.token_urlsafe(32))"
 salt_key = ""
+# Optional: for key rotation, set salt_keys (plural) to a list of salts. When present it
+# overrides salt_key. Values are encrypted with the FIRST key and can be decrypted with any,
+# so during rotation list the new key first and keep the old one until every row is
+# re-encrypted (run the reencrypt_encrypted_fields migration), then drop the old key.
+# salt_keys = ["<new-salt>", "<old-salt>"]
 sentry_dsn = "https://your-sentry-dsn@o1.ingest.us.sentry.io/project-id"
 firetower_base_url = "http://localhost:5173"
 # Optional: link rendered in /inc mitigated and /inc resolved modals to help users pick service_tier/affected_service.

--- a/src/firetower/config.py
+++ b/src/firetower/config.py
@@ -134,6 +134,9 @@ class ConfigFile:
     salt_key: str
     sentry_dsn: str
     service_registry_url: str | None = None
+    # When non-empty, `salt_keys` overrides `salt_key`. Used for key rotation:
+    # values are encrypted with the first key and can be decrypted with any.
+    salt_keys: list[str] = field(default_factory=list)
     notion: NotionConfig | None = None
     genai: GenAIConfig | None = None
     log_level: str = "INFO"
@@ -205,6 +208,7 @@ class DummyConfigFile(ConfigFile):
         self.firetower_base_url = ""
         self.django_secret_key = "dummy_value_DO_NOT_USE"
         self.salt_key = ""
+        self.salt_keys = []
         self.sentry_dsn = ""
         self.service_registry_url = None
         self.region_grouping: list[list[str]] = []

--- a/src/firetower/integrations/migrations/0003_reencrypt_encrypted_fields.py
+++ b/src/firetower/integrations/migrations/0003_reencrypt_encrypted_fields.py
@@ -1,0 +1,40 @@
+from django.db import migrations
+from encrypted_fields.fields import EncryptedFieldMixin
+
+
+def _encrypted_field_names(model) -> list[str]:
+    """Return the names of any encrypted fields declared on ``model``."""
+    return [
+        field.name
+        for field in model._meta.get_fields()
+        if isinstance(field, EncryptedFieldMixin)
+    ]
+
+
+def reencrypt(apps, schema_editor):
+    """Load and re-save every row of every model that has an encrypted field.
+
+    Encrypted fields decrypt on read and encrypt on write, so a load/save
+    cycle re-encrypts each value with the current primary key. Run this after
+    rotating ``SALT_KEY`` (keeping the old key in the list so existing values
+    can still be decrypted) to migrate all ciphertext onto the new key.
+    """
+    for model in apps.get_models():
+        encrypted_fields = _encrypted_field_names(model)
+        if not encrypted_fields:
+            continue
+
+        # ``update_fields`` limits the write to the encrypted columns, avoiding
+        # side effects like bumping ``auto_now`` timestamps.
+        for instance in model.objects.all().iterator():
+            instance.save(update_fields=encrypted_fields)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("integrations", "0002_alter_linearoauthtoken_access_token"),
+    ]
+
+    operations = [
+        migrations.RunPython(reencrypt, migrations.RunPython.noop),
+    ]

--- a/src/firetower/settings.py
+++ b/src/firetower/settings.py
@@ -86,7 +86,10 @@ SERVICE_REGISTRY_URL = config.service_registry_url
 SECRET_KEY = config.django_secret_key
 
 # Used by django-fernet-encrypted-fields to encrypt sensitive DB fields (e.g. OAuth tokens).
-SALT_KEY = config.salt_key
+# `salt_keys` (plural) takes precedence when set: values are encrypted with the first
+# key and can be decrypted with any of them, which supports key rotation. Otherwise the
+# single `salt_key` is used.
+SALT_KEY = config.salt_keys if config.salt_keys else config.salt_key
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env_is_dev()


### PR DESCRIPTION
## Summary

Adds a `salt_keys` (plural) config setting to support rotating the encryption key used by `django-fernet-encrypted-fields`.

- **`salt_keys`** is a list of strings. When non-empty, it **overrides** the single `salt_key` and `salt_key` is ignored.
- The library encrypts with the **first** key and can decrypt with **any** of them (`MultiFernet`), which is what enables rotation.
- Backward-compatible: `salt_keys` defaults to `[]`, so existing configs using `salt_key` are unaffected.

Also adds a data migration (`integrations/0003_reencrypt_encrypted_fields`) that re-encrypts every model with an encrypted field by loading and re-saving each row, migrating existing ciphertext onto the new primary key.

## Files changed

- `src/firetower/config.py` — add `salt_keys: list[str]` to `ConfigFile` (+ `DummyConfigFile`).
- `src/firetower/settings.py` — `SALT_KEY` resolves to `salt_keys` when set, else `salt_key`.
- `config.example.toml` — documented, commented-out `salt_keys` example with rotation steps.
- `src/firetower/integrations/migrations/0003_reencrypt_encrypted_fields.py` — re-encryption data migration.

## Rotation procedure

1. Set `salt_keys = ["<new-salt>", "<old-salt>"]` (new key first, old key retained).
2. Deploy, then run migrations — `0003_reencrypt_encrypted_fields` re-encrypts all rows onto the new key.
3. Once complete, drop the old key: `salt_keys = ["<new-salt>"]` (or just set `salt_key`).

## Test plan

- [x] `makemigrations --check` reports no schema drift.
- [x] Verified `salt_keys` override logic: empty → falls back to `salt_key`; set → resolves to the list.
- [x] Pre-commit (ruff, mypy) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)