### PR TITLE
feat: add /inc page command to manually page on-call

### DIFF
--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -303,6 +303,9 @@ def manual_page(
                 "text": "Slack Channel",
             }
         )
+    # The manual path (handle_page_submission) owns its own channel messaging,
+    # reporting both successes and failures in a single message, so we pass
+    # channel_id=None here to suppress page_policies' per-policy warnings.
     return page_policies(
         policy_names,
         incident.incident_number,
@@ -310,7 +313,7 @@ def manual_page(
         incident.title,
         _slack_service,
         links=links,
-        channel_id=channel_id,
+        channel_id=None,
         note=note,
     )
 

--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -175,7 +175,9 @@ def page_policies(
         page_label = policy_info.page_label
         summary = f"[{page_label}] [{severity}] {dedup_prefix}: {title}"
         if note:
-            summary = f"{summary}\nNote: {note}"
+            # Flatten user newlines/whitespace so the PD alert summary stays
+            # on one line (Slack display keeps the original text).
+            summary = f"{summary}\nNote: {' '.join(note.split())}"
         summary = summary[:PD_SUMMARY_MAX_LENGTH]
 
         try:
@@ -425,6 +427,15 @@ def _get_channel_id(incident: Incident) -> str | None:
     if not slack_link:
         return None
     return _slack_service.parse_channel_id_from_url(slack_link.url)
+
+
+def get_incident_channel_id(incident: Incident) -> str | None:
+    """Return the incident's primary Slack channel id (never the status channel).
+
+    Used by /inc page so paging side effects target the main incident channel
+    even when the command is run from the -status channel.
+    """
+    return _get_channel_id(incident)
 
 
 def _get_status_channel_id(incident: Incident) -> str | None:

--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any
@@ -74,15 +75,22 @@ def get_statuspage_warning_buffer_minutes() -> int:
 class PolicyConfig:
     label: str
     page_label: str
+    display_name: str
     max_level: int
 
 
 PAGING_POLICIES: dict[str, PolicyConfig] = {
     "IMOC": PolicyConfig(
-        label="On-Call Incident Manager", page_label="IMOC", max_level=1
+        label="On-Call Incident Manager",
+        page_label="IMOC",
+        display_name="IMOC",
+        max_level=1,
     ),
     "PROD_ENG": PolicyConfig(
-        label="On-Call Prod Eng", page_label="PE On-Call", max_level=2
+        label="On-Call Prod Eng",
+        page_label="PE On-Call",
+        display_name="Production Engineering",
+        max_level=2,
     ),
 }
 
@@ -108,25 +116,28 @@ class ChannelSetupContext:
     topic: str | None = None
 
 
-def page_for_channel(
-    severity: str,
+def page_policies(
+    policy_names: Iterable[str],
     dedup_prefix: str,
+    severity: str,
     title: str,
     slack_service: SlackService,
     *,
     links: list[dict[str, str]] | None = None,
     channel_id: str | None = None,
-    is_private: bool = False,
-    skip_paging: bool = False,
+    note: str | None = None,
 ) -> set[str]:
-    """Trigger PD pages for pageable severities. No DB access.
+    """Trigger PD pages for the named escalation policies. No gating, no DB access.
+
+    Unlike page_for_channel this does not gate on severity or privacy; callers
+    that need that gating (auto-paging) apply it before calling. Unknown policy
+    names are ignored. Uses the same deterministic firetower-<prefix>-<POLICY>
+    dedup key as everywhere else, so pages triggered here still auto-resolve via
+    resolve_pages_for_incident.
 
     Returns the set of policy names that were successfully paged.
     """
     paged: set[str] = set()
-
-    if is_private or skip_paging or severity not in HIGH_SEVERITIES:
-        return paged
 
     pd_config = settings.PAGERDUTY
     if not pd_config:
@@ -136,7 +147,11 @@ def page_for_channel(
 
     pd_service = None
 
-    for policy_name, policy_info in PAGING_POLICIES.items():
+    for policy_name in policy_names:
+        policy_info = PAGING_POLICIES.get(policy_name)
+        if not policy_info:
+            continue
+
         policy = escalation_policies.get(policy_name)
         if not policy:
             logger.info(f"No {policy_name} escalation policy configured, skipping page")
@@ -159,6 +174,8 @@ def page_for_channel(
         dedup_key = f"firetower-{dedup_prefix}-{policy_name}"
         page_label = policy_info.page_label
         summary = f"[{page_label}] [{severity}] {dedup_prefix}: {title}"
+        if note:
+            summary = f"{summary}\nNote: {note}"
         summary = summary[:PD_SUMMARY_MAX_LENGTH]
 
         try:
@@ -176,6 +193,54 @@ def page_for_channel(
             logger.exception(f"Failed to page {policy_name} for {dedup_prefix}")
 
     return paged
+
+
+def get_pageable_policies() -> list[tuple[str, str]]:
+    """Return (policy_name, display_name) for each configured escalation policy.
+
+    Only policies that have an integration_key configured are returned, so the
+    /inc page modal never offers a policy that cannot actually be paged.
+    """
+    pd_config = settings.PAGERDUTY
+    if not pd_config:
+        return []
+
+    escalation_policies = pd_config.get("ESCALATION_POLICIES", {})
+    result: list[tuple[str, str]] = []
+    for policy_name, policy_info in PAGING_POLICIES.items():
+        policy = escalation_policies.get(policy_name)
+        if policy and policy.get("integration_key"):
+            result.append((policy_name, policy_info.display_name))
+    return result
+
+
+def page_for_channel(
+    severity: str,
+    dedup_prefix: str,
+    title: str,
+    slack_service: SlackService,
+    *,
+    links: list[dict[str, str]] | None = None,
+    channel_id: str | None = None,
+    is_private: bool = False,
+    skip_paging: bool = False,
+) -> set[str]:
+    """Trigger PD pages for pageable severities. No DB access.
+
+    Returns the set of policy names that were successfully paged.
+    """
+    if is_private or skip_paging or severity not in HIGH_SEVERITIES:
+        return set()
+
+    return page_policies(
+        PAGING_POLICIES.keys(),
+        dedup_prefix,
+        severity,
+        title,
+        slack_service,
+        links=links,
+        channel_id=channel_id,
+    )
 
 
 def _page_if_needed(
@@ -203,6 +268,50 @@ def _page_if_needed(
         channel_id=channel_id,
         is_private=incident.is_private,
         skip_paging=skip_paging,
+    )
+
+
+def manual_page(
+    incident: Incident,
+    policy_names: Iterable[str],
+    *,
+    channel_id: str | None = None,
+    note: str | None = None,
+) -> set[str]:
+    """Manually page the given escalation policies for an incident.
+
+    Unlike _page_if_needed this is not gated on severity or privacy: the caller
+    (the /inc page command) has explicitly chosen to page. It reuses the
+    deterministic firetower-<incident_number>-<POLICY> dedup key so pages
+    triggered here still auto-resolve via resolve_pages_for_incident when the
+    incident is mitigated/resolved.
+
+    Note: PagerDuty dedups on that key, so if a page for a policy is already
+    open (e.g. from auto-paging), re-paging it is a no-op that does not
+    re-notify. This covers the primary use case of paging incidents that did
+    not auto-page (private, low severity, or a skipped policy).
+
+    Returns the set of policy names that were successfully paged.
+    """
+    links: list[dict[str, str]] = [
+        {"href": _build_incident_url(incident), "text": "View in Firetower"}
+    ]
+    if channel_id:
+        links.append(
+            {
+                "href": _slack_service.build_channel_url(channel_id),
+                "text": "Slack Channel",
+            }
+        )
+    return page_policies(
+        policy_names,
+        incident.incident_number,
+        incident.severity,
+        incident.title,
+        _slack_service,
+        links=links,
+        channel_id=channel_id,
+        note=note,
     )
 
 

--- a/src/firetower/incidents/hooks.py
+++ b/src/firetower/incidents/hooks.py
@@ -483,18 +483,16 @@ def _oncall_role_label(
     return policy_label
 
 
-def _invite_oncall_to_channel(
-    severity: str,
+def invite_oncall_for_policies(
+    policy_names: Iterable[str],
     channel_id: str,
     slack_service: SlackService,
     *,
-    is_private: bool = False,
-    skip_paging: bool = False,
     paged_policies: set[str] | None = None,
 ) -> None:
-    """Invite on-call users to a channel. No DB access."""
-    if is_private or skip_paging or severity not in HIGH_SEVERITIES:
-        return
+    """Invite on-call users for the given policies to a channel and post their
+    roles. No gating, no DB access. Unknown policy names are ignored."""
+    selected = set(policy_names)
 
     pd_config = settings.PAGERDUTY
     if not pd_config:
@@ -512,6 +510,8 @@ def _invite_oncall_to_channel(
     users_to_invite: list[tuple[str, str]] = []
 
     for policy_index, (policy_name, policy_info) in enumerate(PAGING_POLICIES.items()):
+        if policy_name not in selected:
+            continue
         policy_label = policy_info.label
         max_level = policy_info.max_level
         policy = escalation_policies.get(policy_name)
@@ -601,6 +601,43 @@ def _invite_oncall_to_channel(
             logger.exception(
                 f"Failed to post oncall role message in channel {channel_id}"
             )
+
+
+def _invite_oncall_to_channel(
+    severity: str,
+    channel_id: str,
+    slack_service: SlackService,
+    *,
+    is_private: bool = False,
+    skip_paging: bool = False,
+    paged_policies: set[str] | None = None,
+) -> None:
+    """Invite on-call users to a channel. No DB access."""
+    if is_private or skip_paging or severity not in HIGH_SEVERITIES:
+        return
+
+    invite_oncall_for_policies(
+        PAGING_POLICIES.keys(),
+        channel_id,
+        slack_service,
+        paged_policies=paged_policies,
+    )
+
+
+def invite_paged_oncall(channel_id: str, paged_policies: set[str]) -> None:
+    """Invite and @mention the on-call users for the given paged policies in a
+    channel, mirroring the high-severity auto-page behavior. Used by /inc page.
+
+    No gating: the caller has already decided which policies were paged.
+    """
+    if not paged_policies:
+        return
+    invite_oncall_for_policies(
+        paged_policies,
+        channel_id,
+        _slack_service,
+        paged_policies=paged_policies,
+    )
 
 
 def _invite_oncall_users(

--- a/src/firetower/incidents/tests/test_hooks.py
+++ b/src/firetower/incidents/tests/test_hooks.py
@@ -3972,3 +3972,27 @@ class TestManualPage:
         links = mock_pd.trigger_incident.call_args[1]["links"]
         assert all(link["text"] != "Slack Channel" for link in links)
         mock_slack.build_channel_url.assert_not_called()
+
+    @patch("firetower.incidents.hooks.PagerDutyService")
+    @patch("firetower.incidents.hooks._slack_service")
+    def test_pd_failure_returns_empty_and_suppresses_warning(
+        self, mock_slack, mock_pd_cls, settings
+    ):
+        # When the PD trigger fails, manual_page returns an empty set and does
+        # not post a per-policy warning to Slack, because it passes
+        # channel_id=None into page_policies. handle_page_submission owns the
+        # single consolidated failure message instead.
+        settings.PAGERDUTY = MOCK_PD_CONFIG
+        settings.FIRETOWER_BASE_URL = "https://firetower.example.com"
+        mock_pd = mock_pd_cls.return_value
+        mock_pd.trigger_incident.return_value = False
+
+        incident = Incident.objects.create(
+            title="Issue",
+            severity=IncidentSeverity.P1,
+        )
+
+        result = manual_page(incident, ["IMOC"], channel_id="C1")
+
+        assert result == set()
+        mock_slack.post_message.assert_not_called()

--- a/src/firetower/incidents/tests/test_hooks.py
+++ b/src/firetower/incidents/tests/test_hooks.py
@@ -21,6 +21,7 @@ from firetower.incidents.hooks import (
     build_channel_name,
     build_channel_topic,
     create_linear_parent_issue,
+    get_incident_channel_id,
     get_pageable_policies,
     invite_paged_oncall,
     manual_page,
@@ -3873,6 +3874,24 @@ class TestPagePolicies:
         assert summary == "[IMOC] [P1] INC-9: Boom\nNote: db is on fire"
 
     @patch("firetower.incidents.hooks.PagerDutyService")
+    def test_note_newlines_flattened_in_summary(self, mock_pd_cls, settings):
+        settings.PAGERDUTY = MOCK_PD_CONFIG
+        mock_pd = mock_pd_cls.return_value
+        mock_pd.trigger_incident.return_value = True
+
+        page_policies(
+            ["IMOC"],
+            "INC-9",
+            IncidentSeverity.P1,
+            "Boom",
+            MagicMock(),
+            note="line one\nline two\r\n  extra",
+        )
+
+        summary = mock_pd.trigger_incident.call_args[0][0]
+        assert summary == "[IMOC] [P1] INC-9: Boom\nNote: line one line two extra"
+
+    @patch("firetower.incidents.hooks.PagerDutyService")
     def test_noop_when_pagerduty_unconfigured(self, mock_pd_cls, settings):
         settings.PAGERDUTY = None
 
@@ -4041,3 +4060,26 @@ class TestInvitePagedOncall:
         mock_pd_cls.assert_not_called()
         mock_slack.invite_to_channel.assert_not_called()
         mock_slack.post_message.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestGetIncidentChannelId:
+    def test_returns_primary_channel_not_status(self, db):
+        incident = Incident.objects.create(title="X", severity=IncidentSeverity.P2)
+        ExternalLink.objects.create(
+            incident=incident,
+            type=ExternalLinkType.SLACK,
+            url="https://slack.com/archives/C_MAIN",
+        )
+        ExternalLink.objects.create(
+            incident=incident,
+            type=ExternalLinkType.SLACK_STATUS,
+            url="https://slack.com/archives/C_STATUS",
+        )
+
+        assert get_incident_channel_id(incident) == "C_MAIN"
+
+    def test_none_when_no_channel(self, db):
+        incident = Incident.objects.create(title="X", severity=IncidentSeverity.P2)
+
+        assert get_incident_channel_id(incident) is None

--- a/src/firetower/incidents/tests/test_hooks.py
+++ b/src/firetower/incidents/tests/test_hooks.py
@@ -22,6 +22,7 @@ from firetower.incidents.hooks import (
     build_channel_topic,
     create_linear_parent_issue,
     get_pageable_policies,
+    invite_paged_oncall,
     manual_page,
     on_captain_changed,
     on_incident_created,
@@ -3995,4 +3996,48 @@ class TestManualPage:
         result = manual_page(incident, ["IMOC"], channel_id="C1")
 
         assert result == set()
+        mock_slack.post_message.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestInvitePagedOncall:
+    @patch("firetower.incidents.hooks._slack_service")
+    @patch("firetower.incidents.hooks.PagerDutyService")
+    def test_invites_only_paged_policies_with_suffix(
+        self, mock_pd_cls, mock_slack, settings
+    ):
+        # Only the paged policy (PROD_ENG) should be queried/invited; IMOC is
+        # left alone. Level-1 on-call gets the "(paged)" suffix.
+        settings.PAGERDUTY = MOCK_PD_CONFIG
+        mock_pd = mock_pd_cls.return_value
+        mock_pd.get_oncall_users.return_value = [
+            {"email": "primary@example.com", "escalation_level": 1},
+            {"email": "secondary@example.com", "escalation_level": 2},
+        ]
+        mock_slack.get_user_profile_by_email.side_effect = [
+            {"slack_user_id": "U_PRIMARY"},
+            {"slack_user_id": "U_SECONDARY"},
+        ]
+
+        invite_paged_oncall("C123", {"PROD_ENG"})
+
+        mock_pd.get_oncall_users.assert_called_once_with("PPE001")
+        mock_slack.invite_to_channel.assert_called_once_with(
+            "C123", ["U_PRIMARY", "U_SECONDARY"]
+        )
+        message = mock_slack.post_message.call_args[0][1]
+        assert message == (
+            "On-Call Prod Eng (Primary): <@U_PRIMARY> (paged)\n"
+            "On-Call Prod Eng (Secondary): <@U_SECONDARY>"
+        )
+
+    @patch("firetower.incidents.hooks._slack_service")
+    @patch("firetower.incidents.hooks.PagerDutyService")
+    def test_empty_paged_is_noop(self, mock_pd_cls, mock_slack, settings):
+        settings.PAGERDUTY = MOCK_PD_CONFIG
+
+        invite_paged_oncall("C123", set())
+
+        mock_pd_cls.assert_not_called()
+        mock_slack.invite_to_channel.assert_not_called()
         mock_slack.post_message.assert_not_called()

--- a/src/firetower/incidents/tests/test_hooks.py
+++ b/src/firetower/incidents/tests/test_hooks.py
@@ -21,6 +21,8 @@ from firetower.incidents.hooks import (
     build_channel_name,
     build_channel_topic,
     create_linear_parent_issue,
+    get_pageable_policies,
+    manual_page,
     on_captain_changed,
     on_incident_created,
     on_incident_updated,
@@ -29,6 +31,7 @@ from firetower.incidents.hooks import (
     on_title_changed,
     on_visibility_changed,
     page_for_channel,
+    page_policies,
     resolve_pages_for_incident,
     schedule_statuspage_followup_reminder,
 )
@@ -3814,3 +3817,158 @@ class TestOnIncidentUpdated:
         on_incident_updated(incident, old_status=IncidentStatus.ACTIVE)
 
         mock_get_linear.return_value.update_issue.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestPagePolicies:
+    @patch("firetower.incidents.hooks.PagerDutyService")
+    def test_pages_low_severity_incident(self, mock_pd_cls, settings):
+        # Unlike page_for_channel, page_policies does not gate on severity.
+        settings.PAGERDUTY = MOCK_PD_CONFIG
+        mock_pd = mock_pd_cls.return_value
+        mock_pd.trigger_incident.return_value = True
+
+        slack = MagicMock()
+        result = page_policies(
+            ["IMOC"], "INC-500", IncidentSeverity.P3, "Low sev", slack
+        )
+
+        assert result == {"IMOC"}
+        mock_pd.trigger_incident.assert_called_once()
+        summary, dedup_key, integration_key = mock_pd.trigger_incident.call_args[0]
+        assert summary == "[IMOC] [P3] INC-500: Low sev"
+        assert dedup_key == "firetower-INC-500-IMOC"
+        assert integration_key == "imoc-integration-key"
+
+    @patch("firetower.incidents.hooks.PagerDutyService")
+    def test_ignores_unknown_policy_names(self, mock_pd_cls, settings):
+        settings.PAGERDUTY = MOCK_PD_CONFIG
+        mock_pd = mock_pd_cls.return_value
+        mock_pd.trigger_incident.return_value = True
+
+        result = page_policies(
+            ["NOPE", "PROD_ENG"], "INC-1", IncidentSeverity.P0, "T", MagicMock()
+        )
+
+        assert result == {"PROD_ENG"}
+        assert mock_pd.trigger_incident.call_count == 1
+
+    @patch("firetower.incidents.hooks.PagerDutyService")
+    def test_note_appended_to_summary(self, mock_pd_cls, settings):
+        settings.PAGERDUTY = MOCK_PD_CONFIG
+        mock_pd = mock_pd_cls.return_value
+        mock_pd.trigger_incident.return_value = True
+
+        page_policies(
+            ["IMOC"],
+            "INC-9",
+            IncidentSeverity.P1,
+            "Boom",
+            MagicMock(),
+            note="db is on fire",
+        )
+
+        summary = mock_pd.trigger_incident.call_args[0][0]
+        assert summary == "[IMOC] [P1] INC-9: Boom\nNote: db is on fire"
+
+    @patch("firetower.incidents.hooks.PagerDutyService")
+    def test_noop_when_pagerduty_unconfigured(self, mock_pd_cls, settings):
+        settings.PAGERDUTY = None
+
+        result = page_policies(["IMOC"], "INC-1", IncidentSeverity.P0, "T", MagicMock())
+
+        assert result == set()
+        mock_pd_cls.assert_not_called()
+
+    @patch("firetower.incidents.hooks.PagerDutyService")
+    def test_posts_warning_on_failure(self, mock_pd_cls, settings):
+        settings.PAGERDUTY = MOCK_PD_CONFIG
+        mock_pd = mock_pd_cls.return_value
+        mock_pd.trigger_incident.return_value = False
+
+        slack = MagicMock()
+        result = page_policies(
+            ["IMOC"], "INC-1", IncidentSeverity.P0, "T", slack, channel_id="C1"
+        )
+
+        assert result == set()
+        slack.post_message.assert_called_once()
+        assert "Failed to page" in slack.post_message.call_args[0][1]
+
+
+@pytest.mark.django_db
+class TestGetPageablePolicies:
+    def test_returns_configured_policies_with_display_names(self, settings):
+        settings.PAGERDUTY = MOCK_PD_CONFIG
+
+        assert get_pageable_policies() == [
+            ("IMOC", "IMOC"),
+            ("PROD_ENG", "Production Engineering"),
+        ]
+
+    def test_excludes_policies_without_integration_key(self, settings):
+        settings.PAGERDUTY = {
+            "API_TOKEN": "test-token",
+            "ESCALATION_POLICIES": {
+                "IMOC": {"id": "PIMOC01", "integration_key": "imoc-integration-key"},
+                "PROD_ENG": {"id": "PPE001"},
+            },
+        }
+
+        assert get_pageable_policies() == [("IMOC", "IMOC")]
+
+    def test_empty_when_unconfigured(self, settings):
+        settings.PAGERDUTY = None
+
+        assert get_pageable_policies() == []
+
+
+@pytest.mark.django_db
+class TestManualPage:
+    @patch("firetower.incidents.hooks.PagerDutyService")
+    @patch("firetower.incidents.hooks._slack_service")
+    def test_pages_private_low_severity_incident(
+        self, mock_slack, mock_pd_cls, settings
+    ):
+        # manual_page is explicit, so it pages even a private P3 incident that
+        # auto-paging would skip.
+        settings.PAGERDUTY = MOCK_PD_CONFIG
+        settings.FIRETOWER_BASE_URL = "https://firetower.example.com"
+        mock_pd = mock_pd_cls.return_value
+        mock_pd.trigger_incident.return_value = True
+        mock_slack.build_channel_url.return_value = "https://slack.example.com/c/C1"
+
+        incident = Incident.objects.create(
+            title="Quiet issue",
+            severity=IncidentSeverity.P3,
+            is_private=True,
+        )
+
+        result = manual_page(incident, ["IMOC"], channel_id="C1", note="context")
+
+        assert result == {"IMOC"}
+        summary, dedup_key, integration_key = mock_pd.trigger_incident.call_args[0]
+        assert dedup_key == f"firetower-{incident.incident_number}-IMOC"
+        assert summary.endswith("\nNote: context")
+        links = mock_pd.trigger_incident.call_args[1]["links"]
+        assert {"text": "View in Firetower"}.items() <= links[0].items()
+        assert any(link["text"] == "Slack Channel" for link in links)
+
+    @patch("firetower.incidents.hooks.PagerDutyService")
+    @patch("firetower.incidents.hooks._slack_service")
+    def test_no_channel_omits_slack_link(self, mock_slack, mock_pd_cls, settings):
+        settings.PAGERDUTY = MOCK_PD_CONFIG
+        settings.FIRETOWER_BASE_URL = "https://firetower.example.com"
+        mock_pd = mock_pd_cls.return_value
+        mock_pd.trigger_incident.return_value = True
+
+        incident = Incident.objects.create(
+            title="Issue",
+            severity=IncidentSeverity.P2,
+        )
+
+        manual_page(incident, ["PROD_ENG"])
+
+        links = mock_pd.trigger_incident.call_args[1]["links"]
+        assert all(link["text"] != "Slack Channel" for link in links)
+        mock_slack.build_channel_url.assert_not_called()

--- a/src/firetower/slack_app/bolt.py
+++ b/src/firetower/slack_app/bolt.py
@@ -33,6 +33,10 @@ from firetower.slack_app.handlers.new_incident import (
     handle_severity_action,
     handle_tag_options,
 )
+from firetower.slack_app.handlers.page import (
+    handle_page_command,
+    handle_page_submission,
+)
 from firetower.slack_app.handlers.reopen import handle_reopen_command
 from firetower.slack_app.handlers.resolved import (
     handle_resolved_command,
@@ -83,6 +87,7 @@ KNOWN_SUBCOMMANDS = {
     "ic",
     "status",
     "statuspage",
+    "page",
     "dumpslack",
 }
 
@@ -176,6 +181,8 @@ def handle_command(
                 handle_subject_command(ack, body, command, respond, new_subject=args)
         elif subcommand in ("captain", "ic"):
             handle_captain_command(ack, body, command, respond)
+        elif subcommand == "page":
+            handle_page_command(ack, body, command, respond)
         elif subcommand == "status":
             handle_status_command(ack, body, command, respond)
         elif subcommand == "statuspage":
@@ -270,6 +277,9 @@ def _register_views(app: App) -> None:
     )
     app.view("statuspage_modal")(
         _with_metrics("statuspage_modal")(handle_statuspage_submission)
+    )
+    app.view("page_incident_modal")(
+        _with_metrics("page_incident_modal")(handle_page_submission)
     )
     app.action("severity")(_with_metrics("severity_action")(handle_severity_action))
     app.action("component_impact_select")(

--- a/src/firetower/slack_app/handlers/help.py
+++ b/src/firetower/slack_app/handlers/help.py
@@ -19,6 +19,7 @@ def handle_help_command(ack: Any, command: dict, respond: Any) -> None:
         f"  `{cmd} reopen` - Reopen an incident\n"
         f"  `{cmd} cancel` - Cancel an incident\n"
         f"  `{cmd} status` - Show current incident status and IC\n"
+        f"  `{cmd} page` - Page on-call escalation policies for this incident\n"
         f"  `{cmd} severity <P0-P4>` - Change incident severity (alias: `{cmd} sev`)\n"
         f"  `{cmd} statuspage` - Create or update a statuspage post\n"
         f"  `{cmd} subject <title>` - Change incident title (alias: `{cmd} title`)\n"

--- a/src/firetower/slack_app/handlers/page.py
+++ b/src/firetower/slack_app/handlers/page.py
@@ -1,0 +1,154 @@
+import logging
+from typing import Any
+
+from django.conf import settings
+
+from firetower.incidents.hooks import (
+    PAGING_POLICIES,
+    get_pageable_policies,
+    manual_page,
+)
+from firetower.integrations.services.slack import escape_slack_text
+from firetower.slack_app.handlers.utils import get_incident_from_channel
+
+logger = logging.getLogger(__name__)
+
+
+def _build_page_modal(
+    incident_number: str,
+    channel_id: str,
+    policies: list[tuple[str, str]],
+) -> dict:
+    options = [
+        {
+            "text": {"type": "plain_text", "text": display_name},
+            "value": policy_name,
+        }
+        for policy_name, display_name in policies
+    ]
+    return {
+        "type": "modal",
+        "callback_id": "page_incident_modal",
+        "private_metadata": channel_id,
+        "title": {"type": "plain_text", "text": incident_number[:24]},
+        "submit": {"type": "plain_text", "text": "Page"},
+        "close": {"type": "plain_text", "text": "Cancel"},
+        "blocks": [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": (
+                        "Select which on-call escalation policies to page "
+                        "for this incident."
+                    ),
+                },
+            },
+            {
+                "type": "input",
+                "block_id": "policies_block",
+                "element": {
+                    "type": "checkboxes",
+                    "action_id": "policies",
+                    "options": options,
+                },
+                "label": {"type": "plain_text", "text": "Who to page"},
+            },
+            {
+                "type": "input",
+                "block_id": "note_block",
+                "optional": True,
+                "element": {
+                    "type": "plain_text_input",
+                    "action_id": "note",
+                    "multiline": True,
+                    "placeholder": {
+                        "type": "plain_text",
+                        "text": "Optional context included in the page",
+                    },
+                },
+                "label": {"type": "plain_text", "text": "Note"},
+            },
+        ],
+    }
+
+
+def handle_page_command(ack: Any, body: dict, command: dict, respond: Any) -> None:
+    ack()
+    channel_id = body.get("channel_id", "")
+    incident = get_incident_from_channel(channel_id)
+    if not incident:
+        respond("Could not find an incident associated with this channel.")
+        return
+
+    policies = get_pageable_policies()
+    if not policies:
+        respond("PagerDuty paging is not configured.")
+        return
+
+    trigger_id = body.get("trigger_id")
+    if not trigger_id:
+        respond("Could not open modal — missing trigger_id.")
+        return
+
+    from firetower.slack_app.bolt import get_bolt_app  # noqa: PLC0415
+
+    get_bolt_app().client.views_open(
+        trigger_id=trigger_id,
+        view=_build_page_modal(incident.incident_number, channel_id, policies),
+    )
+
+
+def handle_page_submission(ack: Any, body: dict, view: dict, client: Any) -> None:
+    values = view.get("state", {}).get("values", {})
+    selected = (
+        values.get("policies_block", {}).get("policies", {}).get("selected_options")
+        or []
+    )
+    policy_names = [opt["value"] for opt in selected]
+
+    if not policy_names:
+        ack(
+            response_action="errors",
+            errors={"policies_block": "Select at least one escalation policy to page."},
+        )
+        return
+
+    ack()
+
+    channel_id = view.get("private_metadata", "")
+    incident = get_incident_from_channel(channel_id)
+    if not incident:
+        logger.error("Page submission: no incident for channel %s", channel_id)
+        return
+
+    note = (
+        values.get("note_block", {}).get("note", {}).get("value") or ""
+    ).strip() or None
+
+    paged = manual_page(incident, policy_names, channel_id=channel_id, note=note)
+
+    pager_id = body.get("user", {}).get("id", "")
+    incident_url = f"{settings.FIRETOWER_BASE_URL}/{incident.incident_number}"
+
+    if paged:
+        paged_labels = [
+            PAGING_POLICIES[name].display_name
+            for name in PAGING_POLICIES
+            if name in paged
+        ]
+        labels_text = ", ".join(f"*{label}*" for label in paged_labels)
+        message = (
+            f"<@{pager_id}> paged {labels_text} for "
+            f"<{incident_url}|{incident.incident_number}>."
+        )
+        if note:
+            message += f"\n*Note:* {escape_slack_text(note)}"
+    else:
+        message = (
+            f"<@{pager_id}> tried to page for "
+            f"<{incident_url}|{incident.incident_number}>, but no escalation "
+            "policies could be paged. Please escalate manually."
+        )
+
+    client.chat_postMessage(channel=channel_id, text=message)

--- a/src/firetower/slack_app/handlers/page.py
+++ b/src/firetower/slack_app/handlers/page.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from firetower.incidents.hooks import (
     PAGING_POLICIES,
     get_pageable_policies,
+    invite_paged_oncall,
     manual_page,
 )
 from firetower.incidents.models import IncidentStatus
@@ -199,3 +200,8 @@ def handle_page_submission(ack: Any, body: dict, view: dict, client: Any) -> Non
         message += f"\n*Note:* {escape_slack_text(note)}"
 
     client.chat_postMessage(channel=channel_id, text=message)
+
+    # Mirror the high-severity auto-page path: invite and @mention the on-call
+    # users for the policies we actually paged.
+    if paged:
+        invite_paged_oncall(channel_id, paged)

--- a/src/firetower/slack_app/handlers/page.py
+++ b/src/firetower/slack_app/handlers/page.py
@@ -121,7 +121,11 @@ def handle_page_submission(ack: Any, body: dict, view: dict, client: Any) -> Non
         values.get("policies_block", {}).get("policies", {}).get("selected_options")
         or []
     )
-    policy_names = [opt["value"] for opt in selected]
+    # Only accept policies we actually offer, guarding against crafted
+    # submissions carrying arbitrary values.
+    policy_names = [
+        opt.get("value") for opt in selected if opt.get("value") in PAGING_POLICIES
+    ]
 
     if not policy_names:
         ack(
@@ -161,7 +165,20 @@ def handle_page_submission(ack: Any, body: dict, view: dict, client: Any) -> Non
         values.get("note_block", {}).get("note", {}).get("value") or ""
     ).strip() or None
 
-    paged = manual_page(incident, policy_names, channel_id=target_channel_id, note=note)
+    try:
+        paged = manual_page(
+            incident, policy_names, channel_id=target_channel_id, note=note
+        )
+    except Exception:
+        logger.exception("Failed to page policies for %s", incident.incident_number)
+        client.chat_postMessage(
+            channel=target_channel_id,
+            text=(
+                f"Failed to page on-call for {incident.incident_number}. "
+                "Please escalate manually."
+            ),
+        )
+        return
 
     pager_id = body.get("user", {}).get("id", "")
     incident_url = f"{settings.FIRETOWER_BASE_URL}/{incident.incident_number}"

--- a/src/firetower/slack_app/handlers/page.py
+++ b/src/firetower/slack_app/handlers/page.py
@@ -8,10 +8,20 @@ from firetower.incidents.hooks import (
     get_pageable_policies,
     manual_page,
 )
+from firetower.incidents.models import IncidentStatus
 from firetower.integrations.services.slack import escape_slack_text
 from firetower.slack_app.handlers.utils import get_incident_from_channel
 
 logger = logging.getLogger(__name__)
+
+# Terminal statuses whose PagerDuty pages have already been resolved on
+# mitigate/close. Paging one of these would re-trigger a fresh PD alert via the
+# deterministic dedup key, so we block them.
+CLOSED_STATUSES = {
+    IncidentStatus.POSTMORTEM,
+    IncidentStatus.DONE,
+    IncidentStatus.CANCELED,
+}
 
 
 def _build_page_modal(
@@ -30,7 +40,7 @@ def _build_page_modal(
         "type": "modal",
         "callback_id": "page_incident_modal",
         "private_metadata": channel_id,
-        "title": {"type": "plain_text", "text": incident_number[:24]},
+        "title": {"type": "plain_text", "text": incident_number},
         "submit": {"type": "plain_text", "text": "Page"},
         "close": {"type": "plain_text", "text": "Cancel"},
         "blocks": [
@@ -81,6 +91,10 @@ def handle_page_command(ack: Any, body: dict, command: dict, respond: Any) -> No
         respond("Could not find an incident associated with this channel.")
         return
 
+    if incident.status in CLOSED_STATUSES:
+        respond(f"Cannot page {incident.incident_number} — it is {incident.status}.")
+        return
+
     policies = get_pageable_policies()
     if not policies:
         respond("PagerDuty paging is not configured.")
@@ -122,6 +136,20 @@ def handle_page_submission(ack: Any, body: dict, view: dict, client: Any) -> Non
         logger.error("Page submission: no incident for channel %s", channel_id)
         return
 
+    # Status may have changed to terminal between opening and submitting the
+    # modal; re-paging would re-trigger an already-resolved PD alert.
+    if incident.status in CLOSED_STATUSES:
+        logger.info(
+            "Page submission: %s is %s, skipping page",
+            incident.incident_number,
+            incident.status,
+        )
+        client.chat_postMessage(
+            channel=channel_id,
+            text=f"Not paging {incident.incident_number} — it is now {incident.status}.",
+        )
+        return
+
     note = (
         values.get("note_block", {}).get("note", {}).get("value") or ""
     ).strip() or None
@@ -131,24 +159,43 @@ def handle_page_submission(ack: Any, body: dict, view: dict, client: Any) -> Non
     pager_id = body.get("user", {}).get("id", "")
     incident_url = f"{settings.FIRETOWER_BASE_URL}/{incident.incident_number}"
 
-    if paged:
-        paged_labels = [
-            PAGING_POLICIES[name].display_name
-            for name in PAGING_POLICIES
-            if name in paged
-        ]
-        labels_text = ", ".join(f"*{label}*" for label in paged_labels)
+    requested = set(policy_names)
+    paged_text = ", ".join(
+        f"*{PAGING_POLICIES[name].display_name}*"
+        for name in PAGING_POLICIES
+        if name in paged
+    )
+    failed_text = ", ".join(
+        f"*{PAGING_POLICIES[name].display_name}*"
+        for name in PAGING_POLICIES
+        if name in requested and name not in paged
+    )
+
+    if paged_text and failed_text:
         message = (
-            f"<@{pager_id}> paged {labels_text} for "
+            f"<@{pager_id}> paged {paged_text} for "
+            f"<{incident_url}|{incident.incident_number}>. "
+            f":warning: Failed to page {failed_text} — please escalate manually."
+        )
+    elif paged_text:
+        message = (
+            f"<@{pager_id}> paged {paged_text} for "
             f"<{incident_url}|{incident.incident_number}>."
         )
-        if note:
-            message += f"\n*Note:* {escape_slack_text(note)}"
-    else:
+    elif failed_text:
         message = (
-            f"<@{pager_id}> tried to page for "
-            f"<{incident_url}|{incident.incident_number}>, but no escalation "
-            "policies could be paged. Please escalate manually."
+            f"<@{pager_id}> could not page {failed_text} for "
+            f"<{incident_url}|{incident.incident_number}>. Please escalate manually."
         )
+    else:
+        logger.warning(
+            "Page submission for %s produced no known policies (requested=%s)",
+            incident.incident_number,
+            policy_names,
+        )
+        return
+
+    if note:
+        message += f"\n*Note:* {escape_slack_text(note)}"
 
     client.chat_postMessage(channel=channel_id, text=message)

--- a/src/firetower/slack_app/handlers/page.py
+++ b/src/firetower/slack_app/handlers/page.py
@@ -5,6 +5,7 @@ from django.conf import settings
 
 from firetower.incidents.hooks import (
     PAGING_POLICIES,
+    get_incident_channel_id,
     get_pageable_policies,
     invite_paged_oncall,
     manual_page,
@@ -137,6 +138,11 @@ def handle_page_submission(ack: Any, body: dict, view: dict, client: Any) -> Non
         logger.error("Page submission: no incident for channel %s", channel_id)
         return
 
+    # Paging side effects (PD Slack link, on-call invite, roster/confirmation)
+    # target the incident's primary channel, matching the auto-page path — not
+    # the channel the command was run from, which may be the -status channel.
+    target_channel_id = get_incident_channel_id(incident) or channel_id
+
     # Status may have changed to terminal between opening and submitting the
     # modal; re-paging would re-trigger an already-resolved PD alert.
     if incident.status in CLOSED_STATUSES:
@@ -146,7 +152,7 @@ def handle_page_submission(ack: Any, body: dict, view: dict, client: Any) -> Non
             incident.status,
         )
         client.chat_postMessage(
-            channel=channel_id,
+            channel=target_channel_id,
             text=f"Not paging {incident.incident_number} — it is now {incident.status}.",
         )
         return
@@ -155,7 +161,7 @@ def handle_page_submission(ack: Any, body: dict, view: dict, client: Any) -> Non
         values.get("note_block", {}).get("note", {}).get("value") or ""
     ).strip() or None
 
-    paged = manual_page(incident, policy_names, channel_id=channel_id, note=note)
+    paged = manual_page(incident, policy_names, channel_id=target_channel_id, note=note)
 
     pager_id = body.get("user", {}).get("id", "")
     incident_url = f"{settings.FIRETOWER_BASE_URL}/{incident.incident_number}"
@@ -199,9 +205,9 @@ def handle_page_submission(ack: Any, body: dict, view: dict, client: Any) -> Non
     if note:
         message += f"\n*Note:* {escape_slack_text(note)}"
 
-    client.chat_postMessage(channel=channel_id, text=message)
+    client.chat_postMessage(channel=target_channel_id, text=message)
 
     # Mirror the high-severity auto-page path: invite and @mention the on-call
     # users for the policies we actually paged.
     if paged:
-        invite_paged_oncall(channel_id, paged)
+        invite_paged_oncall(target_channel_id, paged)

--- a/src/firetower/slack_app/tests/handlers/test_page.py
+++ b/src/firetower/slack_app/tests/handlers/test_page.py
@@ -8,7 +8,7 @@ from firetower.slack_app.handlers.page import (
     handle_page_submission,
 )
 
-from .conftest import CHANNEL_ID
+from .conftest import CHANNEL_ID, STATUS_CHANNEL_ID
 
 MOCK_PD_CONFIG = {
     "API_TOKEN": "test-token",
@@ -165,6 +165,35 @@ class TestPageSubmission:
 
     @patch("firetower.slack_app.handlers.page.invite_paged_oncall")
     @patch("firetower.slack_app.handlers.page.manual_page")
+    def test_uses_primary_channel_when_run_from_status_channel(
+        self, mock_manual_page, mock_invite_oncall, incident, settings
+    ):
+        settings.FIRETOWER_BASE_URL = "https://firetower.example.com"
+        mock_manual_page.return_value = {"IMOC"}
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_PAGER"}}
+        view = {
+            "private_metadata": STATUS_CHANNEL_ID,
+            "state": {
+                "values": {
+                    "policies_block": {
+                        "policies": {"selected_options": [{"value": "IMOC"}]}
+                    },
+                    "note_block": {"note": {"value": ""}},
+                }
+            },
+        }
+
+        handle_page_submission(ack, body, view, client)
+
+        # Side effects target the primary incident channel, not the status one.
+        assert mock_manual_page.call_args.kwargs["channel_id"] == CHANNEL_ID
+        mock_invite_oncall.assert_called_once_with(CHANNEL_ID, {"IMOC"})
+        assert client.chat_postMessage.call_args[1]["channel"] == CHANNEL_ID
+
+    @patch("firetower.slack_app.handlers.page.invite_paged_oncall")
+    @patch("firetower.slack_app.handlers.page.manual_page")
     def test_note_trimmed_passed_and_posted(
         self, mock_manual_page, mock_invite_oncall, incident, settings
     ):
@@ -312,6 +341,38 @@ class TestPageSubmission:
         msg = client.chat_postMessage.call_args[1]["text"]
         assert "Not paging" in msg
         assert incident.status in msg
+
+    @patch("firetower.slack_app.handlers.page.invite_paged_oncall")
+    @patch("firetower.slack_app.handlers.page.manual_page")
+    def test_terminal_status_message_posts_to_primary_channel(
+        self, mock_manual_page, mock_invite_oncall, incident, settings
+    ):
+        settings.FIRETOWER_BASE_URL = "https://firetower.example.com"
+        incident.status = IncidentStatus.DONE
+        incident.save(update_fields=["status"])
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_PAGER"}}
+        view = {
+            "private_metadata": STATUS_CHANNEL_ID,
+            "state": {
+                "values": {
+                    "policies_block": {
+                        "policies": {"selected_options": [{"value": "IMOC"}]}
+                    },
+                    "note_block": {"note": {"value": ""}},
+                }
+            },
+        }
+
+        handle_page_submission(ack, body, view, client)
+
+        mock_manual_page.assert_not_called()
+        mock_invite_oncall.assert_not_called()
+        client.chat_postMessage.assert_called_once()
+        # Terminal-status notice posts to the primary channel, not the status one.
+        assert client.chat_postMessage.call_args[1]["channel"] == CHANNEL_ID
+        assert "Not paging" in client.chat_postMessage.call_args[1]["text"]
 
     @patch("firetower.slack_app.handlers.page.manual_page")
     def test_missing_incident_does_not_crash(self, mock_manual_page, db):

--- a/src/firetower/slack_app/tests/handlers/test_page.py
+++ b/src/firetower/slack_app/tests/handlers/test_page.py
@@ -120,8 +120,11 @@ class TestPageCommand:
 
 @pytest.mark.django_db
 class TestPageSubmission:
+    @patch("firetower.slack_app.handlers.page.invite_paged_oncall")
     @patch("firetower.slack_app.handlers.page.manual_page")
-    def test_pages_selected_policies(self, mock_manual_page, incident, settings):
+    def test_pages_selected_policies(
+        self, mock_manual_page, mock_invite_oncall, incident, settings
+    ):
         settings.FIRETOWER_BASE_URL = "https://firetower.example.com"
         mock_manual_page.return_value = {"IMOC", "PROD_ENG"}
         ack = MagicMock()
@@ -158,9 +161,13 @@ class TestPageSubmission:
         assert "*IMOC*" in msg
         assert "*Production Engineering*" in msg
         assert incident.incident_number in msg
+        mock_invite_oncall.assert_called_once_with(CHANNEL_ID, {"IMOC", "PROD_ENG"})
 
+    @patch("firetower.slack_app.handlers.page.invite_paged_oncall")
     @patch("firetower.slack_app.handlers.page.manual_page")
-    def test_note_trimmed_passed_and_posted(self, mock_manual_page, incident, settings):
+    def test_note_trimmed_passed_and_posted(
+        self, mock_manual_page, mock_invite_oncall, incident, settings
+    ):
         settings.FIRETOWER_BASE_URL = "https://firetower.example.com"
         mock_manual_page.return_value = {"IMOC"}
         ack = MagicMock()
@@ -184,8 +191,11 @@ class TestPageSubmission:
         msg = client.chat_postMessage.call_args[1]["text"]
         assert "db is on fire" in msg
 
+    @patch("firetower.slack_app.handlers.page.invite_paged_oncall")
     @patch("firetower.slack_app.handlers.page.manual_page")
-    def test_no_selection_returns_errors(self, mock_manual_page, incident):
+    def test_no_selection_returns_errors(
+        self, mock_manual_page, mock_invite_oncall, incident
+    ):
         ack = MagicMock()
         client = MagicMock()
         body = {"user": {"id": "U_PAGER"}}
@@ -205,10 +215,14 @@ class TestPageSubmission:
             errors={"policies_block": "Select at least one escalation policy to page."},
         )
         mock_manual_page.assert_not_called()
+        mock_invite_oncall.assert_not_called()
         client.chat_postMessage.assert_not_called()
 
+    @patch("firetower.slack_app.handlers.page.invite_paged_oncall")
     @patch("firetower.slack_app.handlers.page.manual_page")
-    def test_none_paged_posts_failure(self, mock_manual_page, incident, settings):
+    def test_none_paged_posts_failure(
+        self, mock_manual_page, mock_invite_oncall, incident, settings
+    ):
         settings.FIRETOWER_BASE_URL = "https://firetower.example.com"
         mock_manual_page.return_value = set()
         ack = MagicMock()
@@ -230,9 +244,13 @@ class TestPageSubmission:
 
         msg = client.chat_postMessage.call_args[1]["text"]
         assert "escalate manually" in msg
+        mock_invite_oncall.assert_not_called()
 
+    @patch("firetower.slack_app.handlers.page.invite_paged_oncall")
     @patch("firetower.slack_app.handlers.page.manual_page")
-    def test_partial_failure_reports_both(self, mock_manual_page, incident, settings):
+    def test_partial_failure_reports_both(
+        self, mock_manual_page, mock_invite_oncall, incident, settings
+    ):
         settings.FIRETOWER_BASE_URL = "https://firetower.example.com"
         mock_manual_page.return_value = {"IMOC"}
         ack = MagicMock()
@@ -260,10 +278,12 @@ class TestPageSubmission:
         msg = client.chat_postMessage.call_args[1]["text"]
         assert "paged *IMOC*" in msg
         assert "Failed to page *Production Engineering*" in msg
+        mock_invite_oncall.assert_called_once_with(CHANNEL_ID, {"IMOC"})
 
+    @patch("firetower.slack_app.handlers.page.invite_paged_oncall")
     @patch("firetower.slack_app.handlers.page.manual_page")
     def test_terminal_status_incident_is_noop(
-        self, mock_manual_page, incident, settings
+        self, mock_manual_page, mock_invite_oncall, incident, settings
     ):
         settings.FIRETOWER_BASE_URL = "https://firetower.example.com"
         incident.status = IncidentStatus.DONE
@@ -287,6 +307,7 @@ class TestPageSubmission:
 
         ack.assert_called_once_with()
         mock_manual_page.assert_not_called()
+        mock_invite_oncall.assert_not_called()
         client.chat_postMessage.assert_called_once()
         msg = client.chat_postMessage.call_args[1]["text"]
         assert "Not paging" in msg

--- a/src/firetower/slack_app/tests/handlers/test_page.py
+++ b/src/firetower/slack_app/tests/handlers/test_page.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from firetower.incidents.models import IncidentStatus
 from firetower.slack_app.handlers.page import (
     handle_page_command,
     handle_page_submission,
@@ -46,6 +47,45 @@ class TestPageCommand:
             "IMOC",
             "Production Engineering",
         ]
+        assert "optional" not in policies_block
+        note_block = next(
+            b for b in view["blocks"] if b.get("block_id") == "note_block"
+        )
+        assert note_block["optional"] is True
+
+    @patch("firetower.slack_app.bolt.get_bolt_app")
+    def test_missing_trigger_id_responds_error(
+        self, mock_get_bolt_app, incident, settings
+    ):
+        settings.PAGERDUTY = MOCK_PD_CONFIG
+        ack = MagicMock()
+        body = {"channel_id": CHANNEL_ID}
+        command = {"command": "/inc"}
+        respond = MagicMock()
+
+        handle_page_command(ack, body, command, respond)
+
+        ack.assert_called_once()
+        assert "trigger_id" in respond.call_args[0][0]
+        mock_get_bolt_app.return_value.client.views_open.assert_not_called()
+
+    @patch("firetower.slack_app.bolt.get_bolt_app")
+    def test_terminal_status_incident_responds_error(
+        self, mock_get_bolt_app, incident, settings
+    ):
+        settings.PAGERDUTY = MOCK_PD_CONFIG
+        incident.status = IncidentStatus.DONE
+        incident.save(update_fields=["status"])
+        ack = MagicMock()
+        body = {"channel_id": CHANNEL_ID, "trigger_id": "T12345"}
+        command = {"command": "/inc"}
+        respond = MagicMock()
+
+        handle_page_command(ack, body, command, respond)
+
+        ack.assert_called_once()
+        assert "Cannot page" in respond.call_args[0][0]
+        mock_get_bolt_app.return_value.client.views_open.assert_not_called()
 
     @patch("firetower.slack_app.bolt.get_bolt_app")
     def test_no_incident_responds_error(self, mock_get_bolt_app, db, settings):
@@ -190,6 +230,67 @@ class TestPageSubmission:
 
         msg = client.chat_postMessage.call_args[1]["text"]
         assert "escalate manually" in msg
+
+    @patch("firetower.slack_app.handlers.page.manual_page")
+    def test_partial_failure_reports_both(self, mock_manual_page, incident, settings):
+        settings.FIRETOWER_BASE_URL = "https://firetower.example.com"
+        mock_manual_page.return_value = {"IMOC"}
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_PAGER"}}
+        view = {
+            "private_metadata": CHANNEL_ID,
+            "state": {
+                "values": {
+                    "policies_block": {
+                        "policies": {
+                            "selected_options": [
+                                {"value": "IMOC"},
+                                {"value": "PROD_ENG"},
+                            ]
+                        }
+                    },
+                    "note_block": {"note": {"value": ""}},
+                }
+            },
+        }
+
+        handle_page_submission(ack, body, view, client)
+
+        msg = client.chat_postMessage.call_args[1]["text"]
+        assert "paged *IMOC*" in msg
+        assert "Failed to page *Production Engineering*" in msg
+
+    @patch("firetower.slack_app.handlers.page.manual_page")
+    def test_terminal_status_incident_is_noop(
+        self, mock_manual_page, incident, settings
+    ):
+        settings.FIRETOWER_BASE_URL = "https://firetower.example.com"
+        incident.status = IncidentStatus.DONE
+        incident.save(update_fields=["status"])
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_PAGER"}}
+        view = {
+            "private_metadata": CHANNEL_ID,
+            "state": {
+                "values": {
+                    "policies_block": {
+                        "policies": {"selected_options": [{"value": "IMOC"}]}
+                    },
+                    "note_block": {"note": {"value": ""}},
+                }
+            },
+        }
+
+        handle_page_submission(ack, body, view, client)
+
+        ack.assert_called_once_with()
+        mock_manual_page.assert_not_called()
+        client.chat_postMessage.assert_called_once()
+        msg = client.chat_postMessage.call_args[1]["text"]
+        assert "Not paging" in msg
+        assert incident.status in msg
 
     @patch("firetower.slack_app.handlers.page.manual_page")
     def test_missing_incident_does_not_crash(self, mock_manual_page, db):

--- a/src/firetower/slack_app/tests/handlers/test_page.py
+++ b/src/firetower/slack_app/tests/handlers/test_page.py
@@ -1,0 +1,214 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from firetower.slack_app.handlers.page import (
+    handle_page_command,
+    handle_page_submission,
+)
+
+from .conftest import CHANNEL_ID
+
+MOCK_PD_CONFIG = {
+    "API_TOKEN": "test-token",
+    "ESCALATION_POLICIES": {
+        "IMOC": {"id": "PIMOC01", "integration_key": "imoc-integration-key"},
+        "PROD_ENG": {"id": "PPE001", "integration_key": "prod-eng-integration-key"},
+    },
+}
+
+
+@pytest.mark.django_db
+class TestPageCommand:
+    @patch("firetower.slack_app.bolt.get_bolt_app")
+    def test_opens_modal_with_configured_policies(
+        self, mock_get_bolt_app, incident, settings
+    ):
+        settings.PAGERDUTY = MOCK_PD_CONFIG
+        ack = MagicMock()
+        body = {"channel_id": CHANNEL_ID, "trigger_id": "T12345"}
+        command = {"command": "/inc"}
+        respond = MagicMock()
+
+        handle_page_command(ack, body, command, respond)
+
+        ack.assert_called_once()
+        mock_get_bolt_app.return_value.client.views_open.assert_called_once()
+        view = mock_get_bolt_app.return_value.client.views_open.call_args[1]["view"]
+        assert view["callback_id"] == "page_incident_modal"
+        assert view["private_metadata"] == CHANNEL_ID
+        policies_block = next(
+            b for b in view["blocks"] if b.get("block_id") == "policies_block"
+        )
+        options = policies_block["element"]["options"]
+        assert [o["value"] for o in options] == ["IMOC", "PROD_ENG"]
+        assert [o["text"]["text"] for o in options] == [
+            "IMOC",
+            "Production Engineering",
+        ]
+
+    @patch("firetower.slack_app.bolt.get_bolt_app")
+    def test_no_incident_responds_error(self, mock_get_bolt_app, db, settings):
+        settings.PAGERDUTY = MOCK_PD_CONFIG
+        ack = MagicMock()
+        body = {"channel_id": "C_UNKNOWN", "trigger_id": "T12345"}
+        command = {"command": "/inc"}
+        respond = MagicMock()
+
+        handle_page_command(ack, body, command, respond)
+
+        ack.assert_called_once()
+        assert "Could not find" in respond.call_args[0][0]
+        mock_get_bolt_app.return_value.client.views_open.assert_not_called()
+
+    @patch("firetower.slack_app.bolt.get_bolt_app")
+    def test_pagerduty_unconfigured_responds_error(
+        self, mock_get_bolt_app, incident, settings
+    ):
+        settings.PAGERDUTY = None
+        ack = MagicMock()
+        body = {"channel_id": CHANNEL_ID, "trigger_id": "T12345"}
+        command = {"command": "/inc"}
+        respond = MagicMock()
+
+        handle_page_command(ack, body, command, respond)
+
+        ack.assert_called_once()
+        assert "not configured" in respond.call_args[0][0]
+        mock_get_bolt_app.return_value.client.views_open.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestPageSubmission:
+    @patch("firetower.slack_app.handlers.page.manual_page")
+    def test_pages_selected_policies(self, mock_manual_page, incident, settings):
+        settings.FIRETOWER_BASE_URL = "https://firetower.example.com"
+        mock_manual_page.return_value = {"IMOC", "PROD_ENG"}
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_PAGER"}}
+        view = {
+            "private_metadata": CHANNEL_ID,
+            "state": {
+                "values": {
+                    "policies_block": {
+                        "policies": {
+                            "selected_options": [
+                                {"value": "IMOC"},
+                                {"value": "PROD_ENG"},
+                            ]
+                        }
+                    },
+                    "note_block": {"note": {"value": ""}},
+                }
+            },
+        }
+
+        handle_page_submission(ack, body, view, client)
+
+        ack.assert_called_once_with()
+        mock_manual_page.assert_called_once()
+        args, kwargs = mock_manual_page.call_args
+        assert args[0] == incident
+        assert args[1] == ["IMOC", "PROD_ENG"]
+        assert kwargs["channel_id"] == CHANNEL_ID
+        assert kwargs["note"] is None
+        msg = client.chat_postMessage.call_args[1]["text"]
+        assert "<@U_PAGER>" in msg
+        assert "*IMOC*" in msg
+        assert "*Production Engineering*" in msg
+        assert incident.incident_number in msg
+
+    @patch("firetower.slack_app.handlers.page.manual_page")
+    def test_note_trimmed_passed_and_posted(self, mock_manual_page, incident, settings):
+        settings.FIRETOWER_BASE_URL = "https://firetower.example.com"
+        mock_manual_page.return_value = {"IMOC"}
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_PAGER"}}
+        view = {
+            "private_metadata": CHANNEL_ID,
+            "state": {
+                "values": {
+                    "policies_block": {
+                        "policies": {"selected_options": [{"value": "IMOC"}]}
+                    },
+                    "note_block": {"note": {"value": "  db is on fire  "}},
+                }
+            },
+        }
+
+        handle_page_submission(ack, body, view, client)
+
+        assert mock_manual_page.call_args.kwargs["note"] == "db is on fire"
+        msg = client.chat_postMessage.call_args[1]["text"]
+        assert "db is on fire" in msg
+
+    @patch("firetower.slack_app.handlers.page.manual_page")
+    def test_no_selection_returns_errors(self, mock_manual_page, incident):
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_PAGER"}}
+        view = {
+            "private_metadata": CHANNEL_ID,
+            "state": {
+                "values": {
+                    "policies_block": {"policies": {"selected_options": []}},
+                }
+            },
+        }
+
+        handle_page_submission(ack, body, view, client)
+
+        ack.assert_called_once_with(
+            response_action="errors",
+            errors={"policies_block": "Select at least one escalation policy to page."},
+        )
+        mock_manual_page.assert_not_called()
+        client.chat_postMessage.assert_not_called()
+
+    @patch("firetower.slack_app.handlers.page.manual_page")
+    def test_none_paged_posts_failure(self, mock_manual_page, incident, settings):
+        settings.FIRETOWER_BASE_URL = "https://firetower.example.com"
+        mock_manual_page.return_value = set()
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_PAGER"}}
+        view = {
+            "private_metadata": CHANNEL_ID,
+            "state": {
+                "values": {
+                    "policies_block": {
+                        "policies": {"selected_options": [{"value": "IMOC"}]}
+                    },
+                    "note_block": {"note": {"value": ""}},
+                }
+            },
+        }
+
+        handle_page_submission(ack, body, view, client)
+
+        msg = client.chat_postMessage.call_args[1]["text"]
+        assert "escalate manually" in msg
+
+    @patch("firetower.slack_app.handlers.page.manual_page")
+    def test_missing_incident_does_not_crash(self, mock_manual_page, db):
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_PAGER"}}
+        view = {
+            "private_metadata": "C_NONEXISTENT",
+            "state": {
+                "values": {
+                    "policies_block": {
+                        "policies": {"selected_options": [{"value": "IMOC"}]}
+                    },
+                }
+            },
+        }
+
+        handle_page_submission(ack, body, view, client)
+
+        ack.assert_called_once()
+        mock_manual_page.assert_not_called()
+        client.chat_postMessage.assert_not_called()

--- a/src/firetower/slack_app/tests/handlers/test_page.py
+++ b/src/firetower/slack_app/tests/handlers/test_page.py
@@ -374,6 +374,94 @@ class TestPageSubmission:
         assert client.chat_postMessage.call_args[1]["channel"] == CHANNEL_ID
         assert "Not paging" in client.chat_postMessage.call_args[1]["text"]
 
+    @patch("firetower.slack_app.handlers.page.invite_paged_oncall")
+    @patch("firetower.slack_app.handlers.page.manual_page")
+    def test_unknown_policy_values_rejected(
+        self, mock_manual_page, mock_invite_oncall, incident
+    ):
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_PAGER"}}
+        view = {
+            "private_metadata": CHANNEL_ID,
+            "state": {
+                "values": {
+                    "policies_block": {
+                        "policies": {"selected_options": [{"value": "BOGUS"}]}
+                    },
+                }
+            },
+        }
+
+        handle_page_submission(ack, body, view, client)
+
+        ack.assert_called_once_with(
+            response_action="errors",
+            errors={"policies_block": "Select at least one escalation policy to page."},
+        )
+        mock_manual_page.assert_not_called()
+        mock_invite_oncall.assert_not_called()
+        client.chat_postMessage.assert_not_called()
+
+    @patch("firetower.slack_app.handlers.page.invite_paged_oncall")
+    @patch("firetower.slack_app.handlers.page.manual_page")
+    def test_unknown_policy_values_filtered_out(
+        self, mock_manual_page, mock_invite_oncall, incident, settings
+    ):
+        settings.FIRETOWER_BASE_URL = "https://firetower.example.com"
+        mock_manual_page.return_value = {"IMOC"}
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_PAGER"}}
+        view = {
+            "private_metadata": CHANNEL_ID,
+            "state": {
+                "values": {
+                    "policies_block": {
+                        "policies": {
+                            "selected_options": [
+                                {"value": "IMOC"},
+                                {"value": "BOGUS"},
+                            ]
+                        }
+                    },
+                    "note_block": {"note": {"value": ""}},
+                }
+            },
+        }
+
+        handle_page_submission(ack, body, view, client)
+
+        assert mock_manual_page.call_args[0][1] == ["IMOC"]
+
+    @patch("firetower.slack_app.handlers.page.invite_paged_oncall")
+    @patch("firetower.slack_app.handlers.page.manual_page")
+    def test_manual_page_exception_posts_failure(
+        self, mock_manual_page, mock_invite_oncall, incident, settings
+    ):
+        settings.FIRETOWER_BASE_URL = "https://firetower.example.com"
+        mock_manual_page.side_effect = Exception("boom")
+        ack = MagicMock()
+        client = MagicMock()
+        body = {"user": {"id": "U_PAGER"}}
+        view = {
+            "private_metadata": CHANNEL_ID,
+            "state": {
+                "values": {
+                    "policies_block": {
+                        "policies": {"selected_options": [{"value": "IMOC"}]}
+                    },
+                    "note_block": {"note": {"value": ""}},
+                }
+            },
+        }
+
+        handle_page_submission(ack, body, view, client)
+
+        client.chat_postMessage.assert_called_once()
+        assert "Failed to page" in client.chat_postMessage.call_args[1]["text"]
+        mock_invite_oncall.assert_not_called()
+
     @patch("firetower.slack_app.handlers.page.manual_page")
     def test_missing_incident_does_not_crash(self, mock_manual_page, db):
         ack = MagicMock()

--- a/src/firetower/slack_app/tests/test_bolt.py
+++ b/src/firetower/slack_app/tests/test_bolt.py
@@ -206,6 +206,17 @@ class TestRouting:
             mock_handler.assert_called_once()
 
     @patch("firetower.slack_app.bolt.statsd")
+    def test_page_routes(self, mock_statsd, incident):
+        ack = MagicMock()
+        respond = MagicMock()
+        body = {"text": "page", "channel_id": CHANNEL_ID}
+        command = {"command": "/ft"}
+
+        with patch("firetower.slack_app.bolt.handle_page_command") as mock_handler:
+            handle_command(ack=ack, body=body, command=command, respond=respond)
+            mock_handler.assert_called_once()
+
+    @patch("firetower.slack_app.bolt.statsd")
     def test_dumpslack_routes(self, mock_statsd, incident):
         ack = MagicMock()
         respond = MagicMock()


### PR DESCRIPTION
Adds a \`/inc page\` Slack command that opens a checkbox modal to manually page on-call escalation policies (IMOC / Production Engineering) for the current incident. RELENG-356