### PR TITLE
feat(datadog): Add rich text header cell to notebook creation

### DIFF
--- a/src/firetower/integrations/services/datadog.py
+++ b/src/firetower/integrations/services/datadog.py
@@ -4,12 +4,27 @@ import os
 from datadog_api_client import ApiClient, Configuration
 from datadog_api_client.exceptions import ApiException
 from datadog_api_client.v1.api.notebooks_api import NotebooksApi
+from datadog_api_client.v1.model.notebook_cell_create_request import (
+    NotebookCellCreateRequest,
+)
+from datadog_api_client.v1.model.notebook_cell_resource_type import (
+    NotebookCellResourceType,
+)
 from datadog_api_client.v1.model.notebook_create_data import NotebookCreateData
 from datadog_api_client.v1.model.notebook_create_data_attributes import (
     NotebookCreateDataAttributes,
 )
 from datadog_api_client.v1.model.notebook_create_request import NotebookCreateRequest
 from datadog_api_client.v1.model.notebook_global_time import NotebookGlobalTime
+from datadog_api_client.v1.model.notebook_markdown_cell_attributes import (
+    NotebookMarkdownCellAttributes,
+)
+from datadog_api_client.v1.model.notebook_markdown_cell_definition import (
+    NotebookMarkdownCellDefinition,
+)
+from datadog_api_client.v1.model.notebook_markdown_cell_definition_type import (
+    NotebookMarkdownCellDefinitionType,
+)
 from datadog_api_client.v1.model.notebook_resource_type import NotebookResourceType
 from datadog_api_client.v1.model.widget_live_span import WidgetLiveSpan
 
@@ -62,10 +77,19 @@ class DatadogService:
             with ApiClient(configuration) as api_client:
                 api_instance = NotebooksApi(api_client)
 
+                header_cell = NotebookCellCreateRequest(
+                    attributes=NotebookMarkdownCellAttributes(
+                        definition=NotebookMarkdownCellDefinition(
+                            text=f"# [{incident_number}] {title}",
+                            type=NotebookMarkdownCellDefinitionType.MARKDOWN,
+                        ),
+                    ),
+                    type=NotebookCellResourceType.NOTEBOOK_CELLS,
+                )
                 notebook_data = NotebookCreateData(
                     attributes=NotebookCreateDataAttributes(
                         name=notebook_name,
-                        cells=[],
+                        cells=[header_cell],
                         time=NotebookGlobalTime(live_span=WidgetLiveSpan("1h")),
                     ),
                     type=NotebookResourceType("notebooks"),

--- a/src/firetower/integrations/services/datadog.py
+++ b/src/firetower/integrations/services/datadog.py
@@ -80,7 +80,7 @@ class DatadogService:
                 header_cell = NotebookCellCreateRequest(
                     attributes=NotebookMarkdownCellAttributes(
                         definition=NotebookMarkdownCellDefinition(
-                            text=f"# [{incident_number}] {title}",
+                            text="---",
                             type=NotebookMarkdownCellDefinitionType.MARKDOWN,
                         ),
                     ),

--- a/src/firetower/integrations/tests/test_datadog.py
+++ b/src/firetower/integrations/tests/test_datadog.py
@@ -63,7 +63,7 @@ class TestCreateNotebook:
         assert body.data.attributes.name == "[INC-100] Database is on fire"
         cells = body.data.attributes.cells
         assert len(cells) == 1
-        assert cells[0].attributes.definition.text == "# [INC-100] Database is on fire"
+        assert cells[0].attributes.definition.text == "---"
         assert str(body.data.attributes.time.live_span) == "1h"
 
     def test_create_notebook_truncates_long_title(self):
@@ -86,7 +86,7 @@ class TestCreateNotebook:
         assert name.startswith("[INC-2000] ")
         assert name.endswith("...")
         cells = body.data.attributes.cells
-        assert cells[0].attributes.definition.text == f"# [INC-2000] {long_title}"
+        assert cells[0].attributes.definition.text == "---"
 
     def test_create_notebook_short_title_not_truncated(self):
         with _patch_dd_env():

--- a/src/firetower/integrations/tests/test_datadog.py
+++ b/src/firetower/integrations/tests/test_datadog.py
@@ -61,7 +61,9 @@ class TestCreateNotebook:
         mock_api.create_notebook.assert_called_once()
         body = mock_api.create_notebook.call_args[1]["body"]
         assert body.data.attributes.name == "[INC-100] Database is on fire"
-        assert body.data.attributes.cells == []
+        cells = body.data.attributes.cells
+        assert len(cells) == 1
+        assert cells[0].attributes.definition.text == "# [INC-100] Database is on fire"
         assert str(body.data.attributes.time.live_span) == "1h"
 
     def test_create_notebook_truncates_long_title(self):
@@ -83,6 +85,8 @@ class TestCreateNotebook:
         assert len(name) == 80
         assert name.startswith("[INC-2000] ")
         assert name.endswith("...")
+        cells = body.data.attributes.cells
+        assert cells[0].attributes.definition.text == f"# [INC-2000] {long_title}"
 
     def test_create_notebook_short_title_not_truncated(self):
         with _patch_dd_env():


### PR DESCRIPTION
## Summary
- Add a simple markdown row to Datadog notebooks on creation, forcing the notebook into rich text format instead of the default empty state.

## Test plan
- [x] `uv run pytest src/firetower/integrations/tests/test_datadog.py` -- all 11 tests pass
- [x] `uv run ruff format` and `uv run ruff check` clean
- [x] Verify in staging that a newly created notebook opens in rich text mode with the header visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Agent transcript: https://claudescope.sentry.dev/share/0x0K3SiI0eWS9wMFkOQkfwm-R4NovDnZ_sq5DYi54QE