### PR TITLE
feat(db): Add fallback password support for Postgres rotation

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -19,6 +19,10 @@ db = "firetower"
 host = "localhost"
 user = "postgres"
 password = "dummy_dev_password"
+# Optional: during a password rotation, list the other valid password(s) here.
+# If `password` is rejected with an auth error, each of these is tried in order.
+# Once the rotation is complete, move the new value into `password` and clear this.
+# fallback_passwords = ["<other-password>"]
 
 [slack]
 bot_token = ""

--- a/src/firetower/config.py
+++ b/src/firetower/config.py
@@ -18,6 +18,10 @@ class PostgresConfig:
     host: str
     user: str
     password: str
+    # Additional passwords tried (in order) only when `password` fails
+    # authentication. Used to bridge the race window during a password
+    # rotation, when the server and app may briefly disagree on the password.
+    fallback_passwords: list[str] = field(default_factory=list)
 
 
 @deserialize
@@ -185,6 +189,7 @@ class DummyConfigFile(ConfigFile):
             host="localhost",
             user="postgres",
             password="dummy_dev_password",
+            fallback_passwords=[],
         )
         self.slack = SlackConfig(
             bot_token="",

--- a/src/firetower/db_backend/__init__.py
+++ b/src/firetower/db_backend/__init__.py
@@ -1,0 +1,1 @@
+"""Custom PostgreSQL backend with password-fallback support (see ``base``)."""

--- a/src/firetower/db_backend/base.py
+++ b/src/firetower/db_backend/base.py
@@ -1,0 +1,66 @@
+"""
+PostgreSQL backend that retries connection auth with fallback passwords.
+
+Extends Django's stock ``postgresql`` backend. When opening a new connection
+fails with a password-authentication error, it retries with each password in
+the ``FALLBACK_PASSWORDS`` list from the database settings (in order). This
+bridges the race window during a password rotation, when the server and the
+app may briefly disagree on the current password.
+
+Enable via ``settings.DATABASES``::
+
+    "default": {
+        "ENGINE": "firetower.db_backend",
+        ...
+        "FALLBACK_PASSWORDS": ["<other-password>", ...],
+    }
+"""
+
+import logging
+from typing import Any
+
+from django.db.backends.postgresql import base
+
+logger = logging.getLogger(__name__)
+
+# PostgreSQL SQLSTATE class 28 -- invalid authorization specification /
+# invalid password. See https://www.postgresql.org/docs/current/errcodes-appendix.html
+_AUTH_SQLSTATE_CLASS = "28"
+
+
+def _is_auth_error(exc: Exception) -> bool:
+    """True if ``exc`` looks like a password-authentication failure."""
+    sqlstate = getattr(exc, "sqlstate", None)
+    if sqlstate and sqlstate.startswith(_AUTH_SQLSTATE_CLASS):
+        return True
+    # libpq reports a bad password during the connection handshake without a
+    # SQLSTATE, so fall back to matching the message text.
+    return "password authentication failed" in str(exc).lower()
+
+
+class DatabaseWrapper(base.DatabaseWrapper):
+    def get_new_connection(self, conn_params: dict[str, Any]) -> Any:
+        try:
+            return super().get_new_connection(conn_params)
+        except self.Database.OperationalError as exc:
+            if not _is_auth_error(exc):
+                raise
+            fallback_passwords = self.settings_dict.get("FALLBACK_PASSWORDS") or []
+            last_exc = exc
+            for password in fallback_passwords:
+                try:
+                    connection = super().get_new_connection(
+                        {**conn_params, "password": password}
+                    )
+                except self.Database.OperationalError as retry_exc:
+                    if not _is_auth_error(retry_exc):
+                        raise
+                    last_exc = retry_exc
+                    continue
+                logger.warning(
+                    "Primary Postgres password rejected; connected using a "
+                    "fallback password. Complete the rotation and remove the "
+                    "fallback."
+                )
+                return connection
+            raise last_exc

--- a/src/firetower/settings.py
+++ b/src/firetower/settings.py
@@ -187,11 +187,14 @@ WSGI_APPLICATION = "firetower.wsgi.application"
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.postgresql",
+        # Custom backend: extends the stock postgresql backend to retry auth
+        # with FALLBACK_PASSWORDS during a password rotation.
+        "ENGINE": "firetower.db_backend",
         "NAME": config.postgres.db,
         "HOST": config.postgres.host,
         "USER": config.postgres.user,
         "PASSWORD": config.postgres.password,
+        "FALLBACK_PASSWORDS": config.postgres.fallback_passwords,
         "CONN_HEALTH_CHECKS": True,
     },
 }


### PR DESCRIPTION
## Problem

`DATABASES["default"]["PASSWORD"]` is a single static string read from config at startup. During a password rotation there's an unavoidable window where the Postgres server has the new password but the app still holds the old one (or vice-versa), and every new connection fails authentication.

## Solution

A custom Django database backend (`firetower.db_backend`) that subclasses the stock `postgresql` backend and overrides `get_new_connection`. When the primary password gets a password-authentication error, it transparently retries with each password in `FALLBACK_PASSWORDS` (in order) before giving up. This is per-connection, so it works cleanly with connection health checks / `CONN_MAX_AGE` and requires no app-code changes elsewhere.

Auth failures are detected by SQLSTATE class `28` **or** the libpq `"password authentication failed"` message (the connection-handshake error carries no SQLSTATE). Non-auth errors (host down, connection refused) are re-raised immediately — no masking.

## Zero-downtime rotation

Works in either order:

1. Deploy config with `password = "<old>"` and `fallback_passwords = ["<new>"]` → app accepts both.
2. Rotate the password on the Postgres server. In-flight new connections fall back automatically.
3. On a later deploy, set `password = "<new>"` and clear `fallback_passwords`.

## Changes

- **`src/firetower/db_backend/{__init__,base}.py`** (new) — the fallback backend.
- **`src/firetower/settings.py`** — `ENGINE` points at the custom backend; passes `FALLBACK_PASSWORDS`.
- **`src/firetower/config.py`** — new `fallback_passwords: list[str]` on `PostgresConfig` (defaults empty).
- **`config.example.toml`** — documents the option.

## Verification

- Custom wrapper loads; `manage.py check` passes.
- `FALLBACK_PASSWORDS` reaches the backend but is **not** forwarded to psycopg's connection params.
- `_is_auth_error` correctly matches by message and SQLSTATE, and rejects non-auth errors.

Note: no automated test added — there's no DB-backend test harness here and end-to-end coverage needs a live Postgres. Happy to add a unit test that mocks the connect call to assert retry ordering if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)