### PR TITLE
feat: adopt-on-create incident id allocator, flagged off

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -57,6 +57,12 @@ team_id = ""
 project_id = ""
 # When true, claim the Linear issue matching the incident number (e.g. INC-2160) instead of creating a new one.
 sync_identifiers = false
+# When true (and sync_identifiers is true), allocate incident ids by claiming or
+# creating a matching INC-N placeholder in Linear at creation time, so the
+# incident's numeric id and Linear parent are minted together. Requires
+# sync_identifiers. Defaults to false (legacy: id from the local counter, Linear
+# parent claimed/created afterwards by the hook).
+adopt_on_create = false
 # Tight timeout (seconds) and retry count for Linear calls on the incident
 # allocation path, which runs while holding a DB lock. Kept lower than the
 # default LinearService budget so a hung Linear can't hold the lock too long.

--- a/src/firetower/config.py
+++ b/src/firetower/config.py
@@ -80,6 +80,7 @@ class LinearConfig:
     team_id: str = ""
     project_id: str = ""
     sync_identifiers: bool = False
+    adopt_on_create: bool = False
     api_key: str = ""
     alloc_timeout_seconds: int = 8
     alloc_max_retries: int = 1

--- a/src/firetower/incidents/allocation.py
+++ b/src/firetower/incidents/allocation.py
@@ -1,0 +1,227 @@
+"""Incident id allocation.
+
+The default (flag-off) path mints ids from the local :class:`IncidentCounter`
+and lets the Linear parent be claimed/created afterwards by the incident hook.
+
+When ``INCIDENT_ADOPT_ON_CREATE`` is enabled (and ``SYNC_IDENTIFIERS`` is set),
+ids are minted by adopting a *matching* ``INC-N`` placeholder in Linear: we walk
+the counter forward, claiming a clean matching placeholder or creating a new one
+and adopting whatever id Linear mints. The incident's numeric id and its Linear
+parent are therefore always allocated together, and we never claim an issue whose
+identifier does not match the id we hand out (which is what let the legacy
+``_claim_linear_issue`` path clobber moved/aliased issues).
+"""
+
+import logging
+import os
+from dataclasses import dataclass
+
+from datadog import statsd
+from django.conf import settings
+from django.db import connection, transaction
+from django.db.models import Max
+
+from firetower.incidents.models import (
+    INCIDENT_ID_START,
+    Incident,
+    IncidentCounter,
+    get_next_incident_id,
+)
+from firetower.integrations.services.linear import (
+    LinearError,
+    LinearService,
+    parse_project_number,
+)
+
+logger = logging.getLogger(__name__)
+
+METRIC_PREFIX = "firetower.inc_alloc"
+
+# Title used for placeholder issues minted by the allocator. ``_looks_like_placeholder``
+# also accepts the legacy title so pre-seeded placeholders keep working.
+PLACEHOLDER_TITLE = "Firetower placeholder — do not edit"
+LEGACY_PLACEHOLDER_TITLE = "Placeholder"
+
+# Upper bound on how many aliased / used / stray ``INC-N`` slots we skip before
+# giving up on claiming and falling through to create-and-adopt.
+MAX_ALIAS_SKIPS = 25
+
+
+@dataclass(frozen=True)
+class AllocatedIdentity:
+    """The result of allocating an incident id.
+
+    ``linear_issue_uuid``/``linear_url`` are empty strings on the flag-off path,
+    meaning "no pre-claimed Linear parent" — the legacy hook path applies.
+    """
+
+    inc_id: int
+    linear_issue_uuid: str
+    linear_url: str
+
+
+class LinearUnavailable(Exception):
+    """Raised when the adopt-on-create allocator cannot reach Linear.
+
+    The surrounding ``transaction.atomic()`` rolls back, so the incident counter
+    is not advanced. Callers route to a degraded path rather than hard-failing.
+    """
+
+
+def adopt_on_create_enabled() -> bool:
+    return bool(
+        settings.LINEAR
+        and settings.LINEAR.get("SYNC_IDENTIFIERS")
+        and settings.LINEAR.get("INCIDENT_ADOPT_ON_CREATE")
+    )
+
+
+def _looks_like_placeholder(issue: dict[str, object]) -> bool:
+    """Conservatively decide whether ``issue`` is a claimable placeholder.
+
+    Only issues whose title matches the current or legacy placeholder title are
+    claimable; anything else is a "stray" real issue we must not touch.
+    """
+    return issue.get("title") in (PLACEHOLDER_TITLE, LEGACY_PLACEHOLDER_TITLE)
+
+
+def _ensure_incident_counter() -> None:
+    """Self-heal a missing counter row, mirroring ``get_next_incident_id``."""
+    if IncidentCounter.objects.filter(pk=1).exists():
+        return
+    max_id = Incident.objects.aggregate(max_id=Max("id"))["max_id"]
+    IncidentCounter.objects.get_or_create(
+        pk=1,
+        defaults={"next_id": (max_id + 1) if max_id else INCIDENT_ID_START},
+    )
+
+
+def _create_and_adopt_placeholder(
+    linear: LinearService, team_id: str, project_id: str | None
+) -> tuple[int, str, str]:
+    """Create a placeholder issue in Linear and adopt whatever id it minted.
+
+    Side-effect free with respect to the DB and counter (no writes, no counter
+    mutation) so a future buffer-refill job can reuse it. Raises
+    :class:`LinearUnavailable` if the create fails or Linear minted an
+    identifier that is not ``INC-<int>`` (e.g. the team was renamed).
+    """
+    issue = linear.create_issue(PLACEHOLDER_TITLE, "", team_id, project_id)
+    if not issue:
+        logger.warning("Failed to create Linear placeholder issue for allocation")
+        statsd.increment(f"{METRIC_PREFIX}.unavailable")
+        raise LinearUnavailable
+    minted = parse_project_number(issue["identifier"])
+    if minted is None:
+        logger.error(
+            "Linear minted a non-%s identifier for a placeholder issue: %s",
+            settings.PROJECT_KEY,
+            issue["identifier"],
+        )
+        statsd.increment(f"{METRIC_PREFIX}.unavailable")
+        raise LinearUnavailable
+    return minted, issue["id"], issue["url"]
+
+
+def allocate_incident_identity() -> AllocatedIdentity:
+    """Allocate the next incident id (and, when adopting, its Linear parent)."""
+    if not adopt_on_create_enabled():
+        return AllocatedIdentity(get_next_incident_id(), "", "")
+
+    assert settings.LINEAR is not None
+    team_id = str(settings.LINEAR.get("TEAM_ID", ""))
+    project_id = str(settings.LINEAR.get("PROJECT_ID", "")) or None
+
+    _ensure_incident_counter()
+    linear = LinearService.for_allocation()
+
+    # The counter row lock must be held only across the Linear calls and released
+    # when this atomic() commits, *before* the slow channel-setup work runs. That
+    # only holds if this is the outermost transaction: nested inside an enclosing
+    # atomic() the lock would instead be held until the outer commit. Assert the
+    # invariant as a regression tripwire. pytest wraps every test in a
+    # transaction, so skip the check there.
+    assert "PYTEST_CURRENT_TEST" in os.environ or not connection.in_atomic_block, (
+        "allocate_incident_identity() must run outside an enclosing transaction "
+        "so the counter lock is released before slow channel work"
+    )
+
+    # ATOMIC_REQUESTS is off and neither creation entry point wraps create() in a
+    # transaction, so this atomic() is its own transaction: the row lock is held
+    # across the Linear calls (intended — it serializes concurrent allocations)
+    # and released when we return. On LinearUnavailable the block rolls back, so
+    # the counter is not advanced.
+    with statsd.timed(f"{METRIC_PREFIX}.duration"), transaction.atomic():
+        counter = IncidentCounter.objects.select_for_update().get(pk=1)
+        n = counter.next_id
+        for _ in range(MAX_ALIAS_SKIPS):
+            identifier = f"{settings.PROJECT_KEY}-{n}"
+            try:
+                issue = linear.get_issue(identifier, raise_on_error=True)
+            except LinearError:
+                logger.warning("Linear unavailable while allocating %s", identifier)
+                statsd.increment(f"{METRIC_PREFIX}.unavailable")
+                raise LinearUnavailable from None
+
+            if issue is None:
+                minted, uuid, url = _create_and_adopt_placeholder(
+                    linear, team_id, project_id
+                )
+                if minted < n:
+                    logger.error(
+                        "Linear minted id %s below the counter position %s; "
+                        "refusing to allocate",
+                        minted,
+                        n,
+                    )
+                    statsd.increment(f"{METRIC_PREFIX}.unavailable")
+                    raise LinearUnavailable
+                counter.next_id = minted + 1
+                counter.save(update_fields=["next_id"])
+                statsd.increment(f"{METRIC_PREFIX}.create_adopt")
+                return AllocatedIdentity(minted, uuid, url)
+
+            if issue["identifier"] != identifier:
+                # INC-n was moved/aliased to another team (e.g. PRODENG-1404);
+                # skip it rather than clobber it.
+                n += 1
+                counter.next_id = n
+                statsd.increment(f"{METRIC_PREFIX}.alias_skip")
+                continue
+
+            if Incident.objects.filter(pk=n).exists():
+                n += 1
+                counter.next_id = n
+                statsd.increment(f"{METRIC_PREFIX}.used_skip")
+                continue
+
+            if not _looks_like_placeholder(issue):
+                logger.error(
+                    "Skipping stray non-placeholder issue at %s while allocating",
+                    identifier,
+                )
+                n += 1
+                counter.next_id = n
+                statsd.increment(f"{METRIC_PREFIX}.stray")
+                continue
+
+            counter.next_id = n + 1
+            counter.save(update_fields=["next_id"])
+            statsd.increment(f"{METRIC_PREFIX}.claim")
+            return AllocatedIdentity(n, issue["id"], issue["url"])
+
+        # Skip budget exhausted — fall through to create-and-adopt.
+        minted, uuid, url = _create_and_adopt_placeholder(linear, team_id, project_id)
+        if minted < n:
+            logger.error(
+                "Linear minted id %s below the counter position %s; "
+                "refusing to allocate",
+                minted,
+                n,
+            )
+            statsd.increment(f"{METRIC_PREFIX}.unavailable")
+            raise LinearUnavailable
+        counter.next_id = minted + 1
+        counter.save(update_fields=["next_id"])
+        statsd.increment(f"{METRIC_PREFIX}.create_adopt")
+        return AllocatedIdentity(minted, uuid, url)

--- a/src/firetower/incidents/allocation.py
+++ b/src/firetower/incidents/allocation.py
@@ -9,7 +9,7 @@ the counter forward, claiming a clean matching placeholder or creating a new one
 and adopting whatever id Linear mints. The incident's numeric id and its Linear
 parent are therefore always allocated together, and we never claim an issue whose
 identifier does not match the id we hand out (which is what let the legacy
-``_claim_linear_issue`` path clobber moved/aliased issues).
+``claim_linear_issue`` path clobber moved/aliased issues).
 """
 
 import logging

--- a/src/firetower/incidents/allocation.py
+++ b/src/firetower/incidents/allocation.py
@@ -37,10 +37,8 @@ logger = logging.getLogger(__name__)
 
 METRIC_PREFIX = "firetower.inc_alloc"
 
-# Title used for placeholder issues minted by the allocator. ``_looks_like_placeholder``
-# also accepts the legacy title so pre-seeded placeholders keep working.
-PLACEHOLDER_TITLE = "Firetower placeholder — do not edit"
-LEGACY_PLACEHOLDER_TITLE = "Placeholder"
+# Title used for placeholder issues minted by the allocator.
+PLACEHOLDER_TITLE = "Placeholder"
 
 # Upper bound on how many aliased / used / stray ``INC-N`` slots we skip before
 # giving up on claiming and falling through to create-and-adopt.
@@ -79,10 +77,10 @@ def adopt_on_create_enabled() -> bool:
 def _looks_like_placeholder(issue: dict[str, object]) -> bool:
     """Conservatively decide whether ``issue`` is a claimable placeholder.
 
-    Only issues whose title matches the current or legacy placeholder title are
-    claimable; anything else is a "stray" real issue we must not touch.
+    Only issues whose title matches the placeholder title are claimable;
+    anything else is a "stray" real issue we must not touch.
     """
-    return issue.get("title") in (PLACEHOLDER_TITLE, LEGACY_PLACEHOLDER_TITLE)
+    return issue.get("title") == PLACEHOLDER_TITLE
 
 
 def _ensure_incident_counter() -> None:

--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -1180,7 +1180,7 @@ def create_linear_parent_issue(
         if not url:
             try:
                 issue = _get_linear_service().get_issue(incident.linear_parent_issue_id)
-                url = issue["url"] if issue else None
+                url = issue.get("url") if issue else None
             except Exception:
                 logger.exception(
                     f"Failed to resolve Linear url for incident {incident.id}"

--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -1085,7 +1085,7 @@ LINEAR_PARENT_DESCRIPTION = (
 MAX_CLAIM_ATTEMPTS = 5
 
 
-def _claim_linear_issue(
+def claim_linear_issue(
     linear_service: LinearService,
     incident: Incident,
     team_id: str,
@@ -1108,7 +1108,7 @@ def _claim_linear_issue(
     return None
 
 
-def _populate_linear_parent(
+def populate_linear_parent(
     incident: Incident, url: str, *, channel_id: str | None = None
 ) -> None:
     """Populate a pre-claimed / adopted Linear parent issue.
@@ -1174,7 +1174,17 @@ def create_linear_parent_issue(
     # Adopt-on-create: the allocator already claimed/created a matching Linear
     # parent whose uuid is on the incident. Populate it directly (no lookup by
     # identifier) and skip the legacy claim/create path entirely.
-    if adopt_on_create_enabled() and incident.linear_parent_issue_id:
+    if adopt_on_create_enabled():
+        # With adopt-on-create on, the legacy claim-by-identifier path must
+        # never run (it is the clobber-prone code RELENG-911 exists to avoid).
+        # The allocator always sets linear_parent_issue_id when the flag is on;
+        # if it is somehow missing, refuse to fall through and claim/clobber.
+        if not incident.linear_parent_issue_id:
+            logger.error(
+                f"Adopt-on-create enabled but incident {incident.id} has no "
+                "linear_parent_issue_id; refusing to run legacy claim path"
+            )
+            return
         identity = getattr(incident, "_allocated_identity", None)
         url = identity.linear_url if identity is not None else None
         if not url:
@@ -1187,7 +1197,7 @@ def create_linear_parent_issue(
                 )
                 url = None
         if url:
-            _populate_linear_parent(incident, url, channel_id=channel_id)
+            populate_linear_parent(incident, url, channel_id=channel_id)
         return
 
     linear_config = settings.LINEAR
@@ -1215,7 +1225,7 @@ def create_linear_parent_issue(
         captain_linear_id = _resolve_linear_user_id(incident.captain, linear_service)
 
         if sync_identifiers:
-            issue = _claim_linear_issue(linear_service, incident, team_id, project_id)
+            issue = claim_linear_issue(linear_service, incident, team_id, project_id)
             if not issue:
                 linear_link.delete()
                 logger.warning(

--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 from django_q.tasks import Schedule
 
 from firetower.auth.models import ExternalProfile, ExternalProfileType
+from firetower.incidents.allocation import adopt_on_create_enabled
 from firetower.incidents.models import (
     ExternalLink,
     ExternalLinkType,
@@ -1107,9 +1108,88 @@ def _claim_linear_issue(
     return None
 
 
+def _populate_linear_parent(
+    incident: Incident, url: str, *, channel_id: str | None = None
+) -> None:
+    """Populate a pre-claimed / adopted Linear parent issue.
+
+    ``incident.linear_parent_issue_id`` is an already-verified match for the
+    incident number, so this updates it directly by uuid via the default
+    LinearService (outside the allocation lock) and never looks the issue up by
+    identifier — so it can never clobber a moved/aliased issue. Every Linear
+    call is best-effort and non-fatal.
+    """
+    ExternalLink.objects.update_or_create(
+        incident=incident,
+        type=ExternalLinkType.LINEAR,
+        defaults={"url": url},
+    )
+
+    linear_config = settings.LINEAR
+    uuid = incident.linear_parent_issue_id
+    if not linear_config or not uuid:
+        return
+
+    team_id = str(linear_config.get("TEAM_ID", ""))
+    linear_service = _get_linear_service()
+
+    try:
+        states = linear_service.get_workflow_states(team_id) if team_id else None
+        started_state_id = states.get("started") if states else None
+        captain_linear_id = _resolve_linear_user_id(incident.captain, linear_service)
+        linear_service.update_issue(
+            uuid,
+            title=_linear_issue_title(incident, sync_identifiers=True),
+            description=LINEAR_PARENT_DESCRIPTION,
+            state_id=started_state_id,
+            assignee_id=captain_linear_id,
+        )
+    except Exception:
+        logger.exception(
+            f"Failed to update adopted Linear issue for incident {incident.id}"
+        )
+
+    try:
+        incident_url = _build_incident_url(incident)
+        linear_service.create_attachment(
+            uuid, incident_url, f"Firetower: {incident.incident_number}"
+        )
+    except Exception:
+        logger.exception(
+            f"Failed to create Linear attachment for incident {incident.id}"
+        )
+
+    if channel_id and url:
+        try:
+            _slack_service.add_bookmark(channel_id, "Linear Issue", url)
+        except Exception:
+            logger.exception(
+                f"Failed to add Linear bookmark for incident {incident.id}"
+            )
+
+
 def create_linear_parent_issue(
     incident: Incident, *, channel_id: str | None = None
 ) -> None:
+    # Adopt-on-create: the allocator already claimed/created a matching Linear
+    # parent whose uuid is on the incident. Populate it directly (no lookup by
+    # identifier) and skip the legacy claim/create path entirely.
+    if adopt_on_create_enabled() and incident.linear_parent_issue_id:
+        identity = getattr(incident, "_allocated_identity", None)
+        url = identity.linear_url if identity is not None else None
+        if not url:
+            try:
+                issue = _get_linear_service().get_issue(incident.linear_parent_issue_id)
+                url = issue["url"] if issue else None
+            except Exception:
+                logger.exception(
+                    f"Failed to resolve Linear url for incident {incident.id}"
+                )
+                url = None
+        if url:
+            _populate_linear_parent(incident, url, channel_id=channel_id)
+        return
+
     linear_config = settings.LINEAR
     if not linear_config:
         return

--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -1172,19 +1172,19 @@ def create_linear_parent_issue(
     incident: Incident, *, channel_id: str | None = None
 ) -> None:
     # Adopt-on-create: the allocator already claimed/created a matching Linear
-    # parent whose uuid is on the incident. Populate it directly (no lookup by
-    # identifier) and skip the legacy claim/create path entirely.
-    if adopt_on_create_enabled():
-        # With adopt-on-create on, the legacy claim-by-identifier path must
-        # never run (it is the clobber-prone code RELENG-911 exists to avoid).
-        # The allocator always sets linear_parent_issue_id when the flag is on;
-        # if it is somehow missing, refuse to fall through and claim/clobber.
-        if not incident.linear_parent_issue_id:
-            logger.error(
-                f"Adopt-on-create enabled but incident {incident.id} has no "
-                "linear_parent_issue_id; refusing to run legacy claim path"
-            )
-            return
+    # parent whose uuid is on the incident. Populate it directly by uuid (no
+    # lookup by identifier, so it can never clobber a moved/aliased issue) and
+    # skip the legacy claim/create path entirely.
+    #
+    # This only applies when the incident actually has a parent uuid. New
+    # incidents always do under the flag (the allocator sets it before this
+    # hook runs). The one flag-on caller that arrives WITHOUT a uuid is the
+    # backfill in sync_action_items_from_linear (incidents predating Linear
+    # integration); those fall through to the legacy claim path below, which
+    # claims their existing INC-N placeholder. That is safe because every such
+    # parentless incident has a clean, correctly-identified INC-N Placeholder
+    # (never moved), so the claim resolves to the right issue.
+    if adopt_on_create_enabled() and incident.linear_parent_issue_id:
         identity = getattr(incident, "_allocated_identity", None)
         url = identity.linear_url if identity is not None else None
         if not url:

--- a/src/firetower/incidents/models.py
+++ b/src/firetower/incidents/models.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.db import models, transaction
 from django.db.models import Q, QuerySet
 
@@ -322,6 +322,14 @@ class Incident(models.Model):
         """Override save to run validation and assign gapless ID"""
         with transaction.atomic():
             if self._state.adding and self.id is None:
+                from firetower.incidents.allocation import (  # noqa: PLC0415
+                    adopt_on_create_enabled,
+                )
+
+                if adopt_on_create_enabled():
+                    raise ImproperlyConfigured(
+                        "incident id must come from allocate_incident_identity()"
+                    )
                 self.id = get_next_incident_id()
             self.full_clean()
             super().save(*args, **kwargs)

--- a/src/firetower/incidents/serializers.py
+++ b/src/firetower/incidents/serializers.py
@@ -10,7 +10,11 @@ from rest_framework import serializers
 
 from firetower.auth.services import get_or_create_user_from_email
 
-from .allocation import allocate_incident_identity
+from .allocation import (
+    AllocatedIdentity,
+    adopt_on_create_enabled,
+    allocate_incident_identity,
+)
 from .hooks import (
     on_incident_created,
     on_incident_updated,
@@ -493,19 +497,26 @@ class IncidentWriteSerializer(serializers.ModelSerializer):
         root_cause_tag_names = validated_data.pop("root_cause_tag_names", None)
         impact_type_tag_names = validated_data.pop("impact_type_tag_names", None)
 
-        # Allocate the id (and, when adopting, the Linear parent) before create so
-        # the incident is saved with both. Lets LinearUnavailable propagate.
-        identity = allocate_incident_identity()
-        validated_data["id"] = identity.inc_id
-        if identity.linear_issue_uuid:
-            validated_data["linear_parent_issue_id"] = identity.linear_issue_uuid
+        # When adopt-on-create is enabled, allocate the id (and Linear parent)
+        # before create so the incident is saved with both; lets
+        # LinearUnavailable propagate. When disabled, skip pre-allocation and let
+        # Incident.save() assign the id inside its own atomic block alongside the
+        # insert, so a failed create rolls back the counter bump (gapless ids) —
+        # the pre-adopt-on-create behavior.
+        identity: AllocatedIdentity | None = None
+        if adopt_on_create_enabled():
+            identity = allocate_incident_identity()
+            validated_data["id"] = identity.inc_id
+            if identity.linear_issue_uuid:
+                validated_data["linear_parent_issue_id"] = identity.linear_issue_uuid
 
         # Create the incident
         incident = super().create(validated_data)
 
         # Stash so the hook / backfill can populate the Linear parent url without
         # an extra Linear round-trip.
-        incident._allocated_identity = identity
+        if identity is not None:
+            incident._allocated_identity = identity
 
         # Create external links if provided
         if external_links_data:

--- a/src/firetower/incidents/serializers.py
+++ b/src/firetower/incidents/serializers.py
@@ -10,6 +10,7 @@ from rest_framework import serializers
 
 from firetower.auth.services import get_or_create_user_from_email
 
+from .allocation import allocate_incident_identity
 from .hooks import (
     on_incident_created,
     on_incident_updated,
@@ -492,8 +493,19 @@ class IncidentWriteSerializer(serializers.ModelSerializer):
         root_cause_tag_names = validated_data.pop("root_cause_tag_names", None)
         impact_type_tag_names = validated_data.pop("impact_type_tag_names", None)
 
+        # Allocate the id (and, when adopting, the Linear parent) before create so
+        # the incident is saved with both. Lets LinearUnavailable propagate.
+        identity = allocate_incident_identity()
+        validated_data["id"] = identity.inc_id
+        if identity.linear_issue_uuid:
+            validated_data["linear_parent_issue_id"] = identity.linear_issue_uuid
+
         # Create the incident
         incident = super().create(validated_data)
+
+        # Stash so the hook / backfill can populate the Linear parent url without
+        # an extra Linear round-trip.
+        incident._allocated_identity = identity
 
         # Create external links if provided
         if external_links_data:

--- a/src/firetower/incidents/tests/test_allocation.py
+++ b/src/firetower/incidents/tests/test_allocation.py
@@ -441,9 +441,12 @@ class TestSerializerAllocation:
         assert incident._allocated_identity is identity
 
     @patch("firetower.incidents.serializers.allocate_incident_identity")
-    def test_flag_off_identity_leaves_no_linear_parent(self, mock_allocate, settings):
+    def test_flag_off_skips_allocator_and_uses_counter(self, mock_allocate, settings):
+        # Flag off: the serializer must NOT call the allocator. The id is
+        # assigned by Incident.save() inside its own atomic block (gapless on
+        # rollback), and no Linear parent is set.
         settings.LINEAR = None
-        mock_allocate.return_value = AllocatedIdentity(2600, "", "")
+        _set_counter(2600)
 
         serializer = IncidentWriteSerializer(
             data=self._serializer_data(), context={"skip_hooks": True}
@@ -451,6 +454,7 @@ class TestSerializerAllocation:
         assert serializer.is_valid(), serializer.errors
         incident = serializer.save()
 
+        mock_allocate.assert_not_called()
         assert incident.id == 2600
         assert incident.linear_parent_issue_id is None
 

--- a/src/firetower/incidents/tests/test_allocation.py
+++ b/src/firetower/incidents/tests/test_allocation.py
@@ -579,18 +579,33 @@ class TestCreateLinearParentIssueAdoptPath:
         )
 
     @patch("firetower.incidents.hooks.populate_linear_parent")
+    @patch("firetower.incidents.hooks.claim_linear_issue")
     @patch("firetower.incidents.hooks._get_linear_service")
-    def test_no_claim_when_flag_on_but_no_parent_id(
-        self, mock_get_linear, mock_populate, adopt_enabled
+    def test_flag_on_no_parent_id_backfills_via_legacy_claim(
+        self, mock_get_linear, mock_claim, mock_populate, adopt_enabled
     ):
-        # With adopt-on-create enabled but no linear_parent_issue_id, the
-        # dangerous legacy claim-by-identifier path must never run (RELENG-911).
+        # Flag on + no linear_parent_issue_id is the backfill case
+        # (sync_action_items_from_linear on an incident predating Linear
+        # integration). It falls through to the legacy claim path, which claims
+        # the incident's existing INC-N Placeholder. Safe because every such
+        # parentless incident has a clean, correctly-identified placeholder
+        # (never moved) — so the by-identifier claim can't clobber. It must NOT
+        # take the uuid adopt path (there's no uuid to populate).
+        adopt_enabled.LINEAR["SYNC_IDENTIFIERS"] = True
         incident = Incident.objects.create(
             id=2501, title="No parent", severity=IncidentSeverity.P2
         )
+        linear = mock_get_linear.return_value
+        linear.get_workflow_states.return_value = {}
+        mock_claim.return_value = {
+            "id": "uuid-claimed",
+            "identifier": "TESTINC-2501",
+            "url": "https://linear.app/issue/claimed",
+        }
+        linear.update_issue.return_value = True
 
         create_linear_parent_issue(incident)
 
+        # Legacy claim ran (backfill); uuid adopt path did not.
+        mock_claim.assert_called_once()
         mock_populate.assert_not_called()
-        mock_get_linear.return_value.get_issue.assert_not_called()
-        mock_get_linear.return_value.create_issue.assert_not_called()

--- a/src/firetower/incidents/tests/test_allocation.py
+++ b/src/firetower/incidents/tests/test_allocation.py
@@ -5,7 +5,6 @@ from django.conf import settings as django_settings
 from django.core.exceptions import ImproperlyConfigured
 
 from firetower.incidents.allocation import (
-    LEGACY_PLACEHOLDER_TITLE,
     PLACEHOLDER_TITLE,
     AllocatedIdentity,
     LinearUnavailable,
@@ -107,9 +106,6 @@ class TestLooksLikePlaceholder:
     def test_accepts_current_title(self):
         assert _looks_like_placeholder({"title": PLACEHOLDER_TITLE}) is True
 
-    def test_accepts_legacy_title(self):
-        assert _looks_like_placeholder({"title": LEGACY_PLACEHOLDER_TITLE}) is True
-
     def test_rejects_other_title(self):
         assert _looks_like_placeholder({"title": "Real incident"}) is False
 
@@ -141,11 +137,9 @@ class TestAllocateClaim:
         assert IncidentCounter.objects.get(pk=1).next_id == 2335
         linear.create_issue.assert_not_called()
 
-    def test_claims_legacy_titled_placeholder(self, adopt_enabled):
+    def test_claims_titled_placeholder(self, adopt_enabled):
         _set_counter(2334)
-        linear = _make_linear(
-            {_identifier(2334): _placeholder(2334, title=LEGACY_PLACEHOLDER_TITLE)}
-        )
+        linear = _make_linear({_identifier(2334): _placeholder(2334)})
 
         with _patch_linear(linear):
             identity = allocate_incident_identity()

--- a/src/firetower/incidents/tests/test_allocation.py
+++ b/src/firetower/incidents/tests/test_allocation.py
@@ -14,8 +14,8 @@ from firetower.incidents.allocation import (
     allocate_incident_identity,
 )
 from firetower.incidents.hooks import (
-    _populate_linear_parent,
     create_linear_parent_issue,
+    populate_linear_parent,
 )
 from firetower.incidents.models import (
     ExternalLink,
@@ -136,15 +136,6 @@ class TestAllocateClaim:
         )
         assert IncidentCounter.objects.get(pk=1).next_id == 2335
         linear.create_issue.assert_not_called()
-
-    def test_claims_titled_placeholder(self, adopt_enabled):
-        _set_counter(2334)
-        linear = _make_linear({_identifier(2334): _placeholder(2334)})
-
-        with _patch_linear(linear):
-            identity = allocate_incident_identity()
-
-        assert identity.inc_id == 2334
 
 
 @pytest.mark.django_db
@@ -355,7 +346,12 @@ class TestAllocateAtomicTripwire:
 
 @pytest.mark.django_db
 class TestAllocateSerialization:
-    def test_consecutive_allocations_get_distinct_ids(self, adopt_enabled):
+    def test_sequential_allocations_get_distinct_ids(self, adopt_enabled):
+        # Verifies that two SEQUENTIAL allocate calls advance the counter and
+        # get distinct ids. This does NOT exercise real concurrent contention
+        # of the select_for_update row lock: pytest wraps each test in a single
+        # transaction, so genuine cross-transaction row-lock contention cannot
+        # be reproduced in-process.
         _set_counter(2334)
         linear = _make_linear(
             {
@@ -491,7 +487,7 @@ class TestPopulateLinearParent:
         linear.get_workflow_states.return_value = {"started": "state-started"}
         linear.update_issue.return_value = True
 
-        _populate_linear_parent(
+        populate_linear_parent(
             incident, "https://linear.app/issue/x", channel_id="C123"
         )
 
@@ -510,8 +506,8 @@ class TestPopulateLinearParent:
         incident = self._incident(settings)
         mock_get_linear.return_value.get_workflow_states.return_value = {}
 
-        _populate_linear_parent(incident, "https://linear.app/issue/x")
-        _populate_linear_parent(incident, "https://linear.app/issue/y")
+        populate_linear_parent(incident, "https://linear.app/issue/x")
+        populate_linear_parent(incident, "https://linear.app/issue/y")
 
         links = ExternalLink.objects.filter(
             incident=incident, type=ExternalLinkType.LINEAR
@@ -527,7 +523,7 @@ class TestPopulateLinearParent:
         linear.get_workflow_states.return_value = {}
         linear.update_issue.side_effect = RuntimeError("boom")
 
-        _populate_linear_parent(incident, "https://linear.app/issue/x")
+        populate_linear_parent(incident, "https://linear.app/issue/x")
 
         link = ExternalLink.objects.get(incident=incident, type=ExternalLinkType.LINEAR)
         assert link.url == "https://linear.app/issue/x"
@@ -538,7 +534,7 @@ class TestPopulateLinearParent:
         incident = self._incident(settings)
         mock_get_linear.return_value.get_workflow_states.return_value = {}
 
-        _populate_linear_parent(incident, "https://linear.app/issue/x")
+        populate_linear_parent(incident, "https://linear.app/issue/x")
 
         mock_slack.add_bookmark.assert_not_called()
 
@@ -552,7 +548,7 @@ class TestCreateLinearParentIssueAdoptPath:
         incident.linear_parent_issue_id = "uuid-verified"
         return incident
 
-    @patch("firetower.incidents.hooks._populate_linear_parent")
+    @patch("firetower.incidents.hooks.populate_linear_parent")
     def test_uses_stashed_identity_url(self, mock_populate, adopt_enabled):
         incident = self._incident()
         incident._allocated_identity = AllocatedIdentity(
@@ -565,7 +561,7 @@ class TestCreateLinearParentIssueAdoptPath:
             incident, "https://linear.app/issue/x", channel_id="C1"
         )
 
-    @patch("firetower.incidents.hooks._populate_linear_parent")
+    @patch("firetower.incidents.hooks.populate_linear_parent")
     @patch("firetower.incidents.hooks._get_linear_service")
     def test_falls_back_to_get_issue_for_url(
         self, mock_get_linear, mock_populate, adopt_enabled
@@ -582,13 +578,13 @@ class TestCreateLinearParentIssueAdoptPath:
             incident, "https://linear.app/issue/fallback", channel_id="C1"
         )
 
-    @patch("firetower.incidents.hooks._populate_linear_parent")
+    @patch("firetower.incidents.hooks.populate_linear_parent")
     @patch("firetower.incidents.hooks._get_linear_service")
-    def test_legacy_path_when_no_parent_id(
+    def test_no_claim_when_flag_on_but_no_parent_id(
         self, mock_get_linear, mock_populate, adopt_enabled
     ):
-        mock_get_linear.return_value.get_issue.return_value = None
-        mock_get_linear.return_value.create_issue.return_value = None
+        # With adopt-on-create enabled but no linear_parent_issue_id, the
+        # dangerous legacy claim-by-identifier path must never run (RELENG-911).
         incident = Incident.objects.create(
             id=2501, title="No parent", severity=IncidentSeverity.P2
         )
@@ -596,3 +592,5 @@ class TestCreateLinearParentIssueAdoptPath:
         create_linear_parent_issue(incident)
 
         mock_populate.assert_not_called()
+        mock_get_linear.return_value.get_issue.assert_not_called()
+        mock_get_linear.return_value.create_issue.assert_not_called()

--- a/src/firetower/incidents/tests/test_allocation.py
+++ b/src/firetower/incidents/tests/test_allocation.py
@@ -1,0 +1,600 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.conf import settings as django_settings
+from django.core.exceptions import ImproperlyConfigured
+
+from firetower.incidents.allocation import (
+    LEGACY_PLACEHOLDER_TITLE,
+    PLACEHOLDER_TITLE,
+    AllocatedIdentity,
+    LinearUnavailable,
+    _create_and_adopt_placeholder,
+    _looks_like_placeholder,
+    adopt_on_create_enabled,
+    allocate_incident_identity,
+)
+from firetower.incidents.hooks import (
+    _populate_linear_parent,
+    create_linear_parent_issue,
+)
+from firetower.incidents.models import (
+    ExternalLink,
+    ExternalLinkType,
+    Incident,
+    IncidentCounter,
+    IncidentSeverity,
+)
+from firetower.incidents.serializers import IncidentWriteSerializer
+from firetower.integrations.services.linear import LinearError
+
+
+def _identifier(n: int) -> str:
+    return f"{django_settings.PROJECT_KEY}-{n}"
+
+
+def _placeholder(n: int, *, title: str = PLACEHOLDER_TITLE) -> dict:
+    return {
+        "id": f"uuid-{n}",
+        "identifier": _identifier(n),
+        "title": title,
+        "url": f"https://linear.app/issue/{_identifier(n)}",
+        "state_type": "backlog",
+    }
+
+
+def _set_counter(next_id: int) -> None:
+    IncidentCounter.objects.update_or_create(pk=1, defaults={"next_id": next_id})
+
+
+def _make_linear(
+    get_issue_map: dict[str, dict | None] | None = None,
+    *,
+    get_issue_side_effect=None,
+    created_issue: dict | None = None,
+) -> MagicMock:
+    linear = MagicMock()
+    if get_issue_side_effect is not None:
+        linear.get_issue.side_effect = get_issue_side_effect
+    else:
+        mapping = get_issue_map or {}
+
+        def _get_issue(identifier, *, raise_on_error=False):
+            return mapping.get(identifier)
+
+        linear.get_issue.side_effect = _get_issue
+    linear.create_issue.return_value = created_issue
+    return linear
+
+
+@pytest.fixture
+def adopt_enabled(settings):
+    settings.LINEAR = {
+        "SYNC_IDENTIFIERS": True,
+        "INCIDENT_ADOPT_ON_CREATE": True,
+        "TEAM_ID": "team-1",
+        "PROJECT_ID": "proj-1",
+    }
+    return settings
+
+
+def _patch_linear(linear: MagicMock):
+    return patch(
+        "firetower.incidents.allocation.LinearService.for_allocation",
+        return_value=linear,
+    )
+
+
+class TestAdoptOnCreateEnabled:
+    def test_disabled_when_linear_unset(self, settings):
+        settings.LINEAR = None
+        assert adopt_on_create_enabled() is False
+
+    def test_disabled_without_sync_identifiers(self, settings):
+        settings.LINEAR = {"INCIDENT_ADOPT_ON_CREATE": True}
+        assert adopt_on_create_enabled() is False
+
+    def test_disabled_without_adopt_flag(self, settings):
+        settings.LINEAR = {"SYNC_IDENTIFIERS": True}
+        assert adopt_on_create_enabled() is False
+
+    def test_enabled_when_both_set(self, settings):
+        settings.LINEAR = {"SYNC_IDENTIFIERS": True, "INCIDENT_ADOPT_ON_CREATE": True}
+        assert adopt_on_create_enabled() is True
+
+
+class TestLooksLikePlaceholder:
+    def test_accepts_current_title(self):
+        assert _looks_like_placeholder({"title": PLACEHOLDER_TITLE}) is True
+
+    def test_accepts_legacy_title(self):
+        assert _looks_like_placeholder({"title": LEGACY_PLACEHOLDER_TITLE}) is True
+
+    def test_rejects_other_title(self):
+        assert _looks_like_placeholder({"title": "Real incident"}) is False
+
+
+@pytest.mark.django_db
+class TestAllocateFlagOff:
+    def test_returns_counter_id_and_empty_linear(self, settings):
+        settings.LINEAR = None
+        _set_counter(2100)
+
+        identity = allocate_incident_identity()
+
+        assert identity == AllocatedIdentity(2100, "", "")
+        assert IncidentCounter.objects.get(pk=1).next_id == 2101
+
+
+@pytest.mark.django_db
+class TestAllocateClaim:
+    def test_claims_clean_matching_placeholder(self, adopt_enabled):
+        _set_counter(2334)
+        linear = _make_linear({_identifier(2334): _placeholder(2334)})
+
+        with _patch_linear(linear):
+            identity = allocate_incident_identity()
+
+        assert identity == AllocatedIdentity(
+            2334, "uuid-2334", f"https://linear.app/issue/{_identifier(2334)}"
+        )
+        assert IncidentCounter.objects.get(pk=1).next_id == 2335
+        linear.create_issue.assert_not_called()
+
+    def test_claims_legacy_titled_placeholder(self, adopt_enabled):
+        _set_counter(2334)
+        linear = _make_linear(
+            {_identifier(2334): _placeholder(2334, title=LEGACY_PLACEHOLDER_TITLE)}
+        )
+
+        with _patch_linear(linear):
+            identity = allocate_incident_identity()
+
+        assert identity.inc_id == 2334
+
+
+@pytest.mark.django_db
+class TestAllocateSkips:
+    def test_alias_skip_then_claim(self, adopt_enabled):
+        _set_counter(2334)
+        aliased = {
+            "id": "uuid-moved",
+            "identifier": "PRODENG-1404",
+            "title": "Moved issue",
+            "url": "https://linear.app/issue/PRODENG-1404",
+            "state_type": "started",
+        }
+        linear = _make_linear(
+            {_identifier(2334): aliased, _identifier(2335): _placeholder(2335)}
+        )
+
+        with _patch_linear(linear):
+            identity = allocate_incident_identity()
+
+        assert identity.inc_id == 2335
+        assert IncidentCounter.objects.get(pk=1).next_id == 2336
+
+    def test_used_id_skip_then_claim(self, adopt_enabled):
+        _set_counter(2400)
+        Incident.objects.create(id=2400, title="Existing", severity=IncidentSeverity.P2)
+        linear = _make_linear(
+            {
+                _identifier(2400): _placeholder(2400),
+                _identifier(2401): _placeholder(2401),
+            }
+        )
+
+        with _patch_linear(linear):
+            identity = allocate_incident_identity()
+
+        assert identity.inc_id == 2401
+        assert IncidentCounter.objects.get(pk=1).next_id == 2402
+
+    def test_stray_non_placeholder_skip_then_claim(self, adopt_enabled):
+        _set_counter(2350)
+        stray = _placeholder(2350, title="A real incident that lives at this id")
+        linear = _make_linear(
+            {_identifier(2350): stray, _identifier(2351): _placeholder(2351)}
+        )
+
+        with _patch_linear(linear):
+            identity = allocate_incident_identity()
+
+        assert identity.inc_id == 2351
+        assert IncidentCounter.objects.get(pk=1).next_id == 2352
+
+
+@pytest.mark.django_db
+class TestAllocateCreateAdopt:
+    def test_not_found_creates_and_adopts_equal_id(self, adopt_enabled):
+        _set_counter(2353)
+        created = {
+            "id": "uuid-new",
+            "identifier": _identifier(2353),
+            "url": "https://linear.app/issue/new",
+        }
+        linear = _make_linear({}, created_issue=created)
+
+        with _patch_linear(linear):
+            identity = allocate_incident_identity()
+
+        assert identity == AllocatedIdentity(
+            2353, "uuid-new", "https://linear.app/issue/new"
+        )
+        assert IncidentCounter.objects.get(pk=1).next_id == 2354
+        linear.create_issue.assert_called_once_with(
+            PLACEHOLDER_TITLE, "", "team-1", "proj-1"
+        )
+
+    def test_not_found_creates_and_adopts_higher_id(self, adopt_enabled):
+        _set_counter(2353)
+        created = {
+            "id": "uuid-new",
+            "identifier": _identifier(2360),
+            "url": "https://linear.app/issue/new",
+        }
+        linear = _make_linear({}, created_issue=created)
+
+        with _patch_linear(linear):
+            identity = allocate_incident_identity()
+
+        assert identity.inc_id == 2360
+        assert IncidentCounter.objects.get(pk=1).next_id == 2361
+
+    def test_skip_budget_valve_falls_through_to_create(self, adopt_enabled):
+        _set_counter(2400)
+        aliased = {
+            "id": "uuid-moved",
+            "identifier": "PRODENG-9",
+            "title": "Moved",
+            "url": "https://linear.app/issue/PRODENG-9",
+            "state_type": "started",
+        }
+        created = {
+            "id": "uuid-new",
+            "identifier": _identifier(2500),
+            "url": "https://linear.app/issue/new",
+        }
+        # Every identifier resolves to an aliased issue, exhausting the budget.
+        linear = _make_linear(
+            get_issue_side_effect=lambda identifier, *, raise_on_error=False: aliased,
+            created_issue=created,
+        )
+
+        with _patch_linear(linear):
+            identity = allocate_incident_identity()
+
+        assert identity.inc_id == 2500
+        assert IncidentCounter.objects.get(pk=1).next_id == 2501
+        linear.create_issue.assert_called_once()
+
+    def test_full_landmine_walk_then_adopt(self, adopt_enabled):
+        _set_counter(2334)
+        aliased_map: dict[str, dict | None] = {}
+        for n in range(2334, 2340):
+            aliased_map[_identifier(n)] = {
+                "id": f"uuid-moved-{n}",
+                "identifier": f"PRODENG-{n}",
+                "title": "Moved issue",
+                "url": f"https://linear.app/issue/PRODENG-{n}",
+                "state_type": "started",
+            }
+        # INC-2340 is genuinely absent -> create+adopt whatever Linear mints.
+        created = {
+            "id": "uuid-new",
+            "identifier": _identifier(2353),
+            "url": "https://linear.app/issue/new",
+        }
+        linear = _make_linear(aliased_map, created_issue=created)
+
+        with _patch_linear(linear):
+            identity = allocate_incident_identity()
+
+        assert identity.inc_id == 2353
+        assert IncidentCounter.objects.get(pk=1).next_id == 2354
+
+
+@pytest.mark.django_db
+class TestAllocateUnavailable:
+    def test_get_issue_error_raises_and_leaves_counter(self, adopt_enabled):
+        _set_counter(2334)
+        linear = _make_linear(get_issue_side_effect=LinearError("boom"))
+
+        with _patch_linear(linear), pytest.raises(LinearUnavailable):
+            allocate_incident_identity()
+
+        assert IncidentCounter.objects.get(pk=1).next_id == 2334
+
+    def test_create_failure_raises_and_leaves_counter(self, adopt_enabled):
+        _set_counter(2353)
+        linear = _make_linear({}, created_issue=None)
+
+        with _patch_linear(linear), pytest.raises(LinearUnavailable):
+            allocate_incident_identity()
+
+        assert IncidentCounter.objects.get(pk=1).next_id == 2353
+
+    def test_minted_below_counter_raises(self, adopt_enabled):
+        _set_counter(2360)
+        created = {
+            "id": "uuid-new",
+            "identifier": _identifier(2355),
+            "url": "https://linear.app/issue/new",
+        }
+        linear = _make_linear({}, created_issue=created)
+
+        with _patch_linear(linear), pytest.raises(LinearUnavailable):
+            allocate_incident_identity()
+
+        assert IncidentCounter.objects.get(pk=1).next_id == 2360
+
+    def test_non_project_identifier_raises(self, adopt_enabled):
+        _set_counter(2353)
+        created = {
+            "id": "uuid-new",
+            "identifier": "RENAMED-5",
+            "url": "https://linear.app/issue/new",
+        }
+        linear = _make_linear({}, created_issue=created)
+
+        with _patch_linear(linear), pytest.raises(LinearUnavailable):
+            allocate_incident_identity()
+
+        assert IncidentCounter.objects.get(pk=1).next_id == 2353
+
+
+@pytest.mark.django_db
+class TestAllocateAtomicTripwire:
+    def test_asserts_when_run_inside_enclosing_transaction(
+        self, adopt_enabled, monkeypatch
+    ):
+        # Drop the pytest marker so the tripwire is armed; the test itself runs
+        # inside pytest's wrapping transaction, standing in for an enclosing
+        # atomic() in production.
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        _set_counter(2334)
+        linear = _make_linear({_identifier(2334): _placeholder(2334)})
+
+        with _patch_linear(linear), pytest.raises(AssertionError):
+            allocate_incident_identity()
+
+
+@pytest.mark.django_db
+class TestAllocateSerialization:
+    def test_consecutive_allocations_get_distinct_ids(self, adopt_enabled):
+        _set_counter(2334)
+        linear = _make_linear(
+            {
+                _identifier(2334): _placeholder(2334),
+                _identifier(2335): _placeholder(2335),
+            }
+        )
+
+        with _patch_linear(linear):
+            first = allocate_incident_identity()
+            second = allocate_incident_identity()
+
+        assert first.inc_id == 2334
+        assert second.inc_id == 2335
+        assert first.inc_id != second.inc_id
+        assert IncidentCounter.objects.get(pk=1).next_id == 2336
+
+
+@pytest.mark.django_db
+class TestCreateAndAdoptPlaceholderNoSideEffects:
+    def test_no_db_or_counter_writes(self, adopt_enabled):
+        _set_counter(2400)
+        linear = _make_linear(
+            {},
+            created_issue={
+                "id": "uuid-new",
+                "identifier": _identifier(2400),
+                "url": "https://linear.app/issue/new",
+            },
+        )
+
+        before = Incident.objects.count()
+        minted, uuid, url = _create_and_adopt_placeholder(linear, "team-1", "proj-1")
+
+        assert (minted, uuid) == (2400, "uuid-new")
+        assert Incident.objects.count() == before
+        assert IncidentCounter.objects.get(pk=1).next_id == 2400
+
+
+@pytest.mark.django_db
+class TestSaveGuard:
+    def test_raises_when_adopt_enabled_and_id_missing(self, adopt_enabled):
+        incident = Incident(title="Test", severity=IncidentSeverity.P1)
+        with pytest.raises(ImproperlyConfigured):
+            incident.save()
+
+    def test_uses_counter_when_adopt_disabled(self, settings):
+        settings.LINEAR = None
+        _set_counter(2200)
+        incident = Incident(title="Test", severity=IncidentSeverity.P1)
+        incident.save()
+        assert incident.id == 2200
+
+    def test_explicit_id_bypasses_guard_when_adopt_enabled(self, adopt_enabled):
+        incident = Incident(id=2500, title="Test", severity=IncidentSeverity.P1)
+        incident.save()
+        assert incident.id == 2500
+
+
+@pytest.mark.django_db
+class TestSerializerAllocation:
+    def _serializer_data(self) -> dict:
+        return {
+            "title": "Serializer Incident",
+            "severity": "P2",
+            "captain": "cap@example.com",
+            "reporter": "rep@example.com",
+        }
+
+    @patch("firetower.incidents.serializers.allocate_incident_identity")
+    def test_injects_id_uuid_and_stashes_identity(self, mock_allocate, adopt_enabled):
+        identity = AllocatedIdentity(2500, "uuid-abc", "https://linear.app/issue/x")
+        mock_allocate.return_value = identity
+
+        serializer = IncidentWriteSerializer(
+            data=self._serializer_data(), context={"skip_hooks": True}
+        )
+        assert serializer.is_valid(), serializer.errors
+        incident = serializer.save()
+
+        assert incident.id == 2500
+        assert incident.linear_parent_issue_id == "uuid-abc"
+        assert incident._allocated_identity is identity
+
+    @patch("firetower.incidents.serializers.allocate_incident_identity")
+    def test_flag_off_identity_leaves_no_linear_parent(self, mock_allocate, settings):
+        settings.LINEAR = None
+        mock_allocate.return_value = AllocatedIdentity(2600, "", "")
+
+        serializer = IncidentWriteSerializer(
+            data=self._serializer_data(), context={"skip_hooks": True}
+        )
+        assert serializer.is_valid(), serializer.errors
+        incident = serializer.save()
+
+        assert incident.id == 2600
+        assert incident.linear_parent_issue_id is None
+
+    @patch(
+        "firetower.incidents.serializers.allocate_incident_identity",
+        side_effect=LinearUnavailable,
+    )
+    def test_linear_unavailable_propagates(self, mock_allocate, adopt_enabled):
+        serializer = IncidentWriteSerializer(
+            data=self._serializer_data(), context={"skip_hooks": True}
+        )
+        assert serializer.is_valid(), serializer.errors
+        with pytest.raises(LinearUnavailable):
+            serializer.save()
+
+
+@pytest.mark.django_db
+class TestPopulateLinearParent:
+    def _incident(self, settings) -> Incident:
+        settings.LINEAR = {"TEAM_ID": "team-1"}
+        incident = Incident.objects.create(
+            title="Populate me", severity=IncidentSeverity.P2
+        )
+        incident.linear_parent_issue_id = "uuid-verified"
+        return incident
+
+    @patch("firetower.incidents.hooks._slack_service")
+    @patch("firetower.incidents.hooks._get_linear_service")
+    def test_updates_by_uuid_never_by_identifier(
+        self, mock_get_linear, mock_slack, settings
+    ):
+        incident = self._incident(settings)
+        linear = mock_get_linear.return_value
+        linear.get_workflow_states.return_value = {"started": "state-started"}
+        linear.update_issue.return_value = True
+
+        _populate_linear_parent(
+            incident, "https://linear.app/issue/x", channel_id="C123"
+        )
+
+        linear.get_issue.assert_not_called()
+        assert linear.update_issue.call_args[0][0] == "uuid-verified"
+        assert linear.update_issue.call_args[1]["state_id"] == "state-started"
+        linear.create_attachment.assert_called_once()
+        assert linear.create_attachment.call_args[0][0] == "uuid-verified"
+        mock_slack.add_bookmark.assert_called_once_with(
+            "C123", "Linear Issue", "https://linear.app/issue/x"
+        )
+
+    @patch("firetower.incidents.hooks._slack_service")
+    @patch("firetower.incidents.hooks._get_linear_service")
+    def test_idempotent_external_link(self, mock_get_linear, mock_slack, settings):
+        incident = self._incident(settings)
+        mock_get_linear.return_value.get_workflow_states.return_value = {}
+
+        _populate_linear_parent(incident, "https://linear.app/issue/x")
+        _populate_linear_parent(incident, "https://linear.app/issue/y")
+
+        links = ExternalLink.objects.filter(
+            incident=incident, type=ExternalLinkType.LINEAR
+        )
+        assert links.count() == 1
+        assert links.first().url == "https://linear.app/issue/y"
+
+    @patch("firetower.incidents.hooks._slack_service")
+    @patch("firetower.incidents.hooks._get_linear_service")
+    def test_non_fatal_when_update_raises(self, mock_get_linear, mock_slack, settings):
+        incident = self._incident(settings)
+        linear = mock_get_linear.return_value
+        linear.get_workflow_states.return_value = {}
+        linear.update_issue.side_effect = RuntimeError("boom")
+
+        _populate_linear_parent(incident, "https://linear.app/issue/x")
+
+        link = ExternalLink.objects.get(incident=incident, type=ExternalLinkType.LINEAR)
+        assert link.url == "https://linear.app/issue/x"
+
+    @patch("firetower.incidents.hooks._slack_service")
+    @patch("firetower.incidents.hooks._get_linear_service")
+    def test_no_bookmark_without_channel(self, mock_get_linear, mock_slack, settings):
+        incident = self._incident(settings)
+        mock_get_linear.return_value.get_workflow_states.return_value = {}
+
+        _populate_linear_parent(incident, "https://linear.app/issue/x")
+
+        mock_slack.add_bookmark.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestCreateLinearParentIssueAdoptPath:
+    def _incident(self) -> Incident:
+        incident = Incident.objects.create(
+            id=2500, title="Adopt me", severity=IncidentSeverity.P2
+        )
+        incident.linear_parent_issue_id = "uuid-verified"
+        return incident
+
+    @patch("firetower.incidents.hooks._populate_linear_parent")
+    def test_uses_stashed_identity_url(self, mock_populate, adopt_enabled):
+        incident = self._incident()
+        incident._allocated_identity = AllocatedIdentity(
+            2500, "uuid-verified", "https://linear.app/issue/x"
+        )
+
+        create_linear_parent_issue(incident, channel_id="C1")
+
+        mock_populate.assert_called_once_with(
+            incident, "https://linear.app/issue/x", channel_id="C1"
+        )
+
+    @patch("firetower.incidents.hooks._populate_linear_parent")
+    @patch("firetower.incidents.hooks._get_linear_service")
+    def test_falls_back_to_get_issue_for_url(
+        self, mock_get_linear, mock_populate, adopt_enabled
+    ):
+        incident = self._incident()
+        mock_get_linear.return_value.get_issue.return_value = {
+            "url": "https://linear.app/issue/fallback"
+        }
+
+        create_linear_parent_issue(incident, channel_id="C1")
+
+        mock_get_linear.return_value.get_issue.assert_called_once_with("uuid-verified")
+        mock_populate.assert_called_once_with(
+            incident, "https://linear.app/issue/fallback", channel_id="C1"
+        )
+
+    @patch("firetower.incidents.hooks._populate_linear_parent")
+    @patch("firetower.incidents.hooks._get_linear_service")
+    def test_legacy_path_when_no_parent_id(
+        self, mock_get_linear, mock_populate, adopt_enabled
+    ):
+        mock_get_linear.return_value.get_issue.return_value = None
+        mock_get_linear.return_value.create_issue.return_value = None
+        incident = Incident.objects.create(
+            id=2501, title="No parent", severity=IncidentSeverity.P2
+        )
+
+        create_linear_parent_issue(incident)
+
+        mock_populate.assert_not_called()

--- a/src/firetower/integrations/services/linear.py
+++ b/src/firetower/integrations/services/linear.py
@@ -62,42 +62,29 @@ class LinearError(Exception):
     """
 
 
-# GraphQL error signatures Linear returns when an issue lookup by identifier
-# references an issue that does not exist. Matched case-insensitively against
-# the error's `extensions.type`/`extensions.code` and, as a fallback, its
-# message. Kept deliberately narrow so only genuine not-found responses are
-# swallowed as "empty"; any other error still surfaces as a failure.
-_NOT_FOUND_ERROR_TOKENS = (
-    "entity not found",
-    "could not find referenced",
-    "not found",
-)
+# Exact message Linear returns when an ``issue(id:)`` lookup references an
+# issue that does not exist. Matched case-insensitively. Deliberately specific
+# to a missing *issue* (not a generic "not found") so unrelated errors
+# (team/user/project not found, auth, etc.) still surface as failures rather
+# than being mistaken for an empty issue lookup.
+_ISSUE_NOT_FOUND_MESSAGE = "could not find referenced issue"
 
 
 def _errors_are_not_found(errors: Any) -> bool:
     """True iff every GraphQL error in ``errors`` is an issue-not-found error.
 
     Linear responds to an ``issue(id:)`` lookup for a nonexistent identifier
-    with an "entity not found" GraphQL error rather than a null result. We only
-    treat the response as an empty (not-found) result when *all* returned
-    errors are not-found errors, so a response mixing a real failure with a
-    not-found error still raises.
+    with a "Could not find referenced Issue." GraphQL error rather than a null
+    result. We only treat the response as an empty (not-found) result when
+    *all* returned errors are that specific issue-not-found error, so a
+    response mixing a real failure with a not-found error still raises.
     """
     if not isinstance(errors, list) or not errors:
         return False
     for err in errors:
         if not isinstance(err, dict):
             return False
-        extensions = err.get("extensions") or {}
-        signal = " ".join(
-            str(extensions.get(key, ""))
-            for key in ("type", "code", "userPresentableMessage")
-        ).lower()
-        message = str(err.get("message", "")).lower()
-        # Normalize underscores so codes like ``NOT_FOUND`` match the
-        # space-delimited tokens below.
-        haystack = f"{signal} {message}".replace("_", " ")
-        if not any(token in haystack for token in _NOT_FOUND_ERROR_TOKENS):
+        if _ISSUE_NOT_FOUND_MESSAGE not in str(err.get("message", "")).lower():
             return False
     return True
 

--- a/src/firetower/integrations/services/linear.py
+++ b/src/firetower/integrations/services/linear.py
@@ -294,7 +294,21 @@ class LinearService:
                     )
                     return None
 
-                data = response.json()
+                try:
+                    data = response.json()
+                except ValueError:
+                    # A 2xx response whose body is not valid JSON is a broken
+                    # response, not a transient transport error, so don't retry.
+                    # Surface it as a failure (LinearError for raise_on_error
+                    # callers) rather than letting the ValueError propagate and
+                    # crash callers like the allocator, which only expect
+                    # LinearError for Linear failures.
+                    logger.exception("Linear API returned non-JSON response")
+                    self._raise_if_requested(
+                        "Linear API returned a non-JSON response",
+                        raise_on_error=raise_on_error,
+                    )
+                    return None
 
                 if "errors" in data:
                     # Looking up an issue by an identifier that does not exist

--- a/src/firetower/integrations/services/linear.py
+++ b/src/firetower/integrations/services/linear.py
@@ -62,6 +62,46 @@ class LinearError(Exception):
     """
 
 
+# GraphQL error signatures Linear returns when an issue lookup by identifier
+# references an issue that does not exist. Matched case-insensitively against
+# the error's `extensions.type`/`extensions.code` and, as a fallback, its
+# message. Kept deliberately narrow so only genuine not-found responses are
+# swallowed as "empty"; any other error still surfaces as a failure.
+_NOT_FOUND_ERROR_TOKENS = (
+    "entity not found",
+    "could not find referenced",
+    "not found",
+)
+
+
+def _errors_are_not_found(errors: Any) -> bool:
+    """True iff every GraphQL error in ``errors`` is an issue-not-found error.
+
+    Linear responds to an ``issue(id:)`` lookup for a nonexistent identifier
+    with an "entity not found" GraphQL error rather than a null result. We only
+    treat the response as an empty (not-found) result when *all* returned
+    errors are not-found errors, so a response mixing a real failure with a
+    not-found error still raises.
+    """
+    if not isinstance(errors, list) or not errors:
+        return False
+    for err in errors:
+        if not isinstance(err, dict):
+            return False
+        extensions = err.get("extensions") or {}
+        signal = " ".join(
+            str(extensions.get(key, ""))
+            for key in ("type", "code", "userPresentableMessage")
+        ).lower()
+        message = str(err.get("message", "")).lower()
+        # Normalize underscores so codes like ``NOT_FOUND`` match the
+        # space-delimited tokens below.
+        haystack = f"{signal} {message}".replace("_", " ")
+        if not any(token in haystack for token in _NOT_FOUND_ERROR_TOKENS):
+            return False
+    return True
+
+
 def parse_project_number(identifier: str) -> int | None:
     """Return the integer N when ``identifier`` is exactly
     ``f"{settings.PROJECT_KEY}-<digits>"`` (e.g. ``"INC-2353"`` -> ``2353``),
@@ -191,6 +231,7 @@ class LinearService:
         retryable: bool = True,
         *,
         raise_on_error: bool = False,
+        not_found_is_empty: bool = False,
     ) -> dict | None:
         access_token = self._get_access_token()
         if not access_token:
@@ -256,6 +297,14 @@ class LinearService:
                 data = response.json()
 
                 if "errors" in data:
+                    # Looking up an issue by an identifier that does not exist
+                    # (e.g. the placeholder slot the allocator wants to mint)
+                    # comes back as a GraphQL "entity not found" error rather
+                    # than a null result. When the caller asked for it, treat
+                    # that specific case as a genuine empty result (None) so a
+                    # missing issue is not mistaken for "Linear unreachable".
+                    if not_found_is_empty and _errors_are_not_found(data["errors"]):
+                        return None
                     logger.error(
                         "Linear GraphQL errors",
                         extra={"errors": data["errors"]},
@@ -335,7 +384,12 @@ class LinearService:
             }}
         }}
         """
-        data = self._graphql(query, {"id": issue_id}, raise_on_error=raise_on_error)
+        data = self._graphql(
+            query,
+            {"id": issue_id},
+            raise_on_error=raise_on_error,
+            not_found_is_empty=True,
+        )
         if not data or not data.get("issue"):
             return None
         issue = data["issue"]

--- a/src/firetower/integrations/tests/test_linear_service.py
+++ b/src/firetower/integrations/tests/test_linear_service.py
@@ -488,6 +488,49 @@ class TestGraphql:
             with pytest.raises(LinearError):
                 linear_service._graphql("query { viewer { id } }", raise_on_error=True)
 
+    def test_raises_linear_error_on_non_json_response(self, linear_service):
+        # A 2xx whose body is not valid JSON must surface as LinearError for
+        # raise_on_error callers, not let the ValueError from .json() propagate
+        # and crash the allocator (which only expects LinearError).
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.status_code = 200
+        mock_response.json.side_effect = ValueError("Expecting value")
+
+        with (
+            patch.object(
+                linear_service, "_get_access_token", return_value="valid-token"
+            ),
+            patch.object(
+                linear_service, "_make_graphql_request", return_value=mock_response
+            ),
+        ):
+            with pytest.raises(LinearError):
+                linear_service._graphql("query { viewer { id } }", raise_on_error=True)
+
+    def test_returns_none_on_non_json_response_when_not_raising(self, linear_service):
+        # Default callers still get None (unchanged behavior), and it is not
+        # retried (a broken body is not a transient transport error).
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.status_code = 200
+        mock_response.json.side_effect = ValueError("Expecting value")
+
+        with (
+            patch.object(
+                linear_service, "_get_access_token", return_value="valid-token"
+            ),
+            patch.object(
+                linear_service, "_make_graphql_request", return_value=mock_response
+            ) as mock_req,
+            patch.object(linear_service, "_sleep_before_retry") as mock_sleep,
+        ):
+            result = linear_service._graphql("query { viewer { id } }")
+
+        assert result is None
+        assert mock_req.call_count == 1
+        mock_sleep.assert_not_called()
+
     def test_raises_linear_error_on_request_exception(self, linear_service):
         with (
             patch.object(

--- a/src/firetower/integrations/tests/test_linear_service.py
+++ b/src/firetower/integrations/tests/test_linear_service.py
@@ -1002,7 +1002,6 @@ class TestGetIssue:
                 {
                     "message": "Entity not found: Issue - Could not find "
                     "referenced Issue.",
-                    "extensions": {"type": "invalid input", "code": "NOT_FOUND"},
                 }
             ]
         }

--- a/src/firetower/integrations/tests/test_linear_service.py
+++ b/src/firetower/integrations/tests/test_linear_service.py
@@ -12,6 +12,7 @@ from firetower.integrations.services.linear import (
     LINEAR_TOKEN_URL,
     LinearError,
     LinearService,
+    _errors_are_not_found,
     parse_project_number,
 )
 
@@ -944,3 +945,115 @@ class TestGetIssue:
         ):
             with pytest.raises(LinearError):
                 linear_service.get_issue("issue-123", raise_on_error=True)
+
+    def _not_found_response(self):
+        # Mirrors the real Linear response for an issue(id:) lookup against an
+        # identifier that does not exist: HTTP 200 with a GraphQL "entity not
+        # found" error and no data. Verified live: looking up an absent
+        # TESTINC-N returns "Could not find referenced Issue." (RELENG-911).
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "errors": [
+                {
+                    "message": "Entity not found: Issue - Could not find "
+                    "referenced Issue.",
+                    "extensions": {"type": "invalid input", "code": "NOT_FOUND"},
+                }
+            ]
+        }
+        return mock_response
+
+    def test_absent_identifier_returns_none_not_raises_end_to_end(self, linear_service):
+        # THE RELENG-911 create_adopt bug: an absent placeholder slot must read
+        # as "not found" (None), not as an error. Before the fix this raised
+        # LinearError -> LinearUnavailable -> degraded on every mint.
+        with (
+            patch.object(
+                linear_service, "_get_access_token", return_value="valid-token"
+            ),
+            patch.object(
+                linear_service,
+                "_make_graphql_request",
+                return_value=self._not_found_response(),
+            ),
+        ):
+            result = linear_service.get_issue("TESTINC-2189", raise_on_error=True)
+
+        assert result is None
+
+    def test_real_graphql_error_still_raises_end_to_end(self, linear_service):
+        # A non-not-found error (e.g. auth/validation) must still raise for
+        # raise_on_error callers, so the allocator degrades rather than clobber.
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "errors": [
+                {
+                    "message": "Authentication required",
+                    "extensions": {"type": "authentication error"},
+                }
+            ]
+        }
+
+        with (
+            patch.object(
+                linear_service, "_get_access_token", return_value="valid-token"
+            ),
+            patch.object(
+                linear_service, "_make_graphql_request", return_value=mock_response
+            ),
+        ):
+            with pytest.raises(LinearError):
+                linear_service.get_issue("TESTINC-2189", raise_on_error=True)
+
+    def test_mixed_errors_with_one_real_error_still_raises(self, linear_service):
+        # If any error in the payload is not a not-found error, the whole
+        # response is treated as a failure (raises), never swallowed as empty.
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "errors": [
+                {"message": "Entity not found: Issue"},
+                {"message": "Rate limit exceeded"},
+            ]
+        }
+
+        with (
+            patch.object(
+                linear_service, "_get_access_token", return_value="valid-token"
+            ),
+            patch.object(
+                linear_service, "_make_graphql_request", return_value=mock_response
+            ),
+        ):
+            with pytest.raises(LinearError):
+                linear_service.get_issue("TESTINC-2189", raise_on_error=True)
+
+
+class TestErrorsAreNotFound:
+    def test_message_only_not_found(self):
+        assert _errors_are_not_found(
+            [{"message": "Entity not found: Issue - Could not find referenced Issue."}]
+        )
+
+    def test_extensions_code_not_found(self):
+        assert _errors_are_not_found(
+            [{"message": "nope", "extensions": {"code": "NOT_FOUND"}}]
+        )
+
+    def test_real_error_is_not_not_found(self):
+        assert not _errors_are_not_found([{"message": "Authentication required"}])
+
+    def test_all_must_be_not_found(self):
+        assert not _errors_are_not_found(
+            [{"message": "Entity not found"}, {"message": "boom"}]
+        )
+
+    def test_empty_or_malformed_is_not_not_found(self):
+        assert not _errors_are_not_found([])
+        assert not _errors_are_not_found(None)
+        assert not _errors_are_not_found(["not a dict"])

--- a/src/firetower/integrations/tests/test_linear_service.py
+++ b/src/firetower/integrations/tests/test_linear_service.py
@@ -1078,14 +1078,20 @@ class TestGetIssue:
 
 
 class TestErrorsAreNotFound:
-    def test_message_only_not_found(self):
+    def test_issue_not_found_message(self):
         assert _errors_are_not_found(
             [{"message": "Entity not found: Issue - Could not find referenced Issue."}]
         )
 
-    def test_extensions_code_not_found(self):
-        assert _errors_are_not_found(
-            [{"message": "nope", "extensions": {"code": "NOT_FOUND"}}]
+    def test_case_insensitive(self):
+        assert _errors_are_not_found([{"message": "COULD NOT FIND REFERENCED ISSUE"}])
+
+    def test_other_not_found_entities_do_not_match(self):
+        # Only a missing *issue* counts; team/user/etc. not-found must still
+        # surface as a failure so the allocator degrades instead of minting.
+        assert not _errors_are_not_found([{"message": "Team not found"}])
+        assert not _errors_are_not_found(
+            [{"message": "Could not find referenced User."}]
         )
 
     def test_real_error_is_not_not_found(self):
@@ -1093,7 +1099,10 @@ class TestErrorsAreNotFound:
 
     def test_all_must_be_not_found(self):
         assert not _errors_are_not_found(
-            [{"message": "Entity not found"}, {"message": "boom"}]
+            [
+                {"message": "Could not find referenced Issue."},
+                {"message": "boom"},
+            ]
         )
 
     def test_empty_or_malformed_is_not_not_found(self):

--- a/src/firetower/settings.py
+++ b/src/firetower/settings.py
@@ -333,6 +333,7 @@ LINEAR: dict | None = (
         "TEAM_ID": config.linear.team_id,
         "PROJECT_ID": config.linear.project_id,
         "SYNC_IDENTIFIERS": config.linear.sync_identifiers,
+        "INCIDENT_ADOPT_ON_CREATE": config.linear.adopt_on_create,
         "ACTION_ITEM_SLO_DAYS_HIGH_PRIORITY": config.linear.action_item_slo_days_high_priority,
         "ACTION_ITEM_SLO_DAYS_MEDIUM_PRIORITY": config.linear.action_item_slo_days_medium_priority,
         "ACTION_ITEM_NAG_COMMENT_HIGH_PRIORITY": config.linear.action_item_nag_comment_high_priority,

--- a/src/firetower/slack_app/handlers/backfill_incident.py
+++ b/src/firetower/slack_app/handlers/backfill_incident.py
@@ -5,7 +5,12 @@ from typing import Any
 from django.conf import settings
 
 from firetower.auth.services import get_or_create_user_from_slack_id
-from firetower.incidents.hooks import build_channel_name, build_channel_topic
+from firetower.incidents.allocation import LinearUnavailable, adopt_on_create_enabled
+from firetower.incidents.hooks import (
+    _populate_linear_parent,
+    build_channel_name,
+    build_channel_topic,
+)
 from firetower.incidents.models import (
     ExternalLink,
     ExternalLinkType,
@@ -273,6 +278,16 @@ def handle_backfill_submission(ack: Any, body: dict, view: dict, client: Any) ->
 
     try:
         incident = serializer.save()
+    except LinearUnavailable:
+        logger.warning("Linear unavailable during backfill incident allocation")
+        client.chat_postMessage(
+            channel=slack_user_id,
+            text=(
+                "Linear was temporarily unreachable, so the incident was not created. "
+                "Please retry `/ft backfill` shortly."
+            ),
+        )
+        return
     except Exception:
         logger.exception("Failed to create backfill incident from Slack modal")
         client.chat_postMessage(
@@ -280,5 +295,19 @@ def handle_backfill_submission(ack: Any, body: dict, view: dict, client: Any) ->
             text="Something went wrong creating the backfill incident. Please try again.",
         )
         return
+
+    # Backfill uses skip_hooks=True, so the populate path never runs via the
+    # hook. Populate the adopted Linear parent here so backfilled incidents get
+    # their parent issue too.
+    if adopt_on_create_enabled() and incident.linear_parent_issue_id:
+        identity = getattr(incident, "_allocated_identity", None)
+        if identity is not None:
+            try:
+                _populate_linear_parent(incident, identity.linear_url)
+            except Exception:
+                logger.exception(
+                    "Failed to populate Linear parent for backfill incident %s",
+                    incident.id,
+                )
 
     _setup_channel_for_incident(incident, channel_id, slack_user_id, client)

--- a/src/firetower/slack_app/handlers/backfill_incident.py
+++ b/src/firetower/slack_app/handlers/backfill_incident.py
@@ -7,9 +7,9 @@ from django.conf import settings
 from firetower.auth.services import get_or_create_user_from_slack_id
 from firetower.incidents.allocation import LinearUnavailable, adopt_on_create_enabled
 from firetower.incidents.hooks import (
-    _populate_linear_parent,
     build_channel_name,
     build_channel_topic,
+    populate_linear_parent,
 )
 from firetower.incidents.models import (
     ExternalLink,
@@ -303,7 +303,7 @@ def handle_backfill_submission(ack: Any, body: dict, view: dict, client: Any) ->
         identity = getattr(incident, "_allocated_identity", None)
         if identity is not None:
             try:
-                _populate_linear_parent(incident, identity.linear_url)
+                populate_linear_parent(incident, identity.linear_url)
             except Exception:
                 logger.exception(
                     "Failed to populate Linear parent for backfill incident %s",

--- a/src/firetower/slack_app/handlers/new_incident.py
+++ b/src/firetower/slack_app/handlers/new_incident.py
@@ -89,8 +89,10 @@ def _create_fallback_channel(
         _slack_service.post_message(
             channel_id,
             f":warning: This channel was created in degraded mode ({channel_reason}). "
-            "The incident has NOT been recorded in Firetower. Details will need to be "
-            "backfilled once the database is restored.",
+            "The incident has NOT been recorded in Firetower. Once the issue is "
+            "resolved, run `/ft backfill` in this channel to record it. "
+            "Note: automated escalations (sentry-sudo) will not work for this "
+            "incident — page Prod Eng directly if you need to escalate.",
         )
     except Exception:
         logger.exception("Failed to post warning in fallback channel %s", channel_name)
@@ -136,8 +138,10 @@ def _create_fallback_channel(
             text=(
                 f"An incident channel has been created in degraded mode ({dm_reason}).\n"
                 f"Slack channel: <#{channel_id}>\n\n"
-                "The incident has NOT been recorded in Firetower and will need to be "
-                "backfilled once the database is restored."
+                "The incident has NOT been recorded in Firetower. Once the issue is "
+                "resolved, run `/ft backfill` in the channel to record it. "
+                "Automated escalations (sentry-sudo) will not work for this "
+                "incident — page Prod Eng directly if you need to escalate."
             ),
         )
     except Exception:

--- a/src/firetower/slack_app/handlers/new_incident.py
+++ b/src/firetower/slack_app/handlers/new_incident.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.db import InterfaceError, OperationalError, close_old_connections
 
 from firetower.auth.services import get_or_create_user_from_slack_id
+from firetower.incidents.allocation import LinearUnavailable
 from firetower.incidents.hooks import (
     HIGH_SEVERITIES,
     ChannelSetupContext,
@@ -28,7 +29,13 @@ logger = logging.getLogger(__name__)
 _slack_service = SlackService()
 
 
-def _create_fallback_channel(client: Any, slack_user_id: str, form_data: dict) -> None:
+def _create_fallback_channel(
+    client: Any,
+    slack_user_id: str,
+    form_data: dict,
+    *,
+    degraded_reason: str | None = None,
+) -> None:
     title = form_data["title"]
     severity = form_data["severity"]
     description = form_data.get("description", "")
@@ -77,10 +84,11 @@ def _create_fallback_channel(client: Any, slack_user_id: str, form_data: dict) -
             "Failed to post/pin metadata in fallback channel %s", channel_name
         )
 
+    channel_reason = degraded_reason or "database unreachable"
     try:
         _slack_service.post_message(
             channel_id,
-            ":warning: This channel was created in degraded mode (database unreachable). "
+            f":warning: This channel was created in degraded mode ({channel_reason}). "
             "The incident has NOT been recorded in Firetower. Details will need to be "
             "backfilled once the database is restored.",
         )
@@ -121,11 +129,12 @@ def _create_fallback_channel(client: Any, slack_user_id: str, form_data: dict) -
         )
 
     # DM the user
+    dm_reason = degraded_reason or "database issue"
     try:
         client.chat_postMessage(
             channel=slack_user_id,
             text=(
-                "An incident channel has been created in degraded mode (database issue).\n"
+                f"An incident channel has been created in degraded mode ({dm_reason}).\n"
                 f"Slack channel: <#{channel_id}>\n\n"
                 "The incident has NOT been recorded in Firetower and will need to be "
                 "backfilled once the database is restored."
@@ -361,6 +370,22 @@ def _create_incident_via_db(
     return serializer.save()
 
 
+def _fallback_form_data(
+    view: dict, *, is_private: bool, skip_paging: bool
+) -> dict[str, Any]:
+    """Build the degraded-mode channel form data from a submitted modal view."""
+    form = parse_incident_form_values(view, resolve_tags=False)
+    return {
+        "title": form["title"],
+        "severity": form["severity"] or _DEFAULT_SEVERITY.value,
+        "description": form["description"],
+        "impact_summary": form["impact_summary"],
+        "captain_slack_id": form["captain_slack_id"],
+        "is_private": is_private,
+        "skip_paging": skip_paging,
+    }
+
+
 def handle_new_incident_submission(
     ack: Any, body: dict, view: dict, client: Any
 ) -> None:
@@ -396,17 +421,24 @@ def handle_new_incident_submission(
         logger.exception(
             "Database unreachable during incident creation from Slack modal"
         )
-        form = parse_incident_form_values(view, resolve_tags=False)
-        form_data = {
-            "title": form["title"],
-            "severity": form["severity"] or _DEFAULT_SEVERITY.value,
-            "description": form["description"],
-            "impact_summary": form["impact_summary"],
-            "captain_slack_id": form["captain_slack_id"],
-            "is_private": is_private,
-            "skip_paging": skip_paging,
-        }
+        form_data = _fallback_form_data(
+            view, is_private=is_private, skip_paging=skip_paging
+        )
         _create_fallback_channel(client, slack_user_id, form_data)
+        return
+    except LinearUnavailable:
+        logger.exception(
+            "Linear unavailable during incident id allocation from Slack modal"
+        )
+        form_data = _fallback_form_data(
+            view, is_private=is_private, skip_paging=skip_paging
+        )
+        _create_fallback_channel(
+            client,
+            slack_user_id,
+            form_data,
+            degraded_reason="Linear was unreachable",
+        )
         return
     except Exception:
         logger.exception("Failed to create incident from Slack modal")

--- a/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
+++ b/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
@@ -556,7 +556,7 @@ class TestBackfillSubmission:
         "firetower.slack_app.handlers.backfill_incident.adopt_on_create_enabled",
         return_value=True,
     )
-    @patch("firetower.slack_app.handlers.backfill_incident._populate_linear_parent")
+    @patch("firetower.slack_app.handlers.backfill_incident.populate_linear_parent")
     @patch("firetower.incidents.serializers.allocate_incident_identity")
     @patch(
         "firetower.slack_app.handlers.backfill_incident.sync_incident_participants_from_slack"

--- a/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
+++ b/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
@@ -549,6 +549,10 @@ class TestBackfillSubmission:
         assert "Could not identify" in msg
 
     @patch(
+        "firetower.incidents.serializers.adopt_on_create_enabled",
+        return_value=True,
+    )
+    @patch(
         "firetower.slack_app.handlers.backfill_incident.adopt_on_create_enabled",
         return_value=True,
     )
@@ -569,6 +573,7 @@ class TestBackfillSubmission:
         mock_allocate,
         mock_populate,
         mock_enabled,
+        mock_enabled_serializer,
     ):
         mock_get_user.return_value = self.user
         mock_allocate.return_value = AllocatedIdentity(
@@ -597,6 +602,14 @@ class TestBackfillSubmission:
         assert mock_populate.call_args[0][1] == "https://linear.app/issue/x"
 
     @patch(
+        "firetower.incidents.serializers.adopt_on_create_enabled",
+        return_value=True,
+    )
+    @patch(
+        "firetower.slack_app.handlers.backfill_incident.adopt_on_create_enabled",
+        return_value=True,
+    )
+    @patch(
         "firetower.incidents.serializers.allocate_incident_identity",
         side_effect=LinearUnavailable,
     )
@@ -605,7 +618,12 @@ class TestBackfillSubmission:
         "firetower.slack_app.handlers.backfill_incident.get_or_create_user_from_slack_id"
     )
     def test_linear_unavailable_dms_retry_and_creates_no_incident(
-        self, mock_get_user, mock_slack_svc, mock_allocate
+        self,
+        mock_get_user,
+        mock_slack_svc,
+        mock_allocate,
+        mock_enabled,
+        mock_enabled_serializer,
     ):
         mock_get_user.return_value = self.user
         mock_slack_svc.build_channel_url.return_value = (

--- a/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
+++ b/src/firetower/slack_app/tests/handlers/test_backfill_incident.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 
 from firetower.auth.models import ExternalProfile, ExternalProfileType
+from firetower.incidents.allocation import AllocatedIdentity, LinearUnavailable
 from firetower.incidents.models import (
     ExternalLink,
     ExternalLinkType,
@@ -546,3 +547,84 @@ class TestBackfillSubmission:
         client.chat_postMessage.assert_called_once()
         msg = client.chat_postMessage.call_args[1]["text"]
         assert "Could not identify" in msg
+
+    @patch(
+        "firetower.slack_app.handlers.backfill_incident.adopt_on_create_enabled",
+        return_value=True,
+    )
+    @patch("firetower.slack_app.handlers.backfill_incident._populate_linear_parent")
+    @patch("firetower.incidents.serializers.allocate_incident_identity")
+    @patch(
+        "firetower.slack_app.handlers.backfill_incident.sync_incident_participants_from_slack"
+    )
+    @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
+    @patch(
+        "firetower.slack_app.handlers.backfill_incident.get_or_create_user_from_slack_id"
+    )
+    def test_adopt_path_populates_linear_parent(
+        self,
+        mock_get_user,
+        mock_slack_svc,
+        mock_sync,
+        mock_allocate,
+        mock_populate,
+        mock_enabled,
+    ):
+        mock_get_user.return_value = self.user
+        mock_allocate.return_value = AllocatedIdentity(
+            2050, "uuid-x", "https://linear.app/issue/x"
+        )
+        mock_slack_svc.build_channel_url.return_value = (
+            "https://T0000.slack.com/archives/C_TEST"
+        )
+        mock_slack_svc.get_channel_info.return_value = {
+            "id": "C_TEST",
+            "name": f"{settings.PROJECT_KEY.lower()}-2050",
+            "is_private": False,
+        }
+        mock_slack_svc.join_channel.return_value = True
+
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_TEST"}}
+
+        handle_backfill_submission(ack, body, self._build_view(), client)
+
+        incident = Incident.objects.get(title="Test Backfill")
+        assert incident.linear_parent_issue_id == "uuid-x"
+        mock_populate.assert_called_once()
+        assert mock_populate.call_args[0][0] == incident
+        assert mock_populate.call_args[0][1] == "https://linear.app/issue/x"
+
+    @patch(
+        "firetower.incidents.serializers.allocate_incident_identity",
+        side_effect=LinearUnavailable,
+    )
+    @patch("firetower.slack_app.handlers.backfill_incident._slack_service")
+    @patch(
+        "firetower.slack_app.handlers.backfill_incident.get_or_create_user_from_slack_id"
+    )
+    def test_linear_unavailable_dms_retry_and_creates_no_incident(
+        self, mock_get_user, mock_slack_svc, mock_allocate
+    ):
+        mock_get_user.return_value = self.user
+        mock_slack_svc.build_channel_url.return_value = (
+            "https://T0000.slack.com/archives/C_TEST"
+        )
+        mock_slack_svc.get_channel_info.return_value = {
+            "id": "C_TEST",
+            "name": f"{settings.PROJECT_KEY.lower()}-2050",
+            "is_private": False,
+        }
+
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_TEST"}}
+
+        handle_backfill_submission(ack, body, self._build_view(), client)
+
+        assert not Incident.objects.filter(title="Test Backfill").exists()
+        client.chat_postMessage.assert_called_once()
+        msg = client.chat_postMessage.call_args[1]["text"]
+        assert "/ft backfill" in msg
+        assert "Linear" in msg

--- a/src/firetower/slack_app/tests/handlers/test_new_incident.py
+++ b/src/firetower/slack_app/tests/handlers/test_new_incident.py
@@ -6,6 +6,7 @@ from django.contrib.auth.models import User
 from django.db import OperationalError
 
 from firetower.auth.models import ExternalProfile, ExternalProfileType
+from firetower.incidents.allocation import LinearUnavailable
 from firetower.incidents.models import Incident, IncidentSeverity, Tag, TagType
 from firetower.slack_app.bolt import handle_command
 from firetower.slack_app.handlers.new_incident import (
@@ -631,6 +632,44 @@ class TestNewIncidentSubmission:
         form_data = mock_fallback.call_args[0][2]
         assert form_data["title"] == "DB Down Incident"
         assert form_data["severity"] == "P0"
+
+    @patch("firetower.slack_app.handlers.new_incident._create_fallback_channel")
+    @patch(
+        "firetower.slack_app.handlers.new_incident._create_incident_via_db",
+        side_effect=LinearUnavailable,
+    )
+    def test_linear_unavailable_creates_fallback_channel(
+        self, mock_create_db, mock_fallback
+    ):
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_TEST"}}
+        view = {
+            "state": {
+                "values": {
+                    "title_block": {"title": {"value": "Linear Down Incident"}},
+                    "severity_block": {
+                        "severity": {"selected_option": {"value": "P1"}}
+                    },
+                    "description_block": {"description": {"value": "Desc"}},
+                    "impact_summary_block": {"impact_summary": {"value": "Impact"}},
+                    "captain_block": {"captain_select": {"selected_user": "U_CAP"}},
+                    "options_block": {"incident_options": {"selected_options": []}},
+                }
+            }
+        }
+
+        handle_new_incident_submission(ack, body, view, client)
+
+        mock_fallback.assert_called_once()
+        assert mock_fallback.call_args[0][1] == "U_TEST"
+        form_data = mock_fallback.call_args[0][2]
+        assert form_data["title"] == "Linear Down Incident"
+        assert form_data["severity"] == "P1"
+        assert (
+            mock_fallback.call_args.kwargs["degraded_reason"]
+            == "Linear was unreachable"
+        )
 
     @pytest.mark.usefixtures("_enable_hooks")
     @patch("firetower.slack_app.handlers.new_incident._create_fallback_channel")


### PR DESCRIPTION
Adds the adopt-on-create allocator (RELENG-911, part of RELENG-909) that mints an incident id by claiming/adopting a matching Linear INC-N placeholder under the counter lock, shipped behind INCIDENT_ADOPT_ON_CREATE (default off) so there is no prod change until it is flipped.