### PR TITLE
fix: add pins:write scope to Slack app manifest

### DIFF
--- a/slack-app-manifest.yaml
+++ b/slack-app-manifest.yaml
@@ -29,6 +29,7 @@ oauth_config:
       - groups:read
       - groups:write
       - files:read
+      - pins:write
       - users:read
       - users:read.email
   pkce_enabled: false


### PR DESCRIPTION
Adds the pins:write bot scope to the Slack app manifest so Firetower can pin the incident summary message on incident creation. Without it, pins.add fails with missing_scope (caught gracefully, but the message isn't pinned). Fixes RELENG-986. Note: after merge, the manifest must be applied to both Slack apps (firetower + firetower-test) and the apps reinstalled/reauthorized for the tokens to pick up the new scope.
