### PR TITLE
feat: Add Restart Service workflow

### DIFF
--- a/.github/workflows/restart-service.yml
+++ b/.github/workflows/restart-service.yml
@@ -40,8 +40,11 @@ jobs:
           # Cloud Run only creates a new revision when the revision
           # template changes. Since we're re-applying the exact same spec,
           # give it a unique revision name so a new revision (and new
-          # instances) are actually created.
-          yq -i '.spec.template.metadata.name = "${{ matrix.service }}-restart-${{ github.run_number }}"' service.yaml
+          # instances) are actually created. Revision names are immutable,
+          # so we can't rely on github.run_number alone: it stays the same
+          # across re-runs of a failed job. Combining run_id and run_attempt
+          # guarantees a fresh name on every attempt, including retries.
+          yq -i '.spec.template.metadata.name = "${{ matrix.service }}-restart-${{ github.run_id }}-${{ github.run_attempt }}"' service.yaml
       - name: Redeploy ${{ matrix.service }}
         run: |
           gcloud run services replace service.yaml \
@@ -84,8 +87,11 @@ jobs:
           # Cloud Run only creates a new revision when the revision
           # template changes. Since we're re-applying the exact same spec,
           # give it a unique revision name so a new revision (and new
-          # instances) are actually created.
-          yq -i '.spec.template.metadata.name = "${{ matrix.service }}-restart-${{ github.run_number }}"' service.yaml
+          # instances) are actually created. Revision names are immutable,
+          # so we can't rely on github.run_number alone: it stays the same
+          # across re-runs of a failed job. Combining run_id and run_attempt
+          # guarantees a fresh name on every attempt, including retries.
+          yq -i '.spec.template.metadata.name = "${{ matrix.service }}-restart-${{ github.run_id }}-${{ github.run_attempt }}"' service.yaml
       - name: Redeploy ${{ matrix.service }}
         run: |
           gcloud run services replace service.yaml \

--- a/.github/workflows/restart-service.yml
+++ b/.github/workflows/restart-service.yml
@@ -35,12 +35,18 @@ jobs:
             --project ${{ secrets.GCP_PROJECT_SLUG }} \
             --region us-west1 \
             --format export > service.yaml
+      - name: Force new revision name
+        run: |
+          # Cloud Run only creates a new revision when the revision
+          # template changes. Since we're re-applying the exact same spec,
+          # give it a unique revision name so a new revision (and new
+          # instances) are actually created.
+          yq -i '.spec.template.metadata.name = "${{ matrix.service }}-restart-${{ github.run_number }}"' service.yaml
       - name: Redeploy ${{ matrix.service }}
-        uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3
-        with:
-          project_id: ${{ secrets.GCP_PROJECT_SLUG }}
-          region: us-west1
-          metadata: service.yaml
+        run: |
+          gcloud run services replace service.yaml \
+            --project ${{ secrets.GCP_PROJECT_SLUG }} \
+            --region us-west1
 
   restart-prod:
     if: ${{ inputs.environment == 'prod' }}
@@ -64,9 +70,15 @@ jobs:
             --project ${{ secrets.GCP_PROJECT_SLUG }} \
             --region us-west1 \
             --format export > service.yaml
+      - name: Force new revision name
+        run: |
+          # Cloud Run only creates a new revision when the revision
+          # template changes. Since we're re-applying the exact same spec,
+          # give it a unique revision name so a new revision (and new
+          # instances) are actually created.
+          yq -i '.spec.template.metadata.name = "${{ matrix.service }}-restart-${{ github.run_number }}"' service.yaml
       - name: Redeploy ${{ matrix.service }}
-        uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3
-        with:
-          project_id: ${{ secrets.GCP_PROJECT_SLUG }}
-          region: us-west1
-          metadata: service.yaml
+        run: |
+          gcloud run services replace service.yaml \
+            --project ${{ secrets.GCP_PROJECT_SLUG }} \
+            --region us-west1

--- a/.github/workflows/restart-service.yml
+++ b/.github/workflows/restart-service.yml
@@ -1,0 +1,72 @@
+name: Restart Service
+permissions:
+  contents: read
+  id-token: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to restart ("prod" or "test")'
+        type: environment
+        default: test
+        required: true
+
+jobs:
+  restart-test:
+    if: ${{ inputs.environment == 'test' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - firetower-test
+          - firetower-slack-app-test
+          - firetower-async-test
+    steps:
+      - name: Authenticate with GCP
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_SLUG }}
+          workload_identity_provider: projects/${{ secrets.GCP_PROJECT_NUM }}/locations/global/workloadIdentityPools/github/providers/github-prvdr
+      - name: Export current service definition
+        run: |
+          gcloud run services describe ${{ matrix.service }} \
+            --project ${{ secrets.GCP_PROJECT_SLUG }} \
+            --region us-west1 \
+            --format export > service.yaml
+      - name: Redeploy ${{ matrix.service }}
+        uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_SLUG }}
+          region: us-west1
+          metadata: service.yaml
+
+  restart-prod:
+    if: ${{ inputs.environment == 'prod' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - firetower
+          - firetower-slack-app
+          - firetower-async-prod
+    steps:
+      - name: Authenticate with GCP
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_SLUG }}
+          workload_identity_provider: projects/${{ secrets.GCP_PROJECT_NUM }}/locations/global/workloadIdentityPools/github/providers/github-prvdr
+      - name: Export current service definition
+        run: |
+          gcloud run services describe ${{ matrix.service }} \
+            --project ${{ secrets.GCP_PROJECT_SLUG }} \
+            --region us-west1 \
+            --format export > service.yaml
+      - name: Redeploy ${{ matrix.service }}
+        uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_SLUG }}
+          region: us-west1
+          metadata: service.yaml

--- a/.github/workflows/restart-service.yml
+++ b/.github/workflows/restart-service.yml
@@ -47,6 +47,15 @@ jobs:
           gcloud run services replace service.yaml \
             --project ${{ secrets.GCP_PROJECT_SLUG }} \
             --region us-west1
+      - name: Route traffic to new revision
+        run: |
+          # Ensure traffic actually shifts to the revision we just created,
+          # regardless of whatever traffic split was in the exported spec
+          # (e.g. if traffic was previously pinned to a specific revision).
+          gcloud run services update-traffic ${{ matrix.service }} \
+            --project ${{ secrets.GCP_PROJECT_SLUG }} \
+            --region us-west1 \
+            --to-latest
 
   restart-prod:
     if: ${{ inputs.environment == 'prod' }}
@@ -82,3 +91,12 @@ jobs:
           gcloud run services replace service.yaml \
             --project ${{ secrets.GCP_PROJECT_SLUG }} \
             --region us-west1
+      - name: Route traffic to new revision
+        run: |
+          # Ensure traffic actually shifts to the revision we just created,
+          # regardless of whatever traffic split was in the exported spec
+          # (e.g. if traffic was previously pinned to a specific revision).
+          gcloud run services update-traffic ${{ matrix.service }} \
+            --project ${{ secrets.GCP_PROJECT_SLUG }} \
+            --region us-west1 \
+            --to-latest


### PR DESCRIPTION
## Summary
Adds a new manually-triggered "Restart Service" GitHub Actions workflow that redeploys the currently deployed Cloud Run service revision, without rebuilding or changing any images.

## How it works
- Triggered via `workflow_dispatch` with an `environment` input (`test`/`prod`), same as `Deploy`.
- No build step — versions are already pinned by image SHA in Artifact Registry.
- For each Cloud Run service (matching the same service matrices as `deploy.yml`):
  1. Authenticates via the same Workload Identity Federation setup as `Deploy`.
  2. Exports the currently deployed service definition with `gcloud run services describe --format export`.
  3. Re-applies that exact definition via `google-github-actions/deploy-cloudrun` (`metadata` input), forcing a new revision with identical config — effectively a restart.

Using the exported YAML avoids hardcoding multi-container flags (e.g. for `firetower`/`firetower-test` with the nginx sidecar), since the full existing spec is captured automatically.