### PR TITLE
fix: detect Linear issue-not-found via extensions.userPresentableMessage

### DIFF
--- a/src/firetower/integrations/services/linear.py
+++ b/src/firetower/integrations/services/linear.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import re
 import time
@@ -68,6 +69,26 @@ class LinearError(Exception):
 # (team/user/project not found, auth, etc.) still surface as failures rather
 # than being mistaken for an empty issue lookup.
 _ISSUE_NOT_FOUND_MESSAGE = "could not find referenced issue"
+
+
+_MAX_LOGGED_ERRORS_LEN = 2000
+
+
+def _summarize_graphql_errors(errors: Any) -> str:
+    """Render a GraphQL ``errors`` payload as a compact string for logging.
+
+    The log formatter drops ``extra={}``, so the raw payload is folded into the
+    message itself to make the actual Linear error visible in Cloud Run logs.
+    Falls back to ``repr`` for anything not JSON-serializable and truncates so a
+    huge payload can't blow up a log line.
+    """
+    try:
+        rendered = json.dumps(errors, default=str, separators=(",", ":"))
+    except (TypeError, ValueError):
+        rendered = repr(errors)
+    if len(rendered) > _MAX_LOGGED_ERRORS_LEN:
+        rendered = rendered[:_MAX_LOGGED_ERRORS_LEN] + "…[truncated]"
+    return rendered
 
 
 def _errors_are_not_found(errors: Any) -> bool:
@@ -307,7 +328,8 @@ class LinearService:
                     if not_found_is_empty and _errors_are_not_found(data["errors"]):
                         return None
                     logger.error(
-                        "Linear GraphQL errors",
+                        "Linear GraphQL errors: %s",
+                        _summarize_graphql_errors(data["errors"]),
                         extra={"errors": data["errors"]},
                     )
                     self._raise_if_requested(

--- a/src/firetower/integrations/services/linear.py
+++ b/src/firetower/integrations/services/linear.py
@@ -91,23 +91,39 @@ def _summarize_graphql_errors(errors: Any) -> str:
     return rendered
 
 
+def _error_is_not_found(err: Any) -> bool:
+    """True iff a single GraphQL error is Linear's issue-not-found error.
+
+    Linear responds to an ``issue(id:)`` lookup for a nonexistent identifier
+    with a "Could not find referenced Issue." error rather than a null result.
+    That sentinel text has been observed in two places depending on the Linear
+    API version: the top-level ``message`` (older) and, more recently, only in
+    ``extensions.userPresentableMessage`` (with ``message`` reduced to the terse
+    "Entity not found: Issue"). Check both so a genuinely-absent issue is not
+    misclassified as "Linear unreachable" and sent to degraded mode.
+    """
+    if not isinstance(err, dict):
+        return False
+    extensions = err.get("extensions")
+    user_message = (
+        extensions.get("userPresentableMessage", "")
+        if isinstance(extensions, dict)
+        else ""
+    )
+    haystack = f"{err.get('message', '')} {user_message}".lower()
+    return _ISSUE_NOT_FOUND_MESSAGE in haystack
+
+
 def _errors_are_not_found(errors: Any) -> bool:
     """True iff every GraphQL error in ``errors`` is an issue-not-found error.
 
-    Linear responds to an ``issue(id:)`` lookup for a nonexistent identifier
-    with a "Could not find referenced Issue." GraphQL error rather than a null
-    result. We only treat the response as an empty (not-found) result when
-    *all* returned errors are that specific issue-not-found error, so a
-    response mixing a real failure with a not-found error still raises.
+    We only treat the response as an empty (not-found) result when *all* returned
+    errors are that specific issue-not-found error, so a response mixing a real
+    failure with a not-found error still raises.
     """
     if not isinstance(errors, list) or not errors:
         return False
-    for err in errors:
-        if not isinstance(err, dict):
-            return False
-        if _ISSUE_NOT_FOUND_MESSAGE not in str(err.get("message", "")).lower():
-            return False
-    return True
+    return all(_error_is_not_found(err) for err in errors)
 
 
 def parse_project_number(identifier: str) -> int | None:

--- a/src/firetower/integrations/tests/test_linear_service.py
+++ b/src/firetower/integrations/tests/test_linear_service.py
@@ -993,16 +993,25 @@ class TestGetIssue:
     def _not_found_response(self):
         # Mirrors the real Linear response for an issue(id:) lookup against an
         # identifier that does not exist: HTTP 200 with a GraphQL "entity not
-        # found" error and no data. Verified live: looking up an absent
-        # TESTINC-N returns "Could not find referenced Issue." (RELENG-911).
+        # found" error and no data. Verified live 2026-07-21 (RELENG-918): the
+        # sentinel "Could not find referenced Issue." is in
+        # extensions.userPresentableMessage, while the top-level message is the
+        # terse "Entity not found: Issue".
         mock_response = MagicMock()
         mock_response.ok = True
         mock_response.status_code = 200
         mock_response.json.return_value = {
             "errors": [
                 {
-                    "message": "Entity not found: Issue - Could not find "
-                    "referenced Issue.",
+                    "message": "Entity not found: Issue",
+                    "path": ["issue"],
+                    "extensions": {
+                        "type": "invalid input",
+                        "code": "INPUT_ERROR",
+                        "statusCode": 400,
+                        "userError": True,
+                        "userPresentableMessage": "Could not find referenced Issue.",
+                    },
                 }
             ]
         }
@@ -1082,6 +1091,28 @@ class TestErrorsAreNotFound:
         assert _errors_are_not_found(
             [{"message": "Entity not found: Issue - Could not find referenced Issue."}]
         )
+
+    def test_issue_not_found_in_extensions_user_presentable_message(self):
+        # Verified live 2026-07-21 (RELENG-918): Linear now puts the sentinel in
+        # extensions.userPresentableMessage, with message reduced to the terse
+        # "Entity not found: Issue". Regression test for the degraded-mode bug.
+        assert _errors_are_not_found(
+            [
+                {
+                    "message": "Entity not found: Issue",
+                    "path": ["issue"],
+                    "extensions": {
+                        "code": "INPUT_ERROR",
+                        "userPresentableMessage": "Could not find referenced Issue.",
+                    },
+                }
+            ]
+        )
+
+    def test_terse_message_without_sentinel_is_not_not_found(self):
+        # "Entity not found: Issue" alone (no sentinel anywhere) must not match,
+        # so an unexpected error still surfaces as a failure.
+        assert not _errors_are_not_found([{"message": "Entity not found: Issue"}])
 
     def test_case_insensitive(self):
         assert _errors_are_not_found([{"message": "COULD NOT FIND REFERENCED ISSUE"}])

--- a/src/firetower/integrations/tests/test_linear_service.py
+++ b/src/firetower/integrations/tests/test_linear_service.py
@@ -13,6 +13,7 @@ from firetower.integrations.services.linear import (
     LinearError,
     LinearService,
     _errors_are_not_found,
+    _summarize_graphql_errors,
     parse_project_number,
 )
 
@@ -1108,3 +1109,21 @@ class TestErrorsAreNotFound:
         assert not _errors_are_not_found([])
         assert not _errors_are_not_found(None)
         assert not _errors_are_not_found(["not a dict"])
+
+
+class TestSummarizeGraphqlErrors:
+    def test_renders_message_content(self):
+        summary = _summarize_graphql_errors(
+            [{"message": "Access denied", "extensions": {"code": "FORBIDDEN"}}]
+        )
+        assert "Access denied" in summary
+        assert "FORBIDDEN" in summary
+
+    def test_non_serializable_falls_back_to_repr(self):
+        summary = _summarize_graphql_errors(object())
+        assert summary  # does not raise, returns something
+
+    def test_truncates_huge_payload(self):
+        summary = _summarize_graphql_errors([{"message": "x" * 5000}])
+        assert len(summary) < 5000
+        assert summary.endswith("…[truncated]")


### PR DESCRIPTION
Fixes incident creation falling back to degraded mode ("Linear was unreachable") when the adopt-on-create allocator walks the counter to a genuinely-nonexistent identifier. Linear now returns the "Could not find referenced Issue." sentinel in extensions.userPresentableMessage rather than the top-level message, so the not-found detector misclassified an absent issue as a real error and raised instead of minting. Now checks both locations. Also folds the GraphQL errors payload into the log message so it survives the Cloud Run log formatter, which drops extra={} (this is what surfaced the real payload in test). Verified live in the test environment.
