### PR TITLE
feat: read config secrets from env vars with TOML fallback

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -5,6 +5,7 @@
 # is used. This lets prod inject per-secret values without changing local dev.
 # Overridable keys and their env vars:
 #   django_secret_key                                  -> DJANGO_SECRET_KEY
+#   [postgres] password                                -> DJANGO_PG_PASS
 #   salt_key                                           -> SALT_KEY
 #     (NOTE: SALT_KEY only overrides the singular salt_key. To rotate salt keys,
 #      use the salt_keys list in this config file, which takes precedence.)
@@ -39,7 +40,7 @@ region_grouping = [["region-a", "region-b"], ["region-c", "region-d"]]
 db = "firetower"
 host = "localhost"
 user = "postgres"
-password = "dummy_dev_password"
+password = "dummy_dev_password"  # Overridable via DJANGO_PG_PASS
 # Optional: during a password rotation, list the other valid password(s) here.
 # If `password` is rejected with an auth error, each of these is tried in order.
 # Once the rotation is complete, move the new value into `password` and clear this.

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,10 +1,28 @@
+# ---------------------------------------------------------------------------
+# Secret env-var overrides (RELENG-918)
+# Each secret below can be overridden by a dedicated environment variable. The
+# env var wins ONLY when it is set AND non-empty; otherwise the TOML value here
+# is used. This lets prod inject per-secret values without changing local dev.
+# Overridable keys and their env vars:
+#   django_secret_key                                  -> DJANGO_SECRET_KEY
+#   salt_key                                           -> SALT_KEY
+#   [slack] bot_token                                  -> SLACK_BOT_TOKEN
+#   [slack] app_token                                  -> SLACK_APP_TOKEN
+#   [linear] client_secret                             -> LINEAR_CLIENT_SECRET
+#   [pagerduty] api_token                              -> PAGERDUTY_API_TOKEN
+#   [pagerduty.escalation_policies.<NAME>] integration_key
+#                                          -> PAGERDUTY_ESCALATION_KEY_<NAME>
+#   [statuspage] api_key                               -> STATUSPAGE_API_KEY
+#   [notion] integration_token                         -> NOTION_INTEGRATION_TOKEN
+# ---------------------------------------------------------------------------
 project_key = "INC"
 log_level = "INFO"
-django_secret_key = "django-insecure-gmj)qc*_dk&^i1=z7oy(ew7%5*fz^yowp8=4=0882_d=i3hl69"
+django_secret_key = "django-insecure-gmj)qc*_dk&^i1=z7oy(ew7%5*fz^yowp8=4=0882_d=i3hl69"  # Overridable via DJANGO_SECRET_KEY env var (env wins if set & non-empty)
 # Salt for django-fernet-encrypted-fields. In prod, use a unique value: python -c "import secrets; print(secrets.token_urlsafe(32))"
-salt_key = ""
+salt_key = ""  # Overridable via SALT_KEY
 # Optional: for key rotation, set salt_keys (plural) to a list of salts. When present it
-# overrides salt_key. Values are encrypted with the FIRST key and can be decrypted with any,
+# overrides salt_key (including any SALT_KEY env override). Values are encrypted with the
+# FIRST key and can be decrypted with any,
 # so during rotation list the new key first and keep the old one until every row is
 # re-encrypted (run the reencrypt_encrypted_fields migration), then drop the old key.
 # salt_keys = ["<new-salt>", "<old-salt>"]
@@ -25,10 +43,10 @@ password = "dummy_dev_password"
 # fallback_passwords = ["<other-password>"]
 
 [slack]
-bot_token = ""
+bot_token = ""  # Overridable via SLACK_BOT_TOKEN
 team_id = "<slack-team-id>"
 participant_sync_throttle_seconds = 300
-app_token = ""
+app_token = ""  # Overridable via SLACK_APP_TOKEN
 incident_feed_channel_id = ""
 always_invited_ids = []
 incident_guide_message = "This is the message posted whenever a new incident slack channel is created."
@@ -39,19 +57,19 @@ iap_enabled = false
 iap_audience = ""
 
 [pagerduty]
-api_token = ""
+api_token = ""  # Overridable via PAGERDUTY_API_TOKEN
 
 [pagerduty.escalation_policies.IMOC]
 id = ""
-integration_key = ""
+integration_key = ""  # Overridable via PAGERDUTY_ESCALATION_KEY_IMOC
 
 [pagerduty.escalation_policies.PROD_ENG]
 id = ""
-integration_key = ""
+integration_key = ""  # Overridable via PAGERDUTY_ESCALATION_KEY_PROD_ENG
 
 [linear]
 client_id = ""
-client_secret = ""
+client_secret = ""  # Overridable via LINEAR_CLIENT_SECRET
 action_item_sync_throttle_seconds = 300
 team_id = ""
 project_id = ""
@@ -76,7 +94,7 @@ action_item_slo_days_high_priority = 14
 action_item_slo_days_medium_priority = 28
 
 [notion]
-integration_token = ""
+integration_token = ""  # Overridable via NOTION_INTEGRATION_TOKEN
 database_id = ""
 template_markdown = """
 # Your postmortem template in Markdown here
@@ -87,7 +105,7 @@ troubleshooting_template_markdown = """
 """
 
 [statuspage]
-api_key = ""
+api_key = ""  # Overridable via STATUSPAGE_API_KEY
 page_id = ""
 url = "https://your-page.statuspage.io/"
 warning_buffer_minutes = 5

--- a/config.example.toml
+++ b/config.example.toml
@@ -6,6 +6,8 @@
 # Overridable keys and their env vars:
 #   django_secret_key                                  -> DJANGO_SECRET_KEY
 #   salt_key                                           -> SALT_KEY
+#     (NOTE: SALT_KEY only overrides the singular salt_key. To rotate salt keys,
+#      use the salt_keys list in this config file, which takes precedence.)
 #   [slack] bot_token                                  -> SLACK_BOT_TOKEN
 #   [slack] app_token                                  -> SLACK_APP_TOKEN
 #   [linear] client_secret                             -> LINEAR_CLIENT_SECRET
@@ -21,7 +23,8 @@ django_secret_key = "django-insecure-gmj)qc*_dk&^i1=z7oy(ew7%5*fz^yowp8=4=0882_d
 # Salt for django-fernet-encrypted-fields. In prod, use a unique value: python -c "import secrets; print(secrets.token_urlsafe(32))"
 salt_key = ""  # Overridable via SALT_KEY
 # Optional: for key rotation, set salt_keys (plural) to a list of salts. When present it
-# overrides salt_key (including any SALT_KEY env override). Values are encrypted with the
+# takes precedence over salt_key (and over any SALT_KEY env override), so rotate salt keys
+# here in the config file rather than via the env var. Values are encrypted with the
 # FIRST key and can be decrypted with any,
 # so during rotation list the new key first and keep the old one until every row is
 # re-encrypted (run the reencrypt_encrypted_fields migration), then drop the old key.

--- a/src/firetower/config.py
+++ b/src/firetower/config.py
@@ -207,6 +207,9 @@ class ConfigFile:
         self.django_secret_key = _env_override(
             self.django_secret_key, "DJANGO_SECRET_KEY"
         )
+        # SALT_KEY overrides only the singular salt_key. Salt-key rotation uses the
+        # salt_keys list, which takes precedence in settings.py; rotate via the
+        # config file, not this env var. See RELENG-918.
         self.salt_key = _env_override(self.salt_key, "SALT_KEY")
 
         # slack is a required section, but guard defensively anyway.

--- a/src/firetower/config.py
+++ b/src/firetower/config.py
@@ -4,12 +4,24 @@ Configuration file loader for Firetower.
 Loads configuration values from a TOML file and validates that all required keys are present.
 """
 
+import os
 from dataclasses import field
 from pathlib import Path
 from typing import Any
 
 from serde import deserialize, from_dict
 from serde.toml import from_toml
+
+
+def _env_override(value: str, env_var: str) -> str:
+    """
+    Return the environment variable value if it is set and non-empty, else `value`.
+
+    The non-empty guard is deliberate: a stray empty env var must not blank out a
+    real secret coming from the TOML config. Unset or empty env vars fall back to
+    the TOML value.
+    """
+    return v if (v := os.environ.get(env_var)) else value
 
 
 @deserialize
@@ -165,6 +177,7 @@ class ConfigFile:
         """
         with open(file_path) as f:
             data: ConfigFile = from_toml(ConfigFile, f.read())
+        data._apply_env_overrides()
         return data
 
     @classmethod
@@ -178,7 +191,55 @@ class ConfigFile:
         Returns:
             ConfigFile instance with loaded configuration.
         """
-        return from_dict(ConfigFile, data)
+        config = from_dict(ConfigFile, data)
+        config._apply_env_overrides()
+        return config
+
+    def _apply_env_overrides(self) -> None:
+        """
+        Override secret config values from dedicated environment variables.
+
+        Applied as the single choke point after construction in both `from_file`
+        and `from_dict` so every code path (and tests) shares one source of truth.
+        Each override wins only when its env var is set AND non-empty; otherwise the
+        TOML value is preserved (see `_env_override`). See RELENG-918.
+        """
+        self.django_secret_key = _env_override(
+            self.django_secret_key, "DJANGO_SECRET_KEY"
+        )
+        self.salt_key = _env_override(self.salt_key, "SALT_KEY")
+
+        # slack is a required section, but guard defensively anyway.
+        if self.slack is not None:
+            self.slack.bot_token = _env_override(
+                self.slack.bot_token, "SLACK_BOT_TOKEN"
+            )
+            self.slack.app_token = _env_override(
+                self.slack.app_token, "SLACK_APP_TOKEN"
+            )
+
+        if self.linear is not None:
+            self.linear.client_secret = _env_override(
+                self.linear.client_secret, "LINEAR_CLIENT_SECRET"
+            )
+
+        if self.pagerduty is not None:
+            self.pagerduty.api_token = _env_override(
+                self.pagerduty.api_token, "PAGERDUTY_API_TOKEN"
+            )
+            for name, policy in self.pagerduty.escalation_policies.items():
+                if override := os.environ.get(f"PAGERDUTY_ESCALATION_KEY_{name}"):
+                    policy.integration_key = override
+
+        if self.statuspage is not None:
+            self.statuspage.api_key = _env_override(
+                self.statuspage.api_key, "STATUSPAGE_API_KEY"
+            )
+
+        if self.notion is not None:
+            self.notion.integration_token = _env_override(
+                self.notion.integration_token, "NOTION_INTEGRATION_TOKEN"
+            )
 
 
 class DummyConfigFile(ConfigFile):

--- a/src/firetower/config.py
+++ b/src/firetower/config.py
@@ -212,6 +212,14 @@ class ConfigFile:
         # config file, not this env var. See RELENG-918.
         self.salt_key = _env_override(self.salt_key, "SALT_KEY")
 
+        # postgres is a required section, but guard defensively anyway. Rotation of
+        # the live password uses postgres.fallback_passwords in the config file;
+        # DJANGO_PG_PASS only overrides the primary password.
+        if self.postgres is not None:
+            self.postgres.password = _env_override(
+                self.postgres.password, "DJANGO_PG_PASS"
+            )
+
         # slack is a required section, but guard defensively anyway.
         if self.slack is not None:
             self.slack.bot_token = _env_override(


### PR DESCRIPTION
Phase 1 of RELENG-918: firetower can now read each secret from a dedicated env var, falling back to the TOML value when the env var is unset or empty (no behavior change for local dev); ops provisioning and stripping secrets from the TOML blob are follow-ups.