### PR TITLE
fix(statuspage): Include component_ids in incident API payloads

### DIFF
--- a/src/firetower/integrations/services/statuspage.py
+++ b/src/firetower/integrations/services/statuspage.py
@@ -134,7 +134,13 @@ class StatuspageService:
         if components:
             # component_ids and components must be in the same payload or Statuspage
             # treats them as separate actions and suppresses one webhook.
-            payload["incident"]["component_ids"] = list(components.keys())
+            # Only list non-operational components in component_ids so the
+            # incident page shows affected components, but send all statuses
+            # in components so resets to operational are still applied.
+            affected_ids = [
+                cid for cid, status in components.items() if status != "operational"
+            ]
+            payload["incident"]["component_ids"] = affected_ids
             payload["incident"]["components"] = components
 
         response = requests.post(
@@ -167,7 +173,13 @@ class StatuspageService:
         if components:
             # component_ids and components must be in the same payload or Statuspage
             # treats them as separate actions and suppresses one webhook.
-            incident_data["component_ids"] = list(components.keys())
+            # Only list non-operational components in component_ids so the
+            # incident page shows affected components, but send all statuses
+            # in components so resets to operational are still applied.
+            affected_ids = [
+                cid for cid, status in components.items() if status != "operational"
+            ]
+            incident_data["component_ids"] = affected_ids
             incident_data["components"] = components
 
         payload = {"incident": incident_data}

--- a/src/firetower/integrations/services/statuspage.py
+++ b/src/firetower/integrations/services/statuspage.py
@@ -132,6 +132,9 @@ class StatuspageService:
             }
         }
         if components:
+            # component_ids and components must be in the same payload or Statuspage
+            # treats them as separate actions and suppresses one webhook.
+            payload["incident"]["component_ids"] = list(components.keys())
             payload["incident"]["components"] = components
 
         response = requests.post(
@@ -162,6 +165,9 @@ class StatuspageService:
         if message:
             incident_data["body"] = message
         if components:
+            # component_ids and components must be in the same payload or Statuspage
+            # treats them as separate actions and suppresses one webhook.
+            incident_data["component_ids"] = list(components.keys())
             incident_data["components"] = components
 
         payload = {"incident": incident_data}

--- a/src/firetower/integrations/tests/test_statuspage.py
+++ b/src/firetower/integrations/tests/test_statuspage.py
@@ -196,6 +196,7 @@ class TestStatuspageServiceCreateIncident:
 
             payload = mock_post.call_args[1]["json"]
             assert payload["incident"]["impact"] == "critical"
+            assert payload["incident"]["component_ids"] == ["comp1"]
             assert payload["incident"]["components"] == {"comp1": "major_outage"}
 
     def test_create_incident_raises_on_error(self):
@@ -257,6 +258,7 @@ class TestStatuspageServiceUpdateIncident:
             )
 
             payload = mock_patch.call_args[1]["json"]
+            assert payload["incident"]["component_ids"] == ["comp1"]
             assert payload["incident"]["components"] == {
                 "comp1": "degraded_performance"
             }
@@ -278,6 +280,7 @@ class TestStatuspageServiceUpdateIncident:
             payload = mock_patch.call_args[1]["json"]
             assert "status" not in payload["incident"]
             assert "body" not in payload["incident"]
+            assert "component_ids" not in payload["incident"]
             assert "components" not in payload["incident"]
             assert payload["incident"]["deliver_notifications"] is True
 

--- a/src/firetower/integrations/tests/test_statuspage.py
+++ b/src/firetower/integrations/tests/test_statuspage.py
@@ -199,6 +199,69 @@ class TestStatuspageServiceCreateIncident:
             assert payload["incident"]["component_ids"] == ["comp1"]
             assert payload["incident"]["components"] == {"comp1": "major_outage"}
 
+    def test_create_incident_filters_operational_from_component_ids(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": "new789"}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(settings, "STATUSPAGE", MOCK_STATUSPAGE_CONFIG):
+            service = StatuspageService()
+
+        with patch(
+            "firetower.integrations.services.statuspage.requests.post",
+            return_value=mock_response,
+        ) as mock_post:
+            service.create_incident(
+                title="Partial Outage",
+                status="investigating",
+                message="Some components affected",
+                components={
+                    "comp1": "major_outage",
+                    "comp2": "operational",
+                    "comp3": "degraded_performance",
+                },
+            )
+
+            payload = mock_post.call_args[1]["json"]
+            assert sorted(payload["incident"]["component_ids"]) == [
+                "comp1",
+                "comp3",
+            ]
+            assert payload["incident"]["components"] == {
+                "comp1": "major_outage",
+                "comp2": "operational",
+                "comp3": "degraded_performance",
+            }
+
+    def test_create_incident_all_operational_components(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": "new999"}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(settings, "STATUSPAGE", MOCK_STATUSPAGE_CONFIG):
+            service = StatuspageService()
+
+        with patch(
+            "firetower.integrations.services.statuspage.requests.post",
+            return_value=mock_response,
+        ) as mock_post:
+            service.create_incident(
+                title="Recovery",
+                status="resolved",
+                message="All clear",
+                components={
+                    "comp1": "operational",
+                    "comp2": "operational",
+                },
+            )
+
+            payload = mock_post.call_args[1]["json"]
+            assert payload["incident"]["component_ids"] == []
+            assert payload["incident"]["components"] == {
+                "comp1": "operational",
+                "comp2": "operational",
+            }
+
     def test_create_incident_raises_on_error(self):
         mock_response = MagicMock()
         mock_response.raise_for_status.side_effect = Exception("API error")
@@ -261,6 +324,38 @@ class TestStatuspageServiceUpdateIncident:
             assert payload["incident"]["component_ids"] == ["comp1"]
             assert payload["incident"]["components"] == {
                 "comp1": "degraded_performance"
+            }
+
+    def test_update_incident_filters_operational_from_component_ids(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": "inc123"}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(settings, "STATUSPAGE", MOCK_STATUSPAGE_CONFIG):
+            service = StatuspageService()
+
+        with patch(
+            "firetower.integrations.services.statuspage.requests.patch",
+            return_value=mock_response,
+        ) as mock_patch:
+            service.update_incident(
+                incident_id="inc123",
+                components={
+                    "comp1": "degraded_performance",
+                    "comp2": "operational",
+                    "comp3": "partial_outage",
+                },
+            )
+
+            payload = mock_patch.call_args[1]["json"]
+            assert sorted(payload["incident"]["component_ids"]) == [
+                "comp1",
+                "comp3",
+            ]
+            assert payload["incident"]["components"] == {
+                "comp1": "degraded_performance",
+                "comp2": "operational",
+                "comp3": "partial_outage",
             }
 
     def test_update_incident_minimal(self):


### PR DESCRIPTION
## Summary
- Include `component_ids` alongside the `components` map in both `create_incident` and `update_incident` Statuspage API calls.
- Without `component_ids`, Statuspage treats incident status and component status changes as separate internal actions, triggering notification-storm suppression that drops one webhook.
- This ensures both updates are processed as a single atomic event, preventing dropped status webhooks to subscribers.


🤖 Generated with [Claude Code](https://claude.com/claude-code)


Agent transcript: https://claudescope.sentry.dev/share/R7LZ2m3MlPwBymJ_y87n0c87srCzPm7v4qzEkJVG6nM