### PR TITLE
fix: Add project key to Sentry tags and Linear parent failure logs

### DIFF
--- a/src/firetower/incidents/services.py
+++ b/src/firetower/incidents/services.py
@@ -263,12 +263,26 @@ def _update_parent_issue_status(
         return
 
     state_id = states.get(target_state)
-    if state_id and linear_service.update_issue(
-        incident.linear_parent_issue_id, state_id=state_id
-    ):
+    if not state_id:
+        return
+
+    if linear_service.update_issue(incident.linear_parent_issue_id, state_id=state_id):
         _comment_parent_issue_status_change(
             incident, linear_service, target_state, statuses
         )
+        return
+
+    # The underlying Linear error is logged by LinearService without any
+    # incident context, so name the incident and its parent here. Without this
+    # a persistently mislinked parent just emits an anonymous GraphQL error
+    # every sync, with nothing tying it back to the row that needs fixing.
+    logger.warning(
+        "Failed to set Linear parent %s to %s for incident %s (team %s)",
+        incident.linear_parent_issue_id,
+        target_state,
+        incident.incident_number,
+        team_id,
+    )
 
 
 def sync_action_items_from_linear(

--- a/src/firetower/incidents/tasks/__init__.py
+++ b/src/firetower/incidents/tasks/__init__.py
@@ -46,6 +46,6 @@ def schedule_demo() -> None:
     incident = Incident.objects.order_by("-created_at").first()
     if incident:
         title = "Private Incident" if incident.is_private else incident.title
-        logger.info(f"Most recent incident: INC-{incident.id}: {title}")
+        logger.info(f"Most recent incident: {incident.incident_number}: {title}")
     else:
         logger.info("No incidents found.")

--- a/src/firetower/incidents/tests/test_services.py
+++ b/src/firetower/incidents/tests/test_services.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
@@ -580,6 +581,30 @@ class TestUpdateParentIssueStatus:
 
         svc.update_issue.assert_called_once_with("lin-123", state_id="state-completed")
         svc.create_comment.assert_not_called()
+
+    def test_update_issue_failure_logs_incident_context(self, caplog):
+        incident = self._make_incident(status=IncidentStatus.DONE)
+        svc = self._make_linear_service()
+        svc.update_issue.return_value = False
+
+        # The firetower logger sets propagate=False, so caplog's root handler
+        # never sees these records; attach it to the logger directly.
+        logger = logging.getLogger("firetower.incidents.services")
+        logger.addHandler(caplog.handler)
+        try:
+            with caplog.at_level(logging.WARNING, logger=logger.name):
+                _update_parent_issue_status(incident, svc)
+        finally:
+            logger.removeHandler(caplog.handler)
+
+        # The Linear-side error carries no incident context, so the warning must
+        # name the parent issue and the incident that points at it.
+        assert len(caplog.records) == 1
+        message = caplog.records[0].getMessage()
+        assert "lin-123" in message
+        assert incident.incident_number in message
+        assert "completed" in message
+        assert "team-1" in message
 
     def test_skips_update_when_already_in_target_state(self):
         incident = self._make_incident(status=IncidentStatus.ACTIVE)

--- a/src/firetower/settings.py
+++ b/src/firetower/settings.py
@@ -65,6 +65,12 @@ if not env_is_dev():
         },
     )
 
+    # Tag every event/log with the deployment's incident key. Environments share
+    # a Sentry project, and an untagged "incident 2178" is ambiguous between
+    # (say) INC-2178 and TESTINC-2178 -- which has already cost real debugging
+    # time chasing a test-only error as if it touched production.
+    sentry_sdk.set_tag("project_key", config.project_key)
+
 
 def _coerce_region_grouping(raw: list[Any]) -> list[list[str]]:
     if not raw:


### PR DESCRIPTION
Test and prod share a Sentry project, and an error naming "incident 2178" was ambiguous between INC-2178 and TESTINC-2178, which cost a lot of time chasing a test-only Linear error as though it were touching production. This tags every event with the deployment's project key, fixes a log line that hardcoded the INC- prefix regardless of environment, and logs the incident number and parent issue id when setting a Linear parent's state fails instead of discarding the failed return value.
